### PR TITLE
Funds Stage A: data-plane endpoints + schema v1

### DIFF
--- a/OPENAPI_SPEC.yaml
+++ b/OPENAPI_SPEC.yaml
@@ -1662,6 +1662,199 @@ components:
           description: Requests allowed per minute for this key.
           example: 60
 
+    Fund:
+      type: object
+      description: >
+        Mutual fund registry row from `public.funds`. One row per `bw_fund_id`.
+        Latest temporal triple (`latest_report_date` / `latest_filing_date` /
+        `latest_extracted_at`) reflects the most recent N-PORT snapshot known
+        for this fund. Q5 lock: `primary_bw_fund_id` is reserved as a nullable
+        column; NULL means this row IS the primary share class (or no primary
+        chosen yet). See ARCHITECTURE_FUNDS_API.md §4.1.
+      properties:
+        bw_fund_id:
+          type: string
+          description: Funds_DAG canonical fund id. Format `BW-FUND-{series_id}`.
+          example: BW-FUND-S000004310
+        series_id:
+          type: string
+          nullable: true
+          description: SEC series id.
+          example: S000004310
+        ticker:
+          type: string
+          nullable: true
+          example: VFINX
+        cik:
+          type: string
+          nullable: true
+        fund_name:
+          type: string
+          nullable: true
+          example: Vanguard 500 Index Fund Investor Shares
+        morningstar_category:
+          type: string
+          nullable: true
+        equity_style_9box:
+          type: string
+          nullable: true
+          enum:
+            - Large Value
+            - Large Blend
+            - Large Growth
+            - Mid Value
+            - Mid Blend
+            - Mid Growth
+            - Small Value
+            - Small Blend
+            - Small Growth
+        style_link_method:
+          type: string
+          nullable: true
+        primary_bw_fund_id:
+          type: string
+          nullable: true
+        latest_report_date:
+          type: string
+          format: date
+          nullable: true
+          description: Period end of the most recent reported holdings (= "fund_date").
+        latest_filing_date:
+          type: string
+          format: date
+          nullable: true
+          description: SEC acceptance date for the latest filing (= "release_date").
+        latest_extracted_at:
+          type: string
+          format: date-time
+          nullable: true
+        latest_total_adj_mv:
+          type: number
+          format: float
+          nullable: true
+        latest_n_holdings:
+          type: integer
+          nullable: true
+        latest_effective_n:
+          type: number
+          format: float
+          nullable: true
+        last_in_eligible_universe_at:
+          type: string
+          format: date
+          nullable: true
+        metadata:
+          type: object
+          additionalProperties: true
+          nullable: true
+
+    FundLatest:
+      type: object
+      description: >
+        Wide-row latest knowledge-mode snapshot from `public.funds_latest`.
+        One row per `bw_fund_id`. Returns and diagnostics flatten the per-fund
+        `ds_portfolio.zarr` (Funds_DAG Slice 8). Multi-quarter history lives
+        in GCS Zarr (Stage B+). See ARCHITECTURE_FUNDS_API.md §4.2.
+      required: [bw_fund_id, report_date, filing_date, extracted_at, last_synced_at]
+      properties:
+        bw_fund_id: { type: string, example: BW-FUND-S000004310 }
+        report_date: { type: string, format: date, example: "2026-04-30" }
+        filing_date: { type: string, format: date, example: "2026-07-14" }
+        extracted_at: { type: string, format: date-time }
+        portfolio_gross_return: { type: number, format: float, nullable: true }
+        portfolio_market_return: { type: number, format: float, nullable: true }
+        portfolio_sector_return: { type: number, format: float, nullable: true }
+        portfolio_subsector_return: { type: number, format: float, nullable: true }
+        portfolio_idiosyncratic_return: { type: number, format: float, nullable: true }
+        identity_residual: { type: number, format: float, nullable: true }
+        weight_sum:
+          type: number
+          format: float
+          nullable: true
+          description: ERM3 universe coverage (fraction of fund AUM mapping to in-universe symbols).
+        n_holdings_active: { type: integer, nullable: true }
+        effective_n:
+          type: number
+          format: float
+          nullable: true
+          description: HHI-derived diversification (1 / sum(w_i^2)).
+        top10_weight_sum: { type: number, format: float, nullable: true }
+        total_adj_mv: { type: number, format: float, nullable: true }
+        equity_style_9box: { type: string, nullable: true }
+        n_funds_in_cell_at_report_date: { type: integer, nullable: true }
+        model_version:
+          type: string
+          nullable: true
+          example: funds_dag.v20260502
+        factor_set_id:
+          type: string
+          nullable: true
+          example: uni_mc_3000_SPY
+        last_synced_at: { type: string, format: date-time }
+        metadata:
+          type: object
+          additionalProperties: true
+          nullable: true
+
+    FundWithLatest:
+      type: object
+      description: Fund registry row joined with the latest knowledge-mode snapshot.
+      required: [fund]
+      properties:
+        fund:
+          $ref: "#/components/schemas/Fund"
+        latest:
+          oneOf:
+            - $ref: "#/components/schemas/FundLatest"
+            - type: "null"
+          nullable: true
+
+    FundsBatchRequest:
+      type: object
+      required: [fund_ids]
+      properties:
+        fund_ids:
+          type: array
+          items:
+            type: string
+          minItems: 1
+          maxItems: 1000
+          example: ["BW-FUND-S000004310", "BW-FUND-S000123456"]
+
+    FundsBatchResponse:
+      type: object
+      description: Multi-fund lookup. Keys are `bw_fund_id`s present in the registry.
+      properties:
+        results:
+          type: object
+          additionalProperties:
+            $ref: "#/components/schemas/FundWithLatest"
+
+    FundsSearchResponse:
+      type: object
+      properties:
+        results:
+          type: array
+          items:
+            $ref: "#/components/schemas/Fund"
+
+    FundsStyleMembersResponse:
+      type: object
+      required: [equity_style_9box, slug, fund_ids, count]
+      properties:
+        equity_style_9box:
+          type: string
+          example: Large Blend
+        slug:
+          type: string
+          example: large-blend
+        fund_ids:
+          type: array
+          items:
+            type: string
+        count:
+          type: integer
+
 security:
   - BearerAuth: []
 
@@ -4924,6 +5117,207 @@ paths:
                 type: object
                 additionalProperties: true
 
+  /data/funds/{bw_fund_id}:
+    get:
+      summary: Get fund (registry + latest snapshot)
+      description: >
+        Returns the registry row from `public.funds` joined with the latest
+        knowledge-mode snapshot from `public.funds_latest`. Bitemporal lineage
+        surfaces as response headers `X-Data-As-Of` (= `report_date`) and
+        `X-Data-Filing-Date` (= `filing_date`).
+
+
+        v1 returns the latest knowledge-mode answer only (no `?as_of=` /
+        `?mode=` query params — deferred to v2 per
+        ARCHITECTURE_FUNDS_API.md §3.5).
+      operationId: getFundDataPlane
+      tags: [Funds Data Plane]
+      security:
+        - BearerAuth: []
+        - {}
+      parameters:
+        - name: bw_fund_id
+          in: path
+          required: true
+          schema: { type: string }
+          example: BW-FUND-S000004310
+      responses:
+        "200":
+          description: Fund + latest snapshot.
+          headers:
+            X-Data-As-Of:
+              schema: { type: string, format: date }
+              description: funds_latest.report_date (period end of the snapshot).
+            X-Data-Filing-Date:
+              schema: { type: string, format: date }
+              description: funds_latest.filing_date (SEC acceptance date).
+            X-Risk-Model-Version:
+              schema: { type: string }
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FundWithLatest"
+        "404":
+          description: Fund not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /data/funds-latest/{bw_fund_id}:
+    get:
+      summary: Get just the funds_latest row
+      description: >
+        Returns only the wide-row snapshot from `public.funds_latest`. Skips
+        the registry join — useful when the SDK already has the registry row
+        or only needs the metric columns.
+      operationId: getFundLatestDataPlane
+      tags: [Funds Data Plane]
+      security:
+        - BearerAuth: []
+        - {}
+      parameters:
+        - name: bw_fund_id
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Latest snapshot row.
+          headers:
+            X-Data-As-Of:
+              schema: { type: string, format: date }
+            X-Data-Filing-Date:
+              schema: { type: string, format: date }
+            X-Risk-Model-Version:
+              schema: { type: string }
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FundLatest"
+        "404":
+          description: No funds_latest row for this fund.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /data/funds/batch:
+    post:
+      summary: Resolve multiple funds in one call
+      description: >
+        Multi-fund lookup. Returns a registry+latest payload keyed by
+        `bw_fund_id`. Up to 1000 ids per request.
+      operationId: postFundsBatchDataPlane
+      tags: [Funds Data Plane]
+      security:
+        - BearerAuth: []
+        - {}
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/FundsBatchRequest"
+      responses:
+        "200":
+          description: Lookup map.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FundsBatchResponse"
+        "400":
+          description: Invalid body (missing/oversized fund_ids array).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /data/funds/search:
+    get:
+      summary: Search funds by ticker or name
+      description: >
+        Full-text ilike search over `ticker` and `fund_name`, optionally
+        filtered by 9-box style cell (slug or canonical name) and
+        share-class primary flag (`?primary=true` filters
+        `primary_bw_fund_id IS NULL`).
+      operationId: getFundsSearchDataPlane
+      tags: [Funds Data Plane]
+      security:
+        - BearerAuth: []
+        - {}
+      parameters:
+        - name: q
+          in: query
+          schema: { type: string }
+          description: ilike pattern on ticker / fund_name.
+        - name: equity_style_9box
+          in: query
+          schema: { type: string }
+          description: 9-box slug ("large-blend") or canonical name ("Large Blend").
+        - name: primary
+          in: query
+          schema: { type: boolean, default: false }
+          description: When true, returns only primary share-class funds (Q5 lock).
+        - name: limit
+          in: query
+          schema: { type: integer, minimum: 1, maximum: 500, default: 50 }
+      responses:
+        "200":
+          description: Up to `limit` matching funds.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FundsSearchResponse"
+
+  /data/funds/style/{slug}/members:
+    get:
+      summary: List fund_ids in a 9-box style cell
+      description: >
+        Returns the `bw_fund_id` list for a 9-box style cell. SDK consumers
+        typically chain this into `/api/data/funds/batch` to materialize a
+        peer cohort's full registry+latest payload.
+      operationId: getStyleCellMembersDataPlane
+      tags: [Funds Data Plane]
+      security:
+        - BearerAuth: []
+        - {}
+      parameters:
+        - name: slug
+          in: path
+          required: true
+          schema:
+            type: string
+            enum:
+              - large-value
+              - large-blend
+              - large-growth
+              - mid-value
+              - mid-blend
+              - mid-growth
+              - small-value
+              - small-blend
+              - small-growth
+        - name: primary
+          in: query
+          schema: { type: boolean, default: false }
+        - name: limit
+          in: query
+          schema: { type: integer, minimum: 1, maximum: 20000, default: 5000 }
+      responses:
+        "200":
+          description: Fund id list for the cell.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FundsStyleMembersResponse"
+        "400":
+          description: Invalid style slug.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
 tags:
   - name: Risk Metrics
     description: ERM3 factor hedge ratios, explained risk, and return decompositions.
@@ -4945,3 +5339,11 @@ tags:
     description: Data handling and privacy disclosure.
   - name: Discovery
     description: Service discovery and capability manifests.
+  - name: Funds Data Plane
+    description: >
+      Raw-shape reads against the funds Supabase tables (`funds`,
+      `funds_latest`). Latest knowledge-mode snapshot only — history reads
+      via the per-fund Zarr endpoints in later stages. Public; soft Bearer
+      auth; not metered. The compute-bearing `/funds/*`,
+      `/funds/style/*`, and `/funds/snapshot/*` surfaces ship in subsequent
+      stages.

--- a/app/api/data/funds-latest/[bw_fund_id]/route.ts
+++ b/app/api/data/funds-latest/[bw_fund_id]/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { verifyGatewayAuth } from "@/lib/gateway-auth";
+import { fetchFundLatest } from "@/lib/dal/funds-engine";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/data/funds-latest/:bw_fund_id
+ *
+ * Returns just the wide-row snapshot from `funds_latest` (skips the registry
+ * join). Useful for SDK consumers that already have the registry row or only
+ * need the metric columns.
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ bw_fund_id: string }> },
+) {
+  const denied = verifyGatewayAuth(request);
+  if (denied) return denied;
+
+  const { bw_fund_id } = await params;
+  if (!bw_fund_id) {
+    return NextResponse.json(
+      { error: "bw_fund_id is required" },
+      { status: 400 },
+    );
+  }
+
+  const latest = await fetchFundLatest(bw_fund_id);
+  if (!latest) {
+    return NextResponse.json(
+      { error: "Fund latest row not found" },
+      { status: 404 },
+    );
+  }
+
+  const headers = new Headers({
+    "X-Data-As-Of": latest.report_date,
+    "X-Data-Filing-Date": latest.filing_date,
+  });
+  if (latest.model_version) {
+    headers.set("X-Risk-Model-Version", latest.model_version);
+  }
+
+  return NextResponse.json(latest, { headers });
+}

--- a/app/api/data/funds/[bw_fund_id]/route.ts
+++ b/app/api/data/funds/[bw_fund_id]/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { verifyGatewayAuth } from "@/lib/gateway-auth";
+import { resolveFundById } from "@/lib/dal/funds-engine";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/data/funds/:bw_fund_id
+ *
+ * Returns the registry row joined with the latest knowledge-mode snapshot
+ * from `funds_latest`. Bitemporal lineage surfaces as response headers:
+ *   X-Data-As-Of:        funds_latest.report_date
+ *   X-Data-Filing-Date:  funds_latest.filing_date
+ *
+ * v1 has no `?as_of=` query — returns "what we know today" only.
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ bw_fund_id: string }> },
+) {
+  const denied = verifyGatewayAuth(request);
+  if (denied) return denied;
+
+  const { bw_fund_id } = await params;
+  if (!bw_fund_id) {
+    return NextResponse.json(
+      { error: "bw_fund_id is required" },
+      { status: 400 },
+    );
+  }
+
+  const result = await resolveFundById(bw_fund_id);
+  if (!result) {
+    return NextResponse.json({ error: "Fund not found" }, { status: 404 });
+  }
+
+  const headers = new Headers();
+  if (result.latest) {
+    headers.set("X-Data-As-Of", result.latest.report_date);
+    headers.set("X-Data-Filing-Date", result.latest.filing_date);
+    if (result.latest.model_version) {
+      headers.set("X-Risk-Model-Version", result.latest.model_version);
+    }
+  }
+
+  return NextResponse.json(
+    { fund: result.fund, latest: result.latest },
+    { headers },
+  );
+}

--- a/app/api/data/funds/batch/route.ts
+++ b/app/api/data/funds/batch/route.ts
@@ -1,0 +1,56 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { verifyGatewayAuth } from "@/lib/gateway-auth";
+import { resolveFundsByIds } from "@/lib/dal/funds-engine";
+
+export const dynamic = "force-dynamic";
+
+const MAX_BATCH = 1000;
+
+/**
+ * POST /api/data/funds/batch
+ *
+ * Body: { fund_ids: string[] }   — up to 1000 bw_fund_ids per request
+ * Returns: { results: { [bw_fund_id]: { fund, latest } } }
+ *
+ * Mirrors POST /api/data/symbols/batch. Mostly used by the SDK to hydrate a
+ * portfolio's full registry+latest payload in one call.
+ */
+export async function POST(request: NextRequest) {
+  const denied = verifyGatewayAuth(request);
+  if (denied) return denied;
+
+  let body: { fund_ids?: unknown };
+  try {
+    body = (await request.json()) as { fund_ids?: unknown };
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const ids = body.fund_ids;
+  if (!Array.isArray(ids) || ids.length === 0) {
+    return NextResponse.json(
+      { error: "fund_ids array is required" },
+      { status: 400 },
+    );
+  }
+  if (ids.length > MAX_BATCH) {
+    return NextResponse.json(
+      { error: `Max ${MAX_BATCH} fund_ids per request` },
+      { status: 400 },
+    );
+  }
+  if (!ids.every((x): x is string => typeof x === "string" && x.length > 0)) {
+    return NextResponse.json(
+      { error: "fund_ids must be a non-empty string array" },
+      { status: 400 },
+    );
+  }
+
+  const map = await resolveFundsByIds(ids);
+  const results: Record<string, unknown> = {};
+  for (const [id, value] of map.entries()) {
+    results[id] = value;
+  }
+
+  return NextResponse.json({ results });
+}

--- a/app/api/data/funds/search/route.ts
+++ b/app/api/data/funds/search/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { verifyGatewayAuth } from "@/lib/gateway-auth";
+import { searchFunds } from "@/lib/dal/funds-engine";
+import { isValidStyleSlug, styleSlugToName } from "@/lib/funds/style-slug";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/data/funds/search
+ *
+ * Query params:
+ *   q                 — full-text on ticker / fund_name (ilike)
+ *   equity_style_9box — slug (e.g. "large-blend") OR canonical name
+ *   primary           — "true" filters to share-class primaries only (Q5)
+ *   limit             — max rows (default 50, capped 500)
+ *
+ * Returns: { results: FundRow[] }
+ */
+export async function GET(request: NextRequest) {
+  const denied = verifyGatewayAuth(request);
+  if (denied) return denied;
+
+  const { searchParams } = request.nextUrl;
+  const q = searchParams.get("q")?.trim() ?? undefined;
+  const limit = Math.min(Math.max(Number(searchParams.get("limit") ?? 50), 1), 500);
+  const primary = searchParams.get("primary") === "true";
+
+  const styleParam = searchParams.get("equity_style_9box")?.trim();
+  let equityStyle9Box: string | null | undefined = undefined;
+  if (styleParam) {
+    if (isValidStyleSlug(styleParam)) {
+      equityStyle9Box = styleSlugToName(styleParam);
+    } else {
+      // Accept the canonical DB form too ("Large Blend"), useful for SDK callers
+      equityStyle9Box = styleParam;
+    }
+  }
+
+  const results = await searchFunds({
+    q,
+    equityStyle9Box,
+    primaryOnly: primary,
+    limit,
+  });
+
+  return NextResponse.json({ results });
+}

--- a/app/api/data/funds/style/[slug]/members/route.ts
+++ b/app/api/data/funds/style/[slug]/members/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { verifyGatewayAuth } from "@/lib/gateway-auth";
+import { getStyleCellMembers } from "@/lib/dal/funds-engine";
+import { styleSlugToName } from "@/lib/funds/style-slug";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/data/funds/style/:slug/members
+ *
+ * Returns the bw_fund_id list for a 9-box style cell. Used by SDK consumers
+ * to materialize a peer cohort before calling /batch for the metric rows.
+ *
+ * Query params:
+ *   primary  — "true" filters to primary share class only (Q5 lock)
+ *   limit    — max ids returned (default 5000, capped 20000)
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ slug: string }> },
+) {
+  const denied = verifyGatewayAuth(request);
+  if (denied) return denied;
+
+  const { slug } = await params;
+  const cellName = styleSlugToName(slug ?? "");
+  if (!cellName) {
+    return NextResponse.json(
+      { error: `Invalid style slug: ${slug}` },
+      { status: 400 },
+    );
+  }
+
+  const { searchParams } = request.nextUrl;
+  const primary = searchParams.get("primary") === "true";
+  const limit = Math.min(
+    Math.max(Number(searchParams.get("limit") ?? 5000), 1),
+    20_000,
+  );
+
+  const members = await getStyleCellMembers(cellName, {
+    primaryOnly: primary,
+    limit,
+  });
+
+  return NextResponse.json({
+    equity_style_9box: cellName,
+    slug,
+    fund_ids: members,
+    count: members.length,
+  });
+}

--- a/lib/dal/funds-engine.ts
+++ b/lib/dal/funds-engine.ts
@@ -1,0 +1,252 @@
+/**
+ * Funds DAL — Supabase reads against `public.funds` and `public.funds_latest`.
+ *
+ * Mirrors `lib/dal/risk-engine-v3.ts` (stocks side). Stage A surface only:
+ * latest knowledge-mode snapshot. History (per-fund time series, holdings
+ * panels) reads via the Zarr DAL in Stage B.
+ *
+ * Public/private boundary: this module backs the data-plane routes under
+ * `/api/data/funds/*`. Metric/snapshot routes wrap these reads with
+ * `withBilling()` in later stages.
+ *
+ * Bitemporal model carried in column shapes (`report_date` / `filing_date` /
+ * `extracted_at`); v1 returns the latest knowledge-mode row only. `?as_of=`
+ * is deferred to v2 per ARCHITECTURE_FUNDS_API.md §3.5.
+ */
+
+import { createAdminClient } from "@/lib/supabase/admin";
+
+export interface FundRow {
+  bw_fund_id: string;
+  series_id: string | null;
+  ticker: string | null;
+  cik: string | null;
+  fund_name: string | null;
+  morningstar_category: string | null;
+  equity_style_9box: string | null;
+  style_link_method: string | null;
+  primary_bw_fund_id: string | null;
+  latest_report_date: string | null;
+  latest_filing_date: string | null;
+  latest_extracted_at: string | null;
+  latest_total_adj_mv: number | null;
+  latest_n_holdings: number | null;
+  latest_effective_n: number | null;
+  last_in_eligible_universe_at: string | null;
+  metadata: Record<string, unknown> | null;
+}
+
+export interface FundLatestRow {
+  bw_fund_id: string;
+  report_date: string;
+  filing_date: string;
+  extracted_at: string;
+  portfolio_gross_return: number | null;
+  portfolio_market_return: number | null;
+  portfolio_sector_return: number | null;
+  portfolio_subsector_return: number | null;
+  portfolio_idiosyncratic_return: number | null;
+  identity_residual: number | null;
+  weight_sum: number | null;
+  n_holdings_active: number | null;
+  effective_n: number | null;
+  top10_weight_sum: number | null;
+  total_adj_mv: number | null;
+  equity_style_9box: string | null;
+  n_funds_in_cell_at_report_date: number | null;
+  model_version: string | null;
+  factor_set_id: string | null;
+  last_synced_at: string;
+  metadata: Record<string, unknown> | null;
+}
+
+export interface FundWithLatest {
+  fund: FundRow;
+  latest: FundLatestRow | null;
+}
+
+export interface SearchFundsOptions {
+  q?: string;
+  equityStyle9Box?: string | null;
+  primaryOnly?: boolean;
+  limit?: number;
+}
+
+const FUND_COLUMNS =
+  "bw_fund_id, series_id, ticker, cik, fund_name, morningstar_category, equity_style_9box, style_link_method, primary_bw_fund_id, latest_report_date, latest_filing_date, latest_extracted_at, latest_total_adj_mv, latest_n_holdings, latest_effective_n, last_in_eligible_universe_at, metadata";
+
+const FUND_LATEST_COLUMNS =
+  "bw_fund_id, report_date, filing_date, extracted_at, portfolio_gross_return, portfolio_market_return, portfolio_sector_return, portfolio_subsector_return, portfolio_idiosyncratic_return, identity_residual, weight_sum, n_holdings_active, effective_n, top10_weight_sum, total_adj_mv, equity_style_9box, n_funds_in_cell_at_report_date, model_version, factor_set_id, last_synced_at, metadata";
+
+export async function fetchFund(bwFundId: string): Promise<FundRow | null> {
+  try {
+    const admin = createAdminClient();
+    const { data, error } = await admin
+      .from("funds")
+      .select(FUND_COLUMNS)
+      .eq("bw_fund_id", bwFundId)
+      .maybeSingle();
+    if (error) {
+      console.error(`[Funds DAL] Error fetching fund ${bwFundId}:`, error);
+      return null;
+    }
+    return (data as FundRow | null) ?? null;
+  } catch (error) {
+    console.error(`[Funds DAL] Error fetching fund ${bwFundId}:`, error);
+    return null;
+  }
+}
+
+export async function fetchFundLatest(
+  bwFundId: string,
+): Promise<FundLatestRow | null> {
+  try {
+    const admin = createAdminClient();
+    const { data, error } = await admin
+      .from("funds_latest")
+      .select(FUND_LATEST_COLUMNS)
+      .eq("bw_fund_id", bwFundId)
+      .maybeSingle();
+    if (error) {
+      console.error(
+        `[Funds DAL] Error fetching funds_latest ${bwFundId}:`,
+        error,
+      );
+      return null;
+    }
+    return (data as FundLatestRow | null) ?? null;
+  } catch (error) {
+    console.error(
+      `[Funds DAL] Error fetching funds_latest ${bwFundId}:`,
+      error,
+    );
+    return null;
+  }
+}
+
+export async function resolveFundById(
+  bwFundId: string,
+): Promise<FundWithLatest | null> {
+  const [fund, latest] = await Promise.all([
+    fetchFund(bwFundId),
+    fetchFundLatest(bwFundId),
+  ]);
+  if (!fund) return null;
+  return { fund, latest };
+}
+
+export async function resolveFundsByIds(
+  bwFundIds: string[],
+): Promise<Map<string, FundWithLatest>> {
+  const result = new Map<string, FundWithLatest>();
+  if (bwFundIds.length === 0) return result;
+
+  try {
+    const admin = createAdminClient();
+    const [fundsRes, latestRes] = await Promise.all([
+      admin.from("funds").select(FUND_COLUMNS).in("bw_fund_id", bwFundIds),
+      admin
+        .from("funds_latest")
+        .select(FUND_LATEST_COLUMNS)
+        .in("bw_fund_id", bwFundIds),
+    ]);
+
+    if (fundsRes.error) {
+      console.error("[Funds DAL] Batch funds error:", fundsRes.error);
+      return result;
+    }
+
+    const latestById = new Map<string, FundLatestRow>();
+    if (!latestRes.error) {
+      for (const row of (latestRes.data ?? []) as FundLatestRow[]) {
+        latestById.set(row.bw_fund_id, row);
+      }
+    } else {
+      console.error("[Funds DAL] Batch funds_latest error:", latestRes.error);
+    }
+
+    for (const fund of (fundsRes.data ?? []) as FundRow[]) {
+      result.set(fund.bw_fund_id, {
+        fund,
+        latest: latestById.get(fund.bw_fund_id) ?? null,
+      });
+    }
+    return result;
+  } catch (error) {
+    console.error("[Funds DAL] Error in resolveFundsByIds:", error);
+    return result;
+  }
+}
+
+export async function searchFunds(
+  options: SearchFundsOptions = {},
+): Promise<FundRow[]> {
+  const { q, equityStyle9Box, primaryOnly, limit = 50 } = options;
+  const safeLimit = Math.min(Math.max(limit, 1), 500);
+
+  try {
+    const admin = createAdminClient();
+    let query = admin.from("funds").select(FUND_COLUMNS);
+
+    if (q && q.trim().length > 0) {
+      const escaped = q.trim().replace(/[%,()]/g, " ");
+      query = query.or(
+        `ticker.ilike.%${escaped}%,fund_name.ilike.%${escaped}%`,
+      );
+    }
+    if (equityStyle9Box) {
+      query = query.eq("equity_style_9box", equityStyle9Box);
+    }
+    if (primaryOnly) {
+      query = query.is("primary_bw_fund_id", null);
+    }
+
+    query = query
+      .order("latest_total_adj_mv", { ascending: false, nullsFirst: false })
+      .limit(safeLimit);
+
+    const { data, error } = await query;
+    if (error) {
+      console.error("[Funds DAL] searchFunds error:", error);
+      return [];
+    }
+    return (data ?? []) as FundRow[];
+  } catch (error) {
+    console.error("[Funds DAL] searchFunds error:", error);
+    return [];
+  }
+}
+
+export async function getStyleCellMembers(
+  equityStyle9Box: string,
+  options: { primaryOnly?: boolean; limit?: number } = {},
+): Promise<string[]> {
+  const { primaryOnly, limit = 5000 } = options;
+  const safeLimit = Math.min(Math.max(limit, 1), 20000);
+
+  try {
+    const admin = createAdminClient();
+    let query = admin
+      .from("funds")
+      .select("bw_fund_id")
+      .eq("equity_style_9box", equityStyle9Box);
+    if (primaryOnly) {
+      query = query.is("primary_bw_fund_id", null);
+    }
+    query = query
+      .order("latest_total_adj_mv", { ascending: false, nullsFirst: false })
+      .limit(safeLimit);
+
+    const { data, error } = await query;
+    if (error) {
+      console.error("[Funds DAL] getStyleCellMembers error:", error);
+      return [];
+    }
+    return ((data ?? []) as { bw_fund_id: string }[]).map(
+      (r) => r.bw_fund_id,
+    );
+  } catch (error) {
+    console.error("[Funds DAL] getStyleCellMembers error:", error);
+    return [];
+  }
+}

--- a/lib/funds/style-slug.ts
+++ b/lib/funds/style-slug.ts
@@ -1,0 +1,42 @@
+/**
+ * 9-box style cell ↔ URL slug mapping.
+ *
+ * DB stores `equity_style_9box` as "Large Blend" (capitalized words, space-separated).
+ * URL slugs are lowercase + hyphenated: "large-blend".
+ *
+ * The 9 valid cells are the cross of {Large, Mid, Small} × {Value, Blend, Growth}.
+ */
+
+export const STYLE_CELL_NAMES = [
+  "Large Value",
+  "Large Blend",
+  "Large Growth",
+  "Mid Value",
+  "Mid Blend",
+  "Mid Growth",
+  "Small Value",
+  "Small Blend",
+  "Small Growth",
+] as const;
+
+export type StyleCellName = (typeof STYLE_CELL_NAMES)[number];
+
+const NAME_TO_SLUG = new Map<string, string>(
+  STYLE_CELL_NAMES.map((name) => [name, name.toLowerCase().replace(/\s+/g, "-")]),
+);
+
+const SLUG_TO_NAME = new Map<string, StyleCellName>(
+  STYLE_CELL_NAMES.map((name) => [name.toLowerCase().replace(/\s+/g, "-"), name]),
+);
+
+export function styleSlugToName(slug: string): StyleCellName | null {
+  return SLUG_TO_NAME.get(slug.trim().toLowerCase()) ?? null;
+}
+
+export function styleNameToSlug(name: string): string | null {
+  return NAME_TO_SLUG.get(name) ?? null;
+}
+
+export function isValidStyleSlug(slug: string): boolean {
+  return SLUG_TO_NAME.has(slug.trim().toLowerCase());
+}

--- a/mcp/data/openapi.json
+++ b/mcp/data/openapi.json
@@ -1905,6 +1905,313 @@
             "example": 60
           }
         }
+      },
+      "Fund": {
+        "type": "object",
+        "description": "Mutual fund registry row from `public.funds`. One row per `bw_fund_id`. Latest temporal triple (`latest_report_date` / `latest_filing_date` / `latest_extracted_at`) reflects the most recent N-PORT snapshot known for this fund. Q5 lock: `primary_bw_fund_id` is reserved as a nullable column; NULL means this row IS the primary share class (or no primary chosen yet). See ARCHITECTURE_FUNDS_API.md §4.1.\n",
+        "properties": {
+          "bw_fund_id": {
+            "type": "string",
+            "description": "Funds_DAG canonical fund id. Format `BW-FUND-{series_id}`.",
+            "example": "BW-FUND-S000004310"
+          },
+          "series_id": {
+            "type": "string",
+            "nullable": true,
+            "description": "SEC series id.",
+            "example": "S000004310"
+          },
+          "ticker": {
+            "type": "string",
+            "nullable": true,
+            "example": "VFINX"
+          },
+          "cik": {
+            "type": "string",
+            "nullable": true
+          },
+          "fund_name": {
+            "type": "string",
+            "nullable": true,
+            "example": "Vanguard 500 Index Fund Investor Shares"
+          },
+          "morningstar_category": {
+            "type": "string",
+            "nullable": true
+          },
+          "equity_style_9box": {
+            "type": "string",
+            "nullable": true,
+            "enum": [
+              "Large Value",
+              "Large Blend",
+              "Large Growth",
+              "Mid Value",
+              "Mid Blend",
+              "Mid Growth",
+              "Small Value",
+              "Small Blend",
+              "Small Growth"
+            ]
+          },
+          "style_link_method": {
+            "type": "string",
+            "nullable": true
+          },
+          "primary_bw_fund_id": {
+            "type": "string",
+            "nullable": true
+          },
+          "latest_report_date": {
+            "type": "string",
+            "format": "date",
+            "nullable": true,
+            "description": "Period end of the most recent reported holdings (= \"fund_date\")."
+          },
+          "latest_filing_date": {
+            "type": "string",
+            "format": "date",
+            "nullable": true,
+            "description": "SEC acceptance date for the latest filing (= \"release_date\")."
+          },
+          "latest_extracted_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "latest_total_adj_mv": {
+            "type": "number",
+            "format": "float",
+            "nullable": true
+          },
+          "latest_n_holdings": {
+            "type": "integer",
+            "nullable": true
+          },
+          "latest_effective_n": {
+            "type": "number",
+            "format": "float",
+            "nullable": true
+          },
+          "last_in_eligible_universe_at": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": true,
+            "nullable": true
+          }
+        }
+      },
+      "FundLatest": {
+        "type": "object",
+        "description": "Wide-row latest knowledge-mode snapshot from `public.funds_latest`. One row per `bw_fund_id`. Returns and diagnostics flatten the per-fund `ds_portfolio.zarr` (Funds_DAG Slice 8). Multi-quarter history lives in GCS Zarr (Stage B+). See ARCHITECTURE_FUNDS_API.md §4.2.\n",
+        "required": [
+          "bw_fund_id",
+          "report_date",
+          "filing_date",
+          "extracted_at",
+          "last_synced_at"
+        ],
+        "properties": {
+          "bw_fund_id": {
+            "type": "string",
+            "example": "BW-FUND-S000004310"
+          },
+          "report_date": {
+            "type": "string",
+            "format": "date",
+            "example": "2026-04-30"
+          },
+          "filing_date": {
+            "type": "string",
+            "format": "date",
+            "example": "2026-07-14"
+          },
+          "extracted_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "portfolio_gross_return": {
+            "type": "number",
+            "format": "float",
+            "nullable": true
+          },
+          "portfolio_market_return": {
+            "type": "number",
+            "format": "float",
+            "nullable": true
+          },
+          "portfolio_sector_return": {
+            "type": "number",
+            "format": "float",
+            "nullable": true
+          },
+          "portfolio_subsector_return": {
+            "type": "number",
+            "format": "float",
+            "nullable": true
+          },
+          "portfolio_idiosyncratic_return": {
+            "type": "number",
+            "format": "float",
+            "nullable": true
+          },
+          "identity_residual": {
+            "type": "number",
+            "format": "float",
+            "nullable": true
+          },
+          "weight_sum": {
+            "type": "number",
+            "format": "float",
+            "nullable": true,
+            "description": "ERM3 universe coverage (fraction of fund AUM mapping to in-universe symbols)."
+          },
+          "n_holdings_active": {
+            "type": "integer",
+            "nullable": true
+          },
+          "effective_n": {
+            "type": "number",
+            "format": "float",
+            "nullable": true,
+            "description": "HHI-derived diversification (1 / sum(w_i^2))."
+          },
+          "top10_weight_sum": {
+            "type": "number",
+            "format": "float",
+            "nullable": true
+          },
+          "total_adj_mv": {
+            "type": "number",
+            "format": "float",
+            "nullable": true
+          },
+          "equity_style_9box": {
+            "type": "string",
+            "nullable": true
+          },
+          "n_funds_in_cell_at_report_date": {
+            "type": "integer",
+            "nullable": true
+          },
+          "model_version": {
+            "type": "string",
+            "nullable": true,
+            "example": "funds_dag.v20260502"
+          },
+          "factor_set_id": {
+            "type": "string",
+            "nullable": true,
+            "example": "uni_mc_3000_SPY"
+          },
+          "last_synced_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": true,
+            "nullable": true
+          }
+        }
+      },
+      "FundWithLatest": {
+        "type": "object",
+        "description": "Fund registry row joined with the latest knowledge-mode snapshot.",
+        "required": [
+          "fund"
+        ],
+        "properties": {
+          "fund": {
+            "$ref": "#/components/schemas/Fund"
+          },
+          "latest": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/FundLatest"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "nullable": true
+          }
+        }
+      },
+      "FundsBatchRequest": {
+        "type": "object",
+        "required": [
+          "fund_ids"
+        ],
+        "properties": {
+          "fund_ids": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1,
+            "maxItems": 1000,
+            "example": [
+              "BW-FUND-S000004310",
+              "BW-FUND-S000123456"
+            ]
+          }
+        }
+      },
+      "FundsBatchResponse": {
+        "type": "object",
+        "description": "Multi-fund lookup. Keys are `bw_fund_id`s present in the registry.",
+        "properties": {
+          "results": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/FundWithLatest"
+            }
+          }
+        }
+      },
+      "FundsSearchResponse": {
+        "type": "object",
+        "properties": {
+          "results": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Fund"
+            }
+          }
+        }
+      },
+      "FundsStyleMembersResponse": {
+        "type": "object",
+        "required": [
+          "equity_style_9box",
+          "slug",
+          "fund_ids",
+          "count"
+        ],
+        "properties": {
+          "equity_style_9box": {
+            "type": "string",
+            "example": "Large Blend"
+          },
+          "slug": {
+            "type": "string",
+            "example": "large-blend"
+          },
+          "fund_ids": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "count": {
+            "type": "integer"
+          }
+        }
       }
     }
   },
@@ -6908,6 +7215,333 @@
           }
         }
       }
+    },
+    "/data/funds/{bw_fund_id}": {
+      "get": {
+        "summary": "Get fund (registry + latest snapshot)",
+        "description": "Returns the registry row from `public.funds` joined with the latest knowledge-mode snapshot from `public.funds_latest`. Bitemporal lineage surfaces as response headers `X-Data-As-Of` (= `report_date`) and `X-Data-Filing-Date` (= `filing_date`).\n\nv1 returns the latest knowledge-mode answer only (no `?as_of=` / `?mode=` query params — deferred to v2 per ARCHITECTURE_FUNDS_API.md §3.5).\n",
+        "operationId": "getFundDataPlane",
+        "tags": [
+          "Funds Data Plane"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {}
+        ],
+        "parameters": [
+          {
+            "name": "bw_fund_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "BW-FUND-S000004310"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Fund + latest snapshot.",
+            "headers": {
+              "X-Data-As-Of": {
+                "schema": {
+                  "type": "string",
+                  "format": "date"
+                },
+                "description": "funds_latest.report_date (period end of the snapshot)."
+              },
+              "X-Data-Filing-Date": {
+                "schema": {
+                  "type": "string",
+                  "format": "date"
+                },
+                "description": "funds_latest.filing_date (SEC acceptance date)."
+              },
+              "X-Risk-Model-Version": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FundWithLatest"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Fund not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/data/funds-latest/{bw_fund_id}": {
+      "get": {
+        "summary": "Get just the funds_latest row",
+        "description": "Returns only the wide-row snapshot from `public.funds_latest`. Skips the registry join — useful when the SDK already has the registry row or only needs the metric columns.\n",
+        "operationId": "getFundLatestDataPlane",
+        "tags": [
+          "Funds Data Plane"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {}
+        ],
+        "parameters": [
+          {
+            "name": "bw_fund_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Latest snapshot row.",
+            "headers": {
+              "X-Data-As-Of": {
+                "schema": {
+                  "type": "string",
+                  "format": "date"
+                }
+              },
+              "X-Data-Filing-Date": {
+                "schema": {
+                  "type": "string",
+                  "format": "date"
+                }
+              },
+              "X-Risk-Model-Version": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FundLatest"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No funds_latest row for this fund.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/data/funds/batch": {
+      "post": {
+        "summary": "Resolve multiple funds in one call",
+        "description": "Multi-fund lookup. Returns a registry+latest payload keyed by `bw_fund_id`. Up to 1000 ids per request.\n",
+        "operationId": "postFundsBatchDataPlane",
+        "tags": [
+          "Funds Data Plane"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {}
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FundsBatchRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Lookup map.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FundsBatchResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid body (missing/oversized fund_ids array).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/data/funds/search": {
+      "get": {
+        "summary": "Search funds by ticker or name",
+        "description": "Full-text ilike search over `ticker` and `fund_name`, optionally filtered by 9-box style cell (slug or canonical name) and share-class primary flag (`?primary=true` filters `primary_bw_fund_id IS NULL`).\n",
+        "operationId": "getFundsSearchDataPlane",
+        "tags": [
+          "Funds Data Plane"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {}
+        ],
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "ilike pattern on ticker / fund_name."
+          },
+          {
+            "name": "equity_style_9box",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "9-box slug (\"large-blend\") or canonical name (\"Large Blend\")."
+          },
+          {
+            "name": "primary",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            },
+            "description": "When true, returns only primary share-class funds (Q5 lock)."
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 500,
+              "default": 50
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Up to `limit` matching funds.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FundsSearchResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/data/funds/style/{slug}/members": {
+      "get": {
+        "summary": "List fund_ids in a 9-box style cell",
+        "description": "Returns the `bw_fund_id` list for a 9-box style cell. SDK consumers typically chain this into `/api/data/funds/batch` to materialize a peer cohort's full registry+latest payload.\n",
+        "operationId": "getStyleCellMembersDataPlane",
+        "tags": [
+          "Funds Data Plane"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {}
+        ],
+        "parameters": [
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "large-value",
+                "large-blend",
+                "large-growth",
+                "mid-value",
+                "mid-blend",
+                "mid-growth",
+                "small-value",
+                "small-blend",
+                "small-growth"
+              ]
+            }
+          },
+          {
+            "name": "primary",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 20000,
+              "default": 5000
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Fund id list for the cell.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FundsStyleMembersResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid style slug.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "tags": [
@@ -6950,6 +7584,10 @@
     {
       "name": "Discovery",
       "description": "Service discovery and capability manifests."
+    },
+    {
+      "name": "Funds Data Plane",
+      "description": "Raw-shape reads against the funds Supabase tables (`funds`, `funds_latest`). Latest knowledge-mode snapshot only — history reads via the per-fund Zarr endpoints in later stages. Public; soft Bearer auth; not metered. The compute-bearing `/funds/*`, `/funds/style/*`, and `/funds/snapshot/*` surfaces ship in subsequent stages.\n"
     }
   ]
 }

--- a/mcp/data/schemas/decompose-v1.json
+++ b/mcp/data/schemas/decompose-v1.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Decompose Position",
+  "description": "Simplified four-layer ERM3 exposure + hedge map for a single ticker. Thin semantic wrapper over the metrics DAL; same billing profile as GET /metrics/{ticker}.",
+  "oneOf": [
+    { "$ref": "#/definitions/DecomposeRequest" },
+    { "$ref": "#/definitions/DecomposeResponse" }
+  ],
+  "definitions": {
+    "DecomposeRequest": {
+      "type": "object",
+      "required": ["ticker"],
+      "properties": {
+        "ticker": {
+          "type": "string",
+          "description": "Stock ticker symbol (case-insensitive).",
+          "examples": ["NVDA", "AAPL"]
+        }
+      }
+    },
+    "DecomposeLayer": {
+      "type": "object",
+      "required": ["er", "hr", "hedge_etf"],
+      "properties": {
+        "er": {
+          "type": ["number", "null"],
+          "description": "Explained-risk variance fraction for this layer (0 to 1)."
+        },
+        "hr": {
+          "type": ["number", "null"],
+          "description": "Hedge ratio (dollar ratio). Null for residual."
+        },
+        "hedge_etf": {
+          "type": ["string", "null"],
+          "description": "Tradable ETF for this layer. Null for residual."
+        }
+      }
+    },
+    "DecomposeResponse": {
+      "type": "object",
+      "required": [
+        "ticker",
+        "symbol",
+        "data_as_of",
+        "teo",
+        "exposure",
+        "hedge"
+      ],
+      "properties": {
+        "ticker": { "type": "string" },
+        "symbol": { "type": "string" },
+        "data_as_of": {
+          "type": "string",
+          "format": "date"
+        },
+        "teo": {
+          "type": "string",
+          "format": "date"
+        },
+        "exposure": {
+          "type": "object",
+          "required": ["market", "sector", "subsector", "residual"],
+          "properties": {
+            "market": { "$ref": "#/definitions/DecomposeLayer" },
+            "sector": { "$ref": "#/definitions/DecomposeLayer" },
+            "subsector": { "$ref": "#/definitions/DecomposeLayer" },
+            "residual": { "$ref": "#/definitions/DecomposeLayer" }
+          }
+        },
+        "hedge": {
+          "type": "object",
+          "additionalProperties": { "type": "number" },
+          "description": "Map of hedge-ETF -> dollar ratio (= negative of layer hr). Duplicate ETFs across layers are summed."
+        },
+        "_metadata": { "type": "object" },
+        "_data_health": {
+          "type": "object",
+          "properties": {
+            "er_populated": { "type": "boolean" },
+            "er_sum": { "type": ["number", "null"] }
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/funds-data-routes.test.ts
+++ b/tests/funds-data-routes.test.ts
@@ -1,0 +1,295 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/dal/funds-engine", () => ({
+  resolveFundById: vi.fn(),
+  resolveFundsByIds: vi.fn(),
+  fetchFundLatest: vi.fn(),
+  searchFunds: vi.fn(),
+  getStyleCellMembers: vi.fn(),
+}));
+
+import {
+  fetchFundLatest,
+  getStyleCellMembers,
+  resolveFundById,
+  resolveFundsByIds,
+  searchFunds,
+} from "@/lib/dal/funds-engine";
+
+import { GET as getFund } from "@/app/api/data/funds/[bw_fund_id]/route";
+import { GET as getFundLatest } from "@/app/api/data/funds-latest/[bw_fund_id]/route";
+import { POST as postFundsBatch } from "@/app/api/data/funds/batch/route";
+import { GET as getFundsSearch } from "@/app/api/data/funds/search/route";
+import { GET as getStyleMembers } from "@/app/api/data/funds/style/[slug]/members/route";
+
+const FUND = {
+  bw_fund_id: "BW-FUND-X",
+  series_id: "SX",
+  ticker: "VFINX",
+  cik: null,
+  fund_name: "Test Fund",
+  morningstar_category: null,
+  equity_style_9box: "Large Blend",
+  style_link_method: null,
+  primary_bw_fund_id: null,
+  latest_report_date: "2026-04-30",
+  latest_filing_date: "2026-07-14",
+  latest_extracted_at: null,
+  latest_total_adj_mv: 1000,
+  latest_n_holdings: 10,
+  latest_effective_n: 5,
+  last_in_eligible_universe_at: null,
+  metadata: {},
+};
+
+const LATEST = {
+  bw_fund_id: "BW-FUND-X",
+  report_date: "2026-04-30",
+  filing_date: "2026-07-14",
+  extracted_at: "2026-05-02T16:38:21.330085+00:00",
+  portfolio_gross_return: 0.05,
+  portfolio_market_return: 0.04,
+  portfolio_sector_return: 0.005,
+  portfolio_subsector_return: 0.003,
+  portfolio_idiosyncratic_return: 0.002,
+  identity_residual: null,
+  weight_sum: 1,
+  n_holdings_active: 10,
+  effective_n: 5,
+  top10_weight_sum: 0.5,
+  total_adj_mv: 1000,
+  equity_style_9box: "Large Blend",
+  n_funds_in_cell_at_report_date: 100,
+  model_version: "funds_dag.v20260502",
+  factor_set_id: "uni_mc_3000_SPY",
+  last_synced_at: "2026-05-02T16:41:31.441605+00:00",
+  metadata: {},
+};
+
+beforeEach(() => {
+  vi.mocked(resolveFundById).mockReset();
+  vi.mocked(resolveFundsByIds).mockReset();
+  vi.mocked(fetchFundLatest).mockReset();
+  vi.mocked(searchFunds).mockReset();
+  vi.mocked(getStyleCellMembers).mockReset();
+});
+
+afterEach(() => {
+  delete process.env.RISKMODELS_API_SERVICE_KEY;
+});
+
+function req(url: string, init?: RequestInit): NextRequest {
+  return new NextRequest(new Request(url, init));
+}
+
+describe("GET /api/data/funds/[bw_fund_id]", () => {
+  it("returns 200 with fund + latest and bitemporal headers", async () => {
+    vi.mocked(resolveFundById).mockResolvedValue({ fund: FUND, latest: LATEST });
+    const res = await getFund(req("http://localhost/api/data/funds/BW-FUND-X"), {
+      params: Promise.resolve({ bw_fund_id: "BW-FUND-X" }),
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("X-Data-As-Of")).toBe("2026-04-30");
+    expect(res.headers.get("X-Data-Filing-Date")).toBe("2026-07-14");
+    expect(res.headers.get("X-Risk-Model-Version")).toBe("funds_dag.v20260502");
+    const body = await res.json();
+    expect(body.fund.ticker).toBe("VFINX");
+    expect(body.latest.portfolio_gross_return).toBeCloseTo(0.05);
+  });
+
+  it("returns 404 when DAL returns null", async () => {
+    vi.mocked(resolveFundById).mockResolvedValue(null);
+    const res = await getFund(req("http://localhost/api/data/funds/BW-FUND-MISSING"), {
+      params: Promise.resolve({ bw_fund_id: "BW-FUND-MISSING" }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("omits bitemporal headers when latest is null", async () => {
+    vi.mocked(resolveFundById).mockResolvedValue({ fund: FUND, latest: null });
+    const res = await getFund(req("http://localhost/api/data/funds/BW-FUND-X"), {
+      params: Promise.resolve({ bw_fund_id: "BW-FUND-X" }),
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("X-Data-As-Of")).toBeNull();
+    expect(res.headers.get("X-Data-Filing-Date")).toBeNull();
+  });
+
+  it("rejects an invalid Bearer token (soft auth still validates when service key set)", async () => {
+    process.env.RISKMODELS_API_SERVICE_KEY = "secret";
+    const res = await getFund(
+      req("http://localhost/api/data/funds/BW-FUND-X", {
+        headers: { authorization: "Bearer wrong" },
+      }),
+      { params: Promise.resolve({ bw_fund_id: "BW-FUND-X" }) },
+    );
+    expect(res.status).toBe(401);
+    expect(vi.mocked(resolveFundById)).not.toHaveBeenCalled();
+  });
+});
+
+describe("GET /api/data/funds/style/[slug]/members", () => {
+  it("returns fund_ids for a valid slug", async () => {
+    vi.mocked(getStyleCellMembers).mockResolvedValue([
+      "BW-FUND-A",
+      "BW-FUND-B",
+    ]);
+    const res = await getStyleMembers(
+      req("http://localhost/api/data/funds/style/large-blend/members"),
+      { params: Promise.resolve({ slug: "large-blend" }) },
+    );
+    expect(res.status).toBe(200);
+    expect(vi.mocked(getStyleCellMembers)).toHaveBeenCalledWith("Large Blend", {
+      primaryOnly: false,
+      limit: 5000,
+    });
+    const body = await res.json();
+    expect(body.equity_style_9box).toBe("Large Blend");
+    expect(body.fund_ids).toEqual(["BW-FUND-A", "BW-FUND-B"]);
+    expect(body.count).toBe(2);
+  });
+
+  it("rejects an unknown slug with 400", async () => {
+    const res = await getStyleMembers(
+      req("http://localhost/api/data/funds/style/mega-blend/members"),
+      { params: Promise.resolve({ slug: "mega-blend" }) },
+    );
+    expect(res.status).toBe(400);
+    expect(vi.mocked(getStyleCellMembers)).not.toHaveBeenCalled();
+  });
+
+  it("forwards primary=true and clamps limit", async () => {
+    vi.mocked(getStyleCellMembers).mockResolvedValue([]);
+    await getStyleMembers(
+      req(
+        "http://localhost/api/data/funds/style/small-value/members?primary=true&limit=999999",
+      ),
+      { params: Promise.resolve({ slug: "small-value" }) },
+    );
+    expect(vi.mocked(getStyleCellMembers)).toHaveBeenCalledWith("Small Value", {
+      primaryOnly: true,
+      limit: 20_000,
+    });
+  });
+});
+
+describe("GET /api/data/funds/search", () => {
+  it("forwards q + style slug to DAL (slug → DB name)", async () => {
+    vi.mocked(searchFunds).mockResolvedValue([FUND]);
+    const res = await getFundsSearch(
+      req(
+        "http://localhost/api/data/funds/search?q=vfinx&equity_style_9box=large-blend&primary=true&limit=10",
+      ),
+    );
+    expect(res.status).toBe(200);
+    expect(vi.mocked(searchFunds)).toHaveBeenCalledWith({
+      q: "vfinx",
+      equityStyle9Box: "Large Blend",
+      primaryOnly: true,
+      limit: 10,
+    });
+    const body = await res.json();
+    expect(body.results.length).toBe(1);
+  });
+
+  it("accepts canonical DB form for equity_style_9box (e.g., 'Large Blend')", async () => {
+    vi.mocked(searchFunds).mockResolvedValue([]);
+    await getFundsSearch(
+      req(
+        "http://localhost/api/data/funds/search?equity_style_9box=Large%20Blend",
+      ),
+    );
+    const call = vi.mocked(searchFunds).mock.calls[0][0]!;
+    expect(call.equityStyle9Box).toBe("Large Blend");
+  });
+
+  it("clamps limit to 500", async () => {
+    vi.mocked(searchFunds).mockResolvedValue([]);
+    await getFundsSearch(
+      req("http://localhost/api/data/funds/search?limit=99999"),
+    );
+    expect(vi.mocked(searchFunds).mock.calls[0][0]?.limit).toBe(500);
+  });
+
+  it("default limit is 50; primary=false unless explicitly true", async () => {
+    vi.mocked(searchFunds).mockResolvedValue([]);
+    await getFundsSearch(req("http://localhost/api/data/funds/search"));
+    const call = vi.mocked(searchFunds).mock.calls[0][0]!;
+    expect(call.limit).toBe(50);
+    expect(call.primaryOnly).toBe(false);
+  });
+});
+
+describe("POST /api/data/funds/batch", () => {
+  function postReq(body: unknown): NextRequest {
+    return req("http://localhost/api/data/funds/batch", {
+      method: "POST",
+      body: JSON.stringify(body),
+      headers: { "content-type": "application/json" },
+    });
+  }
+
+  it("returns results keyed by bw_fund_id", async () => {
+    vi.mocked(resolveFundsByIds).mockResolvedValue(
+      new Map([["BW-FUND-X", { fund: FUND, latest: LATEST }]]),
+    );
+    const res = await postFundsBatch(postReq({ fund_ids: ["BW-FUND-X"] }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.results["BW-FUND-X"].fund.ticker).toBe("VFINX");
+    expect(body.results["BW-FUND-X"].latest.report_date).toBe("2026-04-30");
+  });
+
+  it("rejects empty fund_ids", async () => {
+    const res = await postFundsBatch(postReq({ fund_ids: [] }));
+    expect(res.status).toBe(400);
+    expect(vi.mocked(resolveFundsByIds)).not.toHaveBeenCalled();
+  });
+
+  it("rejects more than 1000 ids", async () => {
+    const fund_ids = Array.from({ length: 1001 }, (_, i) => `BW-FUND-${i}`);
+    const res = await postFundsBatch(postReq({ fund_ids }));
+    expect(res.status).toBe(400);
+    expect(vi.mocked(resolveFundsByIds)).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-string entries", async () => {
+    const res = await postFundsBatch(postReq({ fund_ids: ["BW-FUND-X", 42] }));
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects invalid JSON body", async () => {
+    const r = req("http://localhost/api/data/funds/batch", {
+      method: "POST",
+      body: "{ not json",
+      headers: { "content-type": "application/json" },
+    });
+    const res = await postFundsBatch(r);
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("GET /api/data/funds-latest/[bw_fund_id]", () => {
+  it("returns 200 with the latest row and headers", async () => {
+    vi.mocked(fetchFundLatest).mockResolvedValue(LATEST);
+    const res = await getFundLatest(
+      req("http://localhost/api/data/funds-latest/BW-FUND-X"),
+      { params: Promise.resolve({ bw_fund_id: "BW-FUND-X" }) },
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("X-Data-As-Of")).toBe("2026-04-30");
+    expect(res.headers.get("X-Data-Filing-Date")).toBe("2026-07-14");
+    const body = await res.json();
+    expect(body.bw_fund_id).toBe("BW-FUND-X");
+  });
+
+  it("returns 404 when DAL returns null", async () => {
+    vi.mocked(fetchFundLatest).mockResolvedValue(null);
+    const res = await getFundLatest(
+      req("http://localhost/api/data/funds-latest/BW-FUND-MISSING"),
+      { params: Promise.resolve({ bw_fund_id: "BW-FUND-MISSING" }) },
+    );
+    expect(res.status).toBe(404);
+  });
+});

--- a/tests/funds-engine.test.ts
+++ b/tests/funds-engine.test.ts
@@ -1,0 +1,240 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(),
+}));
+
+import { createAdminClient } from "@/lib/supabase/admin";
+import {
+  fetchFund,
+  fetchFundLatest,
+  getStyleCellMembers,
+  resolveFundById,
+  resolveFundsByIds,
+  searchFunds,
+} from "@/lib/dal/funds-engine";
+
+type Result<T> = { data: T; error: unknown };
+
+interface QueryStub {
+  select: () => QueryStub;
+  eq: () => QueryStub;
+  in: () => QueryStub;
+  is: () => QueryStub;
+  or: () => QueryStub;
+  ilike: () => QueryStub;
+  order: () => QueryStub;
+  limit: () => QueryStub;
+  maybeSingle: () => Promise<Result<unknown>>;
+  then: <R>(
+    resolve: (value: Result<unknown>) => R,
+    reject?: (error: unknown) => R,
+  ) => Promise<R>;
+}
+
+function makeQuery(result: Result<unknown>): QueryStub {
+  const stub = {} as QueryStub;
+  stub.select = () => stub;
+  stub.eq = () => stub;
+  stub.in = () => stub;
+  stub.is = () => stub;
+  stub.or = () => stub;
+  stub.ilike = () => stub;
+  stub.order = () => stub;
+  stub.limit = () => stub;
+  stub.maybeSingle = () => Promise.resolve(result);
+  stub.then = (resolve, reject) =>
+    Promise.resolve(result).then(resolve, reject);
+  return stub;
+}
+
+function setMockClient(byTable: Record<string, Result<unknown>>) {
+  vi.mocked(createAdminClient).mockReturnValue({
+    from: (table: string) => {
+      const result = byTable[table];
+      if (!result) throw new Error(`unmocked table: ${table}`);
+      return makeQuery(result);
+    },
+  } as never);
+}
+
+const FUND_VFINX = {
+  bw_fund_id: "BW-FUND-S000004310",
+  series_id: "S000004310",
+  ticker: "VFINX",
+  cik: "0000036405",
+  fund_name: "Vanguard 500 Index Fund Investor Shares",
+  morningstar_category: "Large Blend",
+  equity_style_9box: "Large Blend",
+  style_link_method: "ticker_match",
+  primary_bw_fund_id: null,
+  latest_report_date: "2026-04-30",
+  latest_filing_date: "2026-07-14",
+  latest_extracted_at: "2026-05-02T16:38:21.330085+00:00",
+  latest_total_adj_mv: 25_000_000_000,
+  latest_n_holdings: 503,
+  latest_effective_n: 102.4,
+  last_in_eligible_universe_at: null,
+  metadata: {},
+};
+
+const FUND_LATEST_VFINX = {
+  bw_fund_id: "BW-FUND-S000004310",
+  report_date: "2026-04-30",
+  filing_date: "2026-07-14",
+  extracted_at: "2026-05-02T16:38:21.330085+00:00",
+  portfolio_gross_return: 0.071,
+  portfolio_market_return: 0.099,
+  portfolio_sector_return: -0.01,
+  portfolio_subsector_return: -0.01,
+  portfolio_idiosyncratic_return: -0.005,
+  identity_residual: -0.003,
+  weight_sum: 0.99,
+  n_holdings_active: 503,
+  effective_n: 102.4,
+  top10_weight_sum: 0.34,
+  total_adj_mv: 25_000_000_000,
+  equity_style_9box: "Large Blend",
+  n_funds_in_cell_at_report_date: 1234,
+  model_version: "funds_dag.v20260502",
+  factor_set_id: "uni_mc_3000_SPY",
+  last_synced_at: "2026-05-02T16:41:31.441605+00:00",
+  metadata: {},
+};
+
+beforeEach(() => {
+  vi.mocked(createAdminClient).mockReset();
+});
+
+describe("fetchFund", () => {
+  it("returns the row when found", async () => {
+    setMockClient({ funds: { data: FUND_VFINX, error: null } });
+    const r = await fetchFund("BW-FUND-S000004310");
+    expect(r?.bw_fund_id).toBe("BW-FUND-S000004310");
+    expect(r?.ticker).toBe("VFINX");
+  });
+
+  it("returns null on error", async () => {
+    setMockClient({
+      funds: { data: null, error: { message: "boom" } },
+    });
+    const r = await fetchFund("BW-FUND-MISSING");
+    expect(r).toBeNull();
+  });
+
+  it("returns null when no row", async () => {
+    setMockClient({ funds: { data: null, error: null } });
+    const r = await fetchFund("BW-FUND-MISSING");
+    expect(r).toBeNull();
+  });
+});
+
+describe("fetchFundLatest", () => {
+  it("returns the latest row when found", async () => {
+    setMockClient({
+      funds_latest: { data: FUND_LATEST_VFINX, error: null },
+    });
+    const r = await fetchFundLatest("BW-FUND-S000004310");
+    expect(r?.report_date).toBe("2026-04-30");
+    expect(r?.filing_date).toBe("2026-07-14");
+  });
+});
+
+describe("resolveFundById", () => {
+  it("joins fund + latest", async () => {
+    setMockClient({
+      funds: { data: FUND_VFINX, error: null },
+      funds_latest: { data: FUND_LATEST_VFINX, error: null },
+    });
+    const r = await resolveFundById("BW-FUND-S000004310");
+    expect(r?.fund.ticker).toBe("VFINX");
+    expect(r?.latest?.portfolio_gross_return).toBeCloseTo(0.071);
+  });
+
+  it("returns null when fund not found, even if latest exists", async () => {
+    setMockClient({
+      funds: { data: null, error: null },
+      funds_latest: { data: FUND_LATEST_VFINX, error: null },
+    });
+    const r = await resolveFundById("BW-FUND-MISSING");
+    expect(r).toBeNull();
+  });
+
+  it("returns fund with null latest when only registry row exists", async () => {
+    setMockClient({
+      funds: { data: FUND_VFINX, error: null },
+      funds_latest: { data: null, error: null },
+    });
+    const r = await resolveFundById("BW-FUND-S000004310");
+    expect(r?.fund.bw_fund_id).toBe("BW-FUND-S000004310");
+    expect(r?.latest).toBeNull();
+  });
+});
+
+describe("resolveFundsByIds", () => {
+  it("returns empty Map for empty input without hitting DB", async () => {
+    const r = await resolveFundsByIds([]);
+    expect(r.size).toBe(0);
+    expect(vi.mocked(createAdminClient)).not.toHaveBeenCalled();
+  });
+
+  it("merges funds + funds_latest by bw_fund_id", async () => {
+    setMockClient({
+      funds: { data: [FUND_VFINX], error: null },
+      funds_latest: { data: [FUND_LATEST_VFINX], error: null },
+    });
+    const r = await resolveFundsByIds(["BW-FUND-S000004310"]);
+    expect(r.size).toBe(1);
+    expect(r.get("BW-FUND-S000004310")?.latest?.report_date).toBe(
+      "2026-04-30",
+    );
+  });
+
+  it("includes funds without latest rows", async () => {
+    setMockClient({
+      funds: { data: [FUND_VFINX], error: null },
+      funds_latest: { data: [], error: null },
+    });
+    const r = await resolveFundsByIds(["BW-FUND-S000004310"]);
+    expect(r.get("BW-FUND-S000004310")?.latest).toBeNull();
+  });
+});
+
+describe("searchFunds", () => {
+  it("returns rows when DB returns rows", async () => {
+    setMockClient({ funds: { data: [FUND_VFINX], error: null } });
+    const r = await searchFunds({ q: "VFINX", limit: 10 });
+    expect(r.length).toBe(1);
+    expect(r[0].ticker).toBe("VFINX");
+  });
+
+  it("clamps limit at 500 (does not throw)", async () => {
+    setMockClient({ funds: { data: [], error: null } });
+    const r = await searchFunds({ limit: 999_999 });
+    expect(r).toEqual([]);
+  });
+});
+
+describe("getStyleCellMembers", () => {
+  it("returns just the bw_fund_id list", async () => {
+    setMockClient({
+      funds: {
+        data: [
+          { bw_fund_id: "BW-FUND-A" },
+          { bw_fund_id: "BW-FUND-B" },
+        ],
+        error: null,
+      },
+    });
+    const r = await getStyleCellMembers("Large Blend");
+    expect(r).toEqual(["BW-FUND-A", "BW-FUND-B"]);
+  });
+
+  it("returns [] on error", async () => {
+    setMockClient({
+      funds: { data: null, error: { message: "fail" } },
+    });
+    const r = await getStyleCellMembers("Large Blend");
+    expect(r).toEqual([]);
+  });
+});

--- a/tests/funds-style-slug.test.ts
+++ b/tests/funds-style-slug.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import {
+  STYLE_CELL_NAMES,
+  isValidStyleSlug,
+  styleNameToSlug,
+  styleSlugToName,
+} from "@/lib/funds/style-slug";
+
+describe("style-slug", () => {
+  it("exports exactly 9 cells", () => {
+    expect(STYLE_CELL_NAMES.length).toBe(9);
+  });
+
+  it("round-trips name → slug → name for every cell", () => {
+    for (const name of STYLE_CELL_NAMES) {
+      const slug = styleNameToSlug(name);
+      expect(slug).not.toBeNull();
+      expect(styleSlugToName(slug!)).toBe(name);
+    }
+  });
+
+  it("normalizes slug case and whitespace", () => {
+    expect(styleSlugToName("LARGE-BLEND")).toBe("Large Blend");
+    expect(styleSlugToName("  large-blend  ")).toBe("Large Blend");
+  });
+
+  it("returns null for unknown slugs", () => {
+    expect(styleSlugToName("mega-blend")).toBeNull();
+    expect(styleSlugToName("")).toBeNull();
+    expect(isValidStyleSlug("mega-blend")).toBe(false);
+    expect(isValidStyleSlug("large-blend")).toBe(true);
+  });
+
+  it("returns null when name is not a 9-box cell", () => {
+    expect(styleNameToSlug("Large Quality")).toBeNull();
+    expect(styleNameToSlug("large blend")).toBeNull(); // case-sensitive on the DB side
+  });
+
+  it("emits hyphenated lowercase slugs", () => {
+    expect(styleNameToSlug("Large Blend")).toBe("large-blend");
+    expect(styleNameToSlug("Small Growth")).toBe("small-growth");
+  });
+});


### PR DESCRIPTION
## Summary

Stage A of the funds-side API build per `Funds_DAG/docs/ARCHITECTURE_FUNDS_API.md` §7.2. Two commits:

1. **`c9d4a71` — Funds Supabase schema v1** (already on the branch from PR #21's source, included here for one-shot review). DDL for `funds`, `funds_latest`, `style_portfolios_latest`, `style_rankings_top`, `funds_sync_state_v1`. Migration **applied** to remote `plurbatnjhpullghyhol` (`supabase migration list` confirms).
2. **`f58f84a` — Stage A data-plane endpoints**. Raw-shape reads against the funds tables, mirroring `/api/data/symbols/*`. Public; soft Bearer auth via `verifyGatewayAuth`; not metered.

### Routes added

| Method | Path | Returns |
|---|---|---|
| GET  | `/api/data/funds/{bw_fund_id}` | fund + funds_latest joined |
| POST | `/api/data/funds/batch` | multi-fund lookup (≤1000 ids) |
| GET  | `/api/data/funds/search` | q + style + primary filters |
| GET  | `/api/data/funds/style/{slug}/members` | fund_ids in a 9-box cell |
| GET  | `/api/data/funds-latest/{bw_fund_id}` | just the funds_latest row |

### New code

- `lib/dal/funds-engine.ts` — mirrors `risk-engine-v3.ts`. Five reads against `public.funds` and `public.funds_latest`.
- `lib/funds/style-slug.ts` — 9-box cell ↔ slug helper (`large-blend` ↔ `Large Blend`).
- 38 Vitest tests against a mocked Supabase client.
- `OPENAPI_SPEC.yaml` + regenerated `mcp/data/openapi.json` with `Fund` / `FundLatest` / `FundWithLatest` schemas, 5 paths, and a `Funds Data Plane` tag.

### Bitemporal model

Per architecture doc §3.5 every endpoint that returns a `funds_latest` row sets:
- `X-Data-As-Of: <report_date>`
- `X-Data-Filing-Date: <filing_date>`
- `X-Risk-Model-Version: <model_version>`

v1 returns the latest knowledge-mode snapshot only. `?as_of=` / `?mode=` is deferred to v2 — schema is forward-compatible (the columns are already there).

### Deliberately out of scope

| Stage | What | Where |
|---|---|---|
| B | `/api/funds/{id}` metrics + history | next PR |
| C | `/api/funds/style/{slug}/*` cohort | later |
| D | `/api/funds/snapshot/*` | later |
| E | AOM extensions + SDK | later |
| F | `/api/13f/*` | later |

## Test plan

- [x] `npm test` — 117/117 passing (38 new in Stage A)
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run cli:openapi-check` — OK (44 paths)
- [x] `npm run build:openapi` — yaml→json regenerates without error
- [x] `supabase migration list --linked` — `20260502000000` recorded as applied
- [ ] Smoke against staging deploy: `GET /api/data/funds/BW-FUND-S000004310` → 200 with bitemporal headers (will return 404 until Funds_DAG Slice 11 sync runs and populates the tables)

## Notes

- `app/api/data/funds/*` route files are force-added because `.gitignore:100` (`data/`) catches them as a side effect — same pattern existing `/api/data/symbols/*` follows. Worth fixing repo-wide later (anchor it as `/data/`).
- `supabase/migrations/20260502160000_13f_filers_schema_v1.sql` remains untracked on disk — Funds_DAG Slice 13 work in flight; will land separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)