### PR TITLE
Funds Stage B.1: GET /api/funds/{bw_fund_id} (latest metrics, billable)

### DIFF
--- a/OPENAPI_SPEC.yaml
+++ b/OPENAPI_SPEC.yaml
@@ -1855,6 +1855,86 @@ components:
         count:
           type: integer
 
+    FundMetricsResponse:
+      type: object
+      description: >
+        Latest knowledge-mode metrics for a single mutual fund. Joins
+        `public.funds` (registry) with `public.funds_latest` (the wide-row
+        snapshot) and groups return components / diagnostics / meta into
+        nested objects. Bitemporal triple is at the top level; lineage in
+        `_metadata`.
+      required: [bw_fund_id, report_date, filing_date, extracted_at, returns, diagnostics, meta, _metadata]
+      properties:
+        bw_fund_id: { type: string, example: BW-FUND-S000004310 }
+        ticker: { type: string, nullable: true, example: VFINX }
+        fund_name: { type: string, nullable: true }
+        equity_style_9box:
+          type: string
+          nullable: true
+          enum:
+            - Large Value
+            - Large Blend
+            - Large Growth
+            - Mid Value
+            - Mid Blend
+            - Mid Growth
+            - Small Value
+            - Small Blend
+            - Small Growth
+        report_date: { type: string, format: date, example: "2026-04-30" }
+        filing_date: { type: string, format: date, example: "2026-07-14" }
+        extracted_at: { type: string, format: date-time }
+        returns:
+          type: object
+          description: Portfolio-level return components from the per-fund Slice 8 zarr.
+          properties:
+            gross: { type: number, format: float, nullable: true }
+            market: { type: number, format: float, nullable: true }
+            sector: { type: number, format: float, nullable: true }
+            subsector: { type: number, format: float, nullable: true }
+            idiosyncratic: { type: number, format: float, nullable: true }
+            identity_residual:
+              type: number
+              format: float
+              nullable: true
+              description: L3 noise diagnostic (gross − sum of layer returns).
+        diagnostics:
+          type: object
+          properties:
+            weight_sum:
+              type: number
+              format: float
+              nullable: true
+              description: ERM3 universe coverage (fraction of fund AUM in mapped symbols).
+            n_holdings_active: { type: integer, nullable: true }
+            effective_n:
+              type: number
+              format: float
+              nullable: true
+              description: HHI-derived diversification (1 / sum(w_i^2)).
+            top10_weight_sum: { type: number, format: float, nullable: true }
+        meta:
+          type: object
+          properties:
+            total_adj_mv: { type: number, format: float, nullable: true }
+            n_funds_in_cell_at_report_date: { type: integer, nullable: true }
+            morningstar_category: { type: string, nullable: true }
+            primary_bw_fund_id: { type: string, nullable: true }
+        _metadata:
+          type: object
+          properties:
+            model_version:
+              type: string
+              nullable: true
+              example: funds_dag.v20260502
+            factor_set_id:
+              type: string
+              nullable: true
+              example: uni_mc_3000_SPY
+            data_as_of: { type: string, format: date }
+            data_freshness: { type: string, format: date-time }
+            last_synced_at: { type: string, format: date-time }
+
 security:
   - BearerAuth: []
 
@@ -5318,6 +5398,77 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
 
+  /funds/{bw_fund_id}:
+    get:
+      summary: Latest fund metrics
+      description: >
+        Knowledge-mode portfolio return decomposition + diagnostics for a
+        single mutual fund. Returns the gross / market / sector / subsector
+        / idiosyncratic return components from the per-fund Slice 8 zarr
+        (materialized in `public.funds_latest`), plus diagnostics
+        (`weight_sum`, `n_holdings_active`, `effective_n`,
+        `top10_weight_sum`) and registry-side meta. Bitemporal lineage on
+        response headers (`X-Data-As-Of`, `X-Data-Filing-Date`).
+
+
+        Per-fund time series, holdings panel, and hedge ratios live in
+        GCS Zarr and ship under `/funds/{bw_fund_id}/portfolio`,
+        `/holdings`, `/hedge` in Stage B.2.
+
+
+        v1 returns the latest knowledge-mode answer only — `?as_of=` /
+        `?mode=` is deferred to v2 (schema is forward-compatible).
+      operationId: getFundMetrics
+      tags: [Funds]
+      x-pricing:
+        capability_id: fund-metrics
+        tier: baseline
+        cost_usd: 0.005
+        billing_code: fund_metrics_v1
+      parameters:
+        - name: bw_fund_id
+          in: path
+          required: true
+          schema: { type: string }
+          example: BW-FUND-S000004310
+      responses:
+        "200":
+          description: Latest fund metrics.
+          headers:
+            X-Data-As-Of:
+              schema: { type: string, format: date }
+              description: funds_latest.report_date (period end of the snapshot).
+            X-Data-Filing-Date:
+              schema: { type: string, format: date }
+              description: funds_latest.filing_date (SEC acceptance date).
+            X-Risk-Model-Version:
+              schema: { type: string }
+            X-API-Cost-USD:
+              schema: { type: string }
+              description: USD cost deducted from prepaid balance for this request.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FundMetricsResponse"
+        "402":
+          description: Insufficient prepaid balance.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InsufficientBalance"
+        "404":
+          description: Fund not found, or registry exists but no funds_latest row yet.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "429":
+          description: Rate limit exceeded.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RateLimitExceeded"
+
 tags:
   - name: Risk Metrics
     description: ERM3 factor hedge ratios, explained risk, and return decompositions.
@@ -5347,3 +5498,11 @@ tags:
       auth; not metered. The compute-bearing `/funds/*`,
       `/funds/style/*`, and `/funds/snapshot/*` surfaces ship in subsequent
       stages.
+  - name: Funds
+    description: >
+      Compute-bearing fund endpoints. Latest metrics (Stage B.1) join
+      `public.funds` with `public.funds_latest` and return a shaped
+      response with bitemporal lineage. Per-fund time series, holdings,
+      and hedge ratios (Stage B.2) read from GCS Zarr. Style-cohort
+      surfaces (Stage C) and snapshot tearsheets (Stage D) follow.
+      Billable per request.

--- a/OPENAPI_SPEC.yaml
+++ b/OPENAPI_SPEC.yaml
@@ -1855,6 +1855,48 @@ components:
         count:
           type: integer
 
+    FundHolding:
+      type: object
+      description: One holding (security) within a fund's top-N snapshot.
+      required: [bw_sym_id, adj_mv]
+      properties:
+        bw_sym_id:
+          type: string
+          description: Internal symbol id. Resolve to ticker via /api/data/symbols/batch.
+          example: BW-BBG000B9XRY4
+        adj_mv:
+          type: number
+          format: float
+          description: Adjusted market value of this position at the snapshot teo.
+        weight:
+          type: number
+          format: float
+          nullable: true
+          description: Fraction of `aum_erm3`. Null when aum_erm3 is null/0.
+
+    FundHoldingsResponse:
+      type: object
+      description: >
+        Top-N current holdings for a fund at the latest teo. Sourced from
+        per-fund `ds_ph.zarr` (Slice 5). `aum_reported` is sum(adj_mv)
+        BEFORE universe filter; `aum_erm3` is sum AFTER (ERM3-mapped
+        symbols only — the denominator for `weight`).
+      required: [bw_fund_id, teo, n_holdings_returned, n_total_holdings, holdings]
+      properties:
+        bw_fund_id: { type: string }
+        ticker: { type: string, nullable: true }
+        fund_name: { type: string, nullable: true }
+        equity_style_9box: { type: string, nullable: true }
+        teo: { type: string, format: date }
+        aum_reported: { type: number, format: float, nullable: true }
+        aum_erm3: { type: number, format: float, nullable: true }
+        n_holdings_returned: { type: integer, example: 25 }
+        n_total_holdings: { type: integer, example: 503 }
+        holdings:
+          type: array
+          items:
+            $ref: "#/components/schemas/FundHolding"
+
     FundPortfolioRow:
       type: object
       description: One teo (month-end) of a fund's portfolio time series.
@@ -5434,6 +5476,73 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+
+  /funds/{bw_fund_id}/holdings:
+    get:
+      summary: Top-N current fund holdings
+      description: >
+        Top-N holdings for a fund at the latest teo. Reads `adj_mv (symbol, teo)`
+        and `aum_erm3 (teo,)` from Slice 5's per-fund `ds_ph.zarr` on GCS,
+        sorts by `adj_mv` descending, and returns `bw_sym_id` + `adj_mv` +
+        `weight = adj_mv / aum_erm3`. Resolve `bw_sym_id` to ticker via
+        `/api/data/symbols/batch` if needed.
+      operationId: getFundHoldings
+      tags: [Funds]
+      x-pricing:
+        capability_id: fund-holdings
+        tier: baseline
+        cost_usd: 0.005
+        billing_code: fund_holdings_v1
+      parameters:
+        - name: bw_fund_id
+          in: path
+          required: true
+          schema: { type: string }
+          example: BW-FUND-S000004310
+        - name: limit
+          in: query
+          required: false
+          schema: { type: integer, minimum: 1, maximum: 1000, default: 25 }
+          description: Max holdings to return (default 25).
+      responses:
+        "200":
+          description: Top-N holdings snapshot.
+          headers:
+            X-Data-As-Of:
+              schema: { type: string, format: date }
+              description: Latest teo in the per-fund holdings panel.
+            X-Data-Filing-Date:
+              schema: { type: string, format: date }
+            X-API-Cost-USD:
+              schema: { type: string }
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FundHoldingsResponse"
+        "400":
+          description: Malformed limit param.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "402":
+          description: Insufficient prepaid balance.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InsufficientBalance"
+        "404":
+          description: Fund not found, or no holdings panel.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "429":
+          description: Rate limit exceeded.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RateLimitExceeded"
 
   /funds/{bw_fund_id}/portfolio:
     get:

--- a/OPENAPI_SPEC.yaml
+++ b/OPENAPI_SPEC.yaml
@@ -1855,6 +1855,43 @@ components:
         count:
           type: integer
 
+    FundHedgeLeg:
+      type: object
+      description: One ETF hedge leg at a given factor level.
+      required: [etf, hr]
+      properties:
+        etf:
+          type: string
+          description: ETF symbol (e.g. SPY, XLK, SMH).
+        hr:
+          type: number
+          format: float
+          description: Hedge ratio (dollar_ratio) — ETF notional per $1 of fund exposure at this level.
+
+    FundHedgeResponse:
+      type: object
+      description: >
+        Latest L1/L2/L3 hedge ratios for a fund. Empty arrays are emitted
+        for levels with no non-NaN entries (e.g. small / niche funds may
+        only have an L1 market hedge). Composing a full hedge basket
+        means concatenating L1 + L2 + L3 entries.
+      required: [bw_fund_id, teo, L1, L2, L3]
+      properties:
+        bw_fund_id: { type: string }
+        ticker: { type: string, nullable: true }
+        fund_name: { type: string, nullable: true }
+        equity_style_9box: { type: string, nullable: true }
+        teo: { type: string, format: date }
+        L1:
+          type: array
+          items: { $ref: "#/components/schemas/FundHedgeLeg" }
+        L2:
+          type: array
+          items: { $ref: "#/components/schemas/FundHedgeLeg" }
+        L3:
+          type: array
+          items: { $ref: "#/components/schemas/FundHedgeLeg" }
+
     FundHolding:
       type: object
       description: One holding (security) within a fund's top-N snapshot.
@@ -5476,6 +5513,60 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+
+  /funds/{bw_fund_id}/hedge:
+    get:
+      summary: Latest fund hedge ratios (L1 / L2 / L3)
+      description: >
+        Latest L1/L2/L3 ETF hedge ratios for a fund. Reads `L{1,2,3}_HR
+        (teo, symbol)` from Slice 7's per-fund `ds_hr.zarr` at the
+        latest teo. Empty arrays are emitted for levels with no non-NaN
+        entries (small / niche funds may only have an L1 market hedge).
+      operationId: getFundHedge
+      tags: [Funds]
+      x-pricing:
+        capability_id: fund-hedge
+        tier: baseline
+        cost_usd: 0.005
+        billing_code: fund_hedge_v1
+      parameters:
+        - name: bw_fund_id
+          in: path
+          required: true
+          schema: { type: string }
+          example: BW-FUND-S000004310
+      responses:
+        "200":
+          description: Per-level hedge legs.
+          headers:
+            X-Data-As-Of:
+              schema: { type: string, format: date }
+            X-Data-Filing-Date:
+              schema: { type: string, format: date }
+            X-API-Cost-USD:
+              schema: { type: string }
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FundHedgeResponse"
+        "402":
+          description: Insufficient prepaid balance.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InsufficientBalance"
+        "404":
+          description: Fund not found, or no hedge ratio panel.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "429":
+          description: Rate limit exceeded.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RateLimitExceeded"
 
   /funds/{bw_fund_id}/holdings:
     get:

--- a/OPENAPI_SPEC.yaml
+++ b/OPENAPI_SPEC.yaml
@@ -1855,6 +1855,43 @@ components:
         count:
           type: integer
 
+    FundPortfolioRow:
+      type: object
+      description: One teo (month-end) of a fund's portfolio time series.
+      required: [teo]
+      properties:
+        teo: { type: string, format: date, example: "2026-04-30" }
+        portfolio_gross_return: { type: number, format: float, nullable: true }
+        portfolio_market_return: { type: number, format: float, nullable: true }
+        portfolio_sector_return: { type: number, format: float, nullable: true }
+        portfolio_subsector_return: { type: number, format: float, nullable: true }
+        portfolio_idiosyncratic_return: { type: number, format: float, nullable: true }
+        identity_residual: { type: number, format: float, nullable: true }
+        weight_sum: { type: number, format: float, nullable: true }
+        n_holdings_active: { type: integer, nullable: true }
+        effective_n: { type: number, format: float, nullable: true }
+        top10_weight_sum: { type: number, format: float, nullable: true }
+
+    FundPortfolioHistoryResponse:
+      type: object
+      description: >
+        Per-fund portfolio time series. Long-form rows indexed by teo
+        (month-end). The `start_teo` / `end_teo` summary fields reflect
+        the post-filter window, not the full panel.
+      required: [bw_fund_id, n_periods, start_teo, end_teo, rows]
+      properties:
+        bw_fund_id: { type: string }
+        ticker: { type: string, nullable: true }
+        fund_name: { type: string, nullable: true }
+        equity_style_9box: { type: string, nullable: true }
+        n_periods: { type: integer, example: 85 }
+        start_teo: { type: string, format: date }
+        end_teo: { type: string, format: date }
+        rows:
+          type: array
+          items:
+            $ref: "#/components/schemas/FundPortfolioRow"
+
     FundMetricsResponse:
       type: object
       description: >
@@ -5397,6 +5434,83 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+
+  /funds/{bw_fund_id}/portfolio:
+    get:
+      summary: Per-fund portfolio time series
+      description: >
+        Time series of portfolio-level return components and diagnostics
+        from Slice 8's per-fund `ds_portfolio.zarr` on GCS. One row per
+        teo (month-end). Optional inclusive `start_date` / `end_date`
+        params trim the panel.
+
+
+        Bitemporal: `X-Data-As-Of` reflects the latest teo in the
+        returned slice; `X-Data-Filing-Date` carries the registry's
+        `latest_filing_date`.
+      operationId: getFundPortfolioHistory
+      tags: [Funds]
+      x-pricing:
+        capability_id: fund-portfolio-history
+        tier: baseline
+        cost_usd: 0.005
+        billing_code: fund_portfolio_history_v1
+      parameters:
+        - name: bw_fund_id
+          in: path
+          required: true
+          schema: { type: string }
+          example: BW-FUND-S000004310
+        - name: start_date
+          in: query
+          required: false
+          schema: { type: string, format: date }
+          description: Inclusive lower bound (YYYY-MM-DD). Default = first teo in the fund's panel.
+        - name: end_date
+          in: query
+          required: false
+          schema: { type: string, format: date }
+          description: Inclusive upper bound (YYYY-MM-DD). Default = latest teo in the fund's panel.
+      responses:
+        "200":
+          description: Time series rows.
+          headers:
+            X-Data-As-Of:
+              schema: { type: string, format: date }
+              description: Latest teo in the returned slice.
+            X-Data-Filing-Date:
+              schema: { type: string, format: date }
+              description: funds.latest_filing_date for the fund.
+            X-API-Cost-USD:
+              schema: { type: string }
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FundPortfolioHistoryResponse"
+        "400":
+          description: Malformed date params or start_date > end_date.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "402":
+          description: Insufficient prepaid balance.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InsufficientBalance"
+        "404":
+          description: Fund not found, or zarr returned no rows for the date window.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "429":
+          description: Rate limit exceeded.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RateLimitExceeded"
 
   /funds/{bw_fund_id}:
     get:

--- a/app/api/funds/[bw_fund_id]/hedge/route.ts
+++ b/app/api/funds/[bw_fund_id]/hedge/route.ts
@@ -1,0 +1,61 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { withBilling, type BillingContext } from "@/lib/agent/billing-middleware";
+import { fetchFund } from "@/lib/dal/funds-engine";
+import { readFundHedgeLatest } from "@/lib/dal/funds-zarr-reader";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/funds/{bw_fund_id}/hedge
+ *
+ * Latest L1/L2/L3 hedge ratios for a fund. Reads `L{1,2,3}_HR (teo, symbol)`
+ * from Slice 7's per-fund `ds_hr.zarr` at the latest teo, drops NaN entries,
+ * returns per-level ETF lists. Most ETFs only have a non-NaN HR at the level
+ * where they were the matched factor ETF — empty levels are still emitted as
+ * empty arrays for consistent shape.
+ */
+export const GET = withBilling(
+  async (request: NextRequest, _context: BillingContext) => {
+    const segments = request.nextUrl.pathname.split("/");
+    const bwFundId = segments[segments.length - 2];
+    if (!bwFundId) {
+      return NextResponse.json(
+        { error: "bw_fund_id is required" },
+        { status: 400 },
+      );
+    }
+
+    const fund = await fetchFund(bwFundId);
+    if (!fund) {
+      return NextResponse.json({ error: "Fund not found" }, { status: 404 });
+    }
+
+    const snapshot = await readFundHedgeLatest(bwFundId);
+    if (!snapshot) {
+      return NextResponse.json(
+        {
+          error: "No hedge ratio panel available for this fund",
+          bw_fund_id: bwFundId,
+        },
+        { status: 404 },
+      );
+    }
+
+    const headers = new Headers({ "X-Data-As-Of": snapshot.teo });
+    if (fund.latest_filing_date) {
+      headers.set("X-Data-Filing-Date", fund.latest_filing_date);
+    }
+
+    return NextResponse.json(
+      {
+        bw_fund_id: bwFundId,
+        ticker: fund.ticker,
+        fund_name: fund.fund_name,
+        equity_style_9box: fund.equity_style_9box,
+        ...snapshot,
+      },
+      { headers },
+    );
+  },
+  { capabilityId: "fund-hedge" },
+);

--- a/app/api/funds/[bw_fund_id]/holdings/route.ts
+++ b/app/api/funds/[bw_fund_id]/holdings/route.ts
@@ -1,0 +1,79 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { withBilling, type BillingContext } from "@/lib/agent/billing-middleware";
+import { fetchFund } from "@/lib/dal/funds-engine";
+import { readFundHoldingsTopN } from "@/lib/dal/funds-zarr-reader";
+
+export const dynamic = "force-dynamic";
+
+const DEFAULT_TOP_N = 25;
+const MAX_TOP_N = 1000;
+
+/**
+ * GET /api/funds/{bw_fund_id}/holdings?limit=25
+ *
+ * Top-N current holdings at the fund's latest teo. Reads `ds_ph.zarr`
+ * (Slice 5) on GCS — `adj_mv (symbol, teo)` and `aum_erm3 (teo,)`. Each
+ * holding includes `bw_sym_id`, `adj_mv`, and `weight = adj_mv / aum_erm3`
+ * (null when AUM is null/0).
+ *
+ * Default `limit = 25` (a page-friendly default per Stage B scope);
+ * caller can request up to 1000.
+ */
+export const GET = withBilling(
+  async (request: NextRequest, _context: BillingContext) => {
+    const segments = request.nextUrl.pathname.split("/");
+    const bwFundId = segments[segments.length - 2];
+    if (!bwFundId) {
+      return NextResponse.json(
+        { error: "bw_fund_id is required" },
+        { status: 400 },
+      );
+    }
+
+    const limitParam = request.nextUrl.searchParams.get("limit");
+    let limit = DEFAULT_TOP_N;
+    if (limitParam !== null) {
+      const parsed = Number(limitParam);
+      if (!Number.isFinite(parsed) || parsed < 1) {
+        return NextResponse.json(
+          { error: "limit must be a positive integer" },
+          { status: 400 },
+        );
+      }
+      limit = Math.min(Math.floor(parsed), MAX_TOP_N);
+    }
+
+    const fund = await fetchFund(bwFundId);
+    if (!fund) {
+      return NextResponse.json({ error: "Fund not found" }, { status: 404 });
+    }
+
+    const snapshot = await readFundHoldingsTopN(bwFundId, limit);
+    if (!snapshot) {
+      return NextResponse.json(
+        {
+          error: "No holdings panel available for this fund",
+          bw_fund_id: bwFundId,
+        },
+        { status: 404 },
+      );
+    }
+
+    const headers = new Headers({ "X-Data-As-Of": snapshot.teo });
+    if (fund.latest_filing_date) {
+      headers.set("X-Data-Filing-Date", fund.latest_filing_date);
+    }
+
+    return NextResponse.json(
+      {
+        bw_fund_id: bwFundId,
+        ticker: fund.ticker,
+        fund_name: fund.fund_name,
+        equity_style_9box: fund.equity_style_9box,
+        ...snapshot,
+      },
+      { headers },
+    );
+  },
+  { capabilityId: "fund-holdings" },
+);

--- a/app/api/funds/[bw_fund_id]/portfolio/route.ts
+++ b/app/api/funds/[bw_fund_id]/portfolio/route.ts
@@ -1,0 +1,92 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { withBilling, type BillingContext } from "@/lib/agent/billing-middleware";
+import { fetchFund } from "@/lib/dal/funds-engine";
+import { readFundPortfolioSeries } from "@/lib/dal/funds-zarr-reader";
+
+export const dynamic = "force-dynamic";
+
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * GET /api/funds/{bw_fund_id}/portfolio?start_date=YYYY-MM-DD&end_date=YYYY-MM-DD
+ *
+ * Per-fund portfolio time series from Slice 8's `ds_portfolio.zarr` on GCS.
+ * Returns one row per teo (month-end) with the five return components,
+ * `identity_residual`, and the four diagnostics. Date params are inclusive
+ * and optional (default = the full panel for this fund).
+ *
+ * The registry row from `public.funds` is the existence check — we 404 fast
+ * when the fund isn't tracked, before paying the GCS open cost.
+ */
+export const GET = withBilling(
+  async (request: NextRequest, _context: BillingContext) => {
+    const segments = request.nextUrl.pathname.split("/");
+    const bwFundId = segments[segments.length - 2];
+    if (!bwFundId) {
+      return NextResponse.json(
+        { error: "bw_fund_id is required" },
+        { status: 400 },
+      );
+    }
+
+    const { searchParams } = request.nextUrl;
+    const startDate = searchParams.get("start_date") ?? undefined;
+    const endDate = searchParams.get("end_date") ?? undefined;
+    if (startDate && !ISO_DATE.test(startDate)) {
+      return NextResponse.json(
+        { error: "start_date must be YYYY-MM-DD" },
+        { status: 400 },
+      );
+    }
+    if (endDate && !ISO_DATE.test(endDate)) {
+      return NextResponse.json(
+        { error: "end_date must be YYYY-MM-DD" },
+        { status: 400 },
+      );
+    }
+    if (startDate && endDate && startDate > endDate) {
+      return NextResponse.json(
+        { error: "start_date must be <= end_date" },
+        { status: 400 },
+      );
+    }
+
+    const fund = await fetchFund(bwFundId);
+    if (!fund) {
+      return NextResponse.json({ error: "Fund not found" }, { status: 404 });
+    }
+
+    const rows = await readFundPortfolioSeries(bwFundId, { startDate, endDate });
+    if (rows.length === 0) {
+      return NextResponse.json(
+        {
+          error: "No portfolio history available for this fund",
+          bw_fund_id: bwFundId,
+        },
+        { status: 404 },
+      );
+    }
+
+    const headers = new Headers({
+      "X-Data-As-Of": rows[rows.length - 1]!.teo,
+    });
+    if (fund.latest_filing_date) {
+      headers.set("X-Data-Filing-Date", fund.latest_filing_date);
+    }
+
+    return NextResponse.json(
+      {
+        bw_fund_id: bwFundId,
+        ticker: fund.ticker,
+        fund_name: fund.fund_name,
+        equity_style_9box: fund.equity_style_9box,
+        n_periods: rows.length,
+        start_teo: rows[0]!.teo,
+        end_teo: rows[rows.length - 1]!.teo,
+        rows,
+      },
+      { headers },
+    );
+  },
+  { capabilityId: "fund-portfolio-history" },
+);

--- a/app/api/funds/[bw_fund_id]/route.ts
+++ b/app/api/funds/[bw_fund_id]/route.ts
@@ -1,0 +1,57 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { withBilling, type BillingContext } from "@/lib/agent/billing-middleware";
+import { resolveFundById } from "@/lib/dal/funds-engine";
+import { formatFundMetrics } from "@/lib/funds/format";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/funds/{bw_fund_id}
+ *
+ * Latest knowledge-mode metrics for a single mutual fund. Reads from
+ * `public.funds` and `public.funds_latest`. Pure Supabase; the per-fund
+ * time series, holdings panel, and hedge ratios live in GCS Zarr and
+ * surface via /portfolio, /holdings, /hedge in Stage B.2.
+ *
+ * Bitemporal lineage on response headers: X-Data-As-Of (= report_date),
+ * X-Data-Filing-Date (= filing_date), X-Risk-Model-Version. v1 returns the
+ * latest knowledge-mode row only; ?as_of= is deferred to v2.
+ */
+export const GET = withBilling(
+  async (request: NextRequest, _context: BillingContext) => {
+    const bwFundId = request.nextUrl.pathname.split("/").pop();
+    if (!bwFundId) {
+      return NextResponse.json(
+        { error: "bw_fund_id is required" },
+        { status: 400 },
+      );
+    }
+
+    const result = await resolveFundById(bwFundId);
+    if (!result) {
+      return NextResponse.json({ error: "Fund not found" }, { status: 404 });
+    }
+
+    if (!result.latest) {
+      return NextResponse.json(
+        {
+          error: "No funds_latest row for this fund",
+          bw_fund_id: result.fund.bw_fund_id,
+        },
+        { status: 404 },
+      );
+    }
+
+    const body = formatFundMetrics(result.fund, result.latest);
+    const headers = new Headers({
+      "X-Data-As-Of": result.latest.report_date,
+      "X-Data-Filing-Date": result.latest.filing_date,
+    });
+    if (result.latest.model_version) {
+      headers.set("X-Risk-Model-Version", result.latest.model_version);
+    }
+
+    return NextResponse.json(body, { headers });
+  },
+  { capabilityId: "fund-metrics" },
+);

--- a/lib/agent/capabilities.ts
+++ b/lib/agent/capabilities.ts
@@ -1126,6 +1126,44 @@ export const CAPABILITIES: Capability[] = [
     },
     tags: ["funds", "holdings", "knowledge-mode"],
   },
+  {
+    id: "fund-hedge",
+    name: "Fund Hedge Ratios",
+    description:
+      "Latest L1/L2/L3 ETF hedge ratios for a mutual fund. Reads L{1,2,3}_HR (teo, symbol) " +
+      "from Slice 7's per-fund ds_hr.zarr at the latest teo and returns per-level lists of " +
+      "{etf, hr} dropping NaN entries. Use these to compose hedging baskets at each ERM3 " +
+      "factor level.",
+    endpoint: "/api/funds/{bw_fund_id}/hedge",
+    method: "GET",
+    parameters: {
+      bw_fund_id: {
+        type: "string",
+        required: true,
+        description:
+          "Funds_DAG canonical fund id (format: BW-FUND-{series_id})",
+      },
+    },
+    pricing: {
+      model: "per_request",
+      tier: "baseline",
+      cost_usd: 0.005,
+      currency: "USD",
+      billing_code: "fund_hedge_v1",
+    },
+    performance: {
+      avg_latency_ms: 200,
+      p95_latency_ms: 500,
+      availability_sla: 99.9,
+      rate_limit_per_minute: 60,
+    },
+    confidence: {
+      data_quality_score: 0.95,
+      update_frequency: "monthly",
+      sources: ["ds_hr.zarr", "funds"],
+    },
+    tags: ["funds", "hedge-ratios", "knowledge-mode"],
+  },
 ];
 
 export async function getCapabilities(): Promise<Capability[]> {

--- a/lib/agent/capabilities.ts
+++ b/lib/agent/capabilities.ts
@@ -991,6 +991,46 @@ export const CAPABILITIES: Capability[] = [
       },
     ],
   },
+  {
+    id: "fund-metrics",
+    name: "Latest Fund Metrics",
+    description:
+      "Latest knowledge-mode portfolio return decomposition + diagnostics for a single mutual fund. " +
+      "Returns the gross / market / sector / subsector / idiosyncratic return components, the " +
+      "identity_residual, ERM3 universe coverage (weight_sum), n_holdings_active, effective_n (HHI-derived " +
+      "diversification), and top10_weight_sum. Resolves bw_fund_id against public.funds + public.funds_latest. " +
+      "Bitemporal lineage surfaces as X-Data-As-Of (report_date) and X-Data-Filing-Date headers; " +
+      "v1 returns the latest knowledge-mode answer only (no ?as_of= / ?mode= — deferred to v2).",
+    endpoint: "/api/funds/{bw_fund_id}",
+    method: "GET",
+    parameters: {
+      bw_fund_id: {
+        type: "string",
+        required: true,
+        description:
+          "Funds_DAG canonical fund id (format: BW-FUND-{series_id}, e.g. BW-FUND-S000004310)",
+      },
+    },
+    pricing: {
+      model: "per_request",
+      tier: "baseline",
+      cost_usd: 0.005,
+      currency: "USD",
+      billing_code: "fund_metrics_v1",
+    },
+    performance: {
+      avg_latency_ms: 80,
+      p95_latency_ms: 150,
+      availability_sla: 99.9,
+      rate_limit_per_minute: 120,
+    },
+    confidence: {
+      data_quality_score: 0.95,
+      update_frequency: "monthly",
+      sources: ["funds", "funds_latest"],
+    },
+    tags: ["funds", "metrics", "knowledge-mode"],
+  },
 ];
 
 export async function getCapabilities(): Promise<Capability[]> {

--- a/lib/agent/capabilities.ts
+++ b/lib/agent/capabilities.ts
@@ -1079,6 +1079,53 @@ export const CAPABILITIES: Capability[] = [
     },
     tags: ["funds", "history", "time-series"],
   },
+  {
+    id: "fund-holdings",
+    name: "Fund Top-N Holdings",
+    description:
+      "Top-N current holdings for a mutual fund at the latest teo. Reads adj_mv (symbol, teo) " +
+      "and aum_erm3 (teo,) from Slice 5's per-fund ds_ph.zarr on GCS, sorts symbols by adj_mv " +
+      "descending, and returns the top N with weight = adj_mv / aum_erm3. Default 25; caller " +
+      "may request up to 1000 via ?limit=. Symbols are bw_sym_id; resolve to ticker via " +
+      "/api/data/symbols/batch if needed.",
+    endpoint: "/api/funds/{bw_fund_id}/holdings",
+    method: "GET",
+    parameters: {
+      bw_fund_id: {
+        type: "string",
+        required: true,
+        description:
+          "Funds_DAG canonical fund id (format: BW-FUND-{series_id})",
+      },
+      limit: {
+        type: "integer",
+        required: false,
+        description: "Max holdings to return (default 25, capped 1000)",
+        default: 25,
+        min: 1,
+        max: 1000,
+      },
+    },
+    pricing: {
+      model: "per_request",
+      tier: "baseline",
+      cost_usd: 0.005,
+      currency: "USD",
+      billing_code: "fund_holdings_v1",
+    },
+    performance: {
+      avg_latency_ms: 200,
+      p95_latency_ms: 500,
+      availability_sla: 99.9,
+      rate_limit_per_minute: 60,
+    },
+    confidence: {
+      data_quality_score: 0.95,
+      update_frequency: "monthly",
+      sources: ["ds_ph.zarr", "funds"],
+    },
+    tags: ["funds", "holdings", "knowledge-mode"],
+  },
 ];
 
 export async function getCapabilities(): Promise<Capability[]> {

--- a/lib/agent/capabilities.ts
+++ b/lib/agent/capabilities.ts
@@ -1031,6 +1031,54 @@ export const CAPABILITIES: Capability[] = [
     },
     tags: ["funds", "metrics", "knowledge-mode"],
   },
+  {
+    id: "fund-portfolio-history",
+    name: "Fund Portfolio History",
+    description:
+      "Per-fund time series of portfolio_*_return components, identity_residual, and diagnostics " +
+      "(weight_sum, n_holdings_active, effective_n, top10_weight_sum) from Slice 8's per-fund " +
+      "ds_portfolio.zarr on GCS. One row per teo (month-end). Optional ?start_date and ?end_date " +
+      "query params (inclusive, YYYY-MM-DD) trim the panel; default returns the full history.",
+    endpoint: "/api/funds/{bw_fund_id}/portfolio",
+    method: "GET",
+    parameters: {
+      bw_fund_id: {
+        type: "string",
+        required: true,
+        description:
+          "Funds_DAG canonical fund id (format: BW-FUND-{series_id})",
+      },
+      start_date: {
+        type: "string",
+        required: false,
+        description: "Inclusive lower bound, YYYY-MM-DD",
+      },
+      end_date: {
+        type: "string",
+        required: false,
+        description: "Inclusive upper bound, YYYY-MM-DD",
+      },
+    },
+    pricing: {
+      model: "per_request",
+      tier: "baseline",
+      cost_usd: 0.005,
+      currency: "USD",
+      billing_code: "fund_portfolio_history_v1",
+    },
+    performance: {
+      avg_latency_ms: 200,
+      p95_latency_ms: 500,
+      availability_sla: 99.9,
+      rate_limit_per_minute: 60,
+    },
+    confidence: {
+      data_quality_score: 0.95,
+      update_frequency: "monthly",
+      sources: ["ds_portfolio.zarr", "funds"],
+    },
+    tags: ["funds", "history", "time-series"],
+  },
 ];
 
 export async function getCapabilities(): Promise<Capability[]> {

--- a/lib/dal/funds-zarr-reader.ts
+++ b/lib/dal/funds-zarr-reader.ts
@@ -31,6 +31,7 @@ import {
   root,
   slice,
   tryWithConsolidated,
+  UnicodeStringArray,
 } from "zarrita";
 import type { AbsolutePath, Readable } from "@zarrita/storage";
 import type { Group } from "zarrita";
@@ -265,4 +266,146 @@ export async function readFundPortfolioSeries(
     rows.push(row as unknown as FundPortfolioRow);
   }
   return rows;
+}
+
+// ---------------------------------------------------------------------------
+// Holdings — ds_ph.zarr (Slice 5)
+//
+// Layout: coords (symbol = bw_sym_id, teo); data_vars adj_mv (symbol, teo),
+// has_new_data (symbol, teo), aum_reported (teo,), aum_erm3 (teo,).
+// We surface top-N at the latest teo only — full panel stays GCS-only.
+// ---------------------------------------------------------------------------
+
+async function readSymbolStrings(
+  grp: Group<Readable>,
+): Promise<string[] | null> {
+  try {
+    const loc = grp.resolve("symbol");
+    const arr = await open.v2(loc, { kind: "array" });
+    const ch = await get(arr, null);
+    const d = ch?.data;
+    if (d instanceof UnicodeStringArray) {
+      const out: string[] = [];
+      for (let i = 0; i < d.length; i++) out.push(String(d.get(i)).trim());
+      return out;
+    }
+    if (Array.isArray(d)) {
+      return d.map((v) => String(v).trim());
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/** Read all symbols at a single teo for a (symbol, teo) float var. */
+async function readFloatAtTeo(
+  grp: Group<Readable>,
+  varName: string,
+  teoIdx: number,
+  nSymbols: number,
+): Promise<(number | null)[] | null> {
+  try {
+    const loc = grp.resolve(varName);
+    const arr = await open.v2(loc, { kind: "array" });
+    const ch = await get(arr, [slice(0, nSymbols), teoIdx]);
+    const d = ch?.data;
+    if (d instanceof Float32Array || d instanceof Float64Array) {
+      return Array.from(d, (x) => (Number.isFinite(x) ? x : null));
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/** Read a single scalar from a 1-D (teo,) variable via a length-1 slice. */
+async function readScalarAtTeo(
+  grp: Group<Readable>,
+  varName: string,
+  teoIdx: number,
+): Promise<number | null> {
+  try {
+    const loc = grp.resolve(varName);
+    const arr = await open.v2(loc, { kind: "array" });
+    const ch = await get(arr, [slice(teoIdx, teoIdx + 1)]);
+    const d = ch?.data;
+    if (d instanceof Float32Array || d instanceof Float64Array) {
+      const v = d[0];
+      return v != null && Number.isFinite(v) ? v : null;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export interface FundHolding {
+  bw_sym_id: string;
+  adj_mv: number;
+  /** Fraction of `aum_erm3` (post-universe-filter denominator). Null when AUM is null/0. */
+  weight: number | null;
+}
+
+export interface FundHoldingsSnapshot {
+  teo: string;
+  aum_reported: number | null;
+  aum_erm3: number | null;
+  n_holdings_returned: number;
+  n_total_holdings: number;
+  holdings: FundHolding[];
+}
+
+/**
+ * Top-N current holdings at the latest teo for a fund. Default n=25.
+ * Returns null when the fund has no zarr or no positive holdings.
+ */
+export async function readFundHoldingsTopN(
+  bwFundId: string,
+  n = 25,
+): Promise<FundHoldingsSnapshot | null> {
+  const grp = await openFundZarrGroup(bwFundId, "ds_ph.zarr");
+  if (!grp) return null;
+
+  const teos = await readTeoStrings(grp);
+  if (!teos || teos.length === 0) return null;
+
+  const symbols = await readSymbolStrings(grp);
+  if (!symbols || symbols.length === 0) return null;
+
+  const teoIdx = teos.length - 1;
+  const teo = teos[teoIdx]!;
+
+  const [adjMv, aumReported, aumErm3] = await Promise.all([
+    readFloatAtTeo(grp, "adj_mv", teoIdx, symbols.length),
+    readScalarAtTeo(grp, "aum_reported", teoIdx),
+    readScalarAtTeo(grp, "aum_erm3", teoIdx),
+  ]);
+  if (!adjMv) return null;
+
+  const holdings: FundHolding[] = [];
+  for (let i = 0; i < adjMv.length; i++) {
+    const v = adjMv[i];
+    if (v != null && v > 0) {
+      holdings.push({
+        bw_sym_id: symbols[i]!,
+        adj_mv: v,
+        weight:
+          aumErm3 != null && aumErm3 > 0 ? v / aumErm3 : null,
+      });
+    }
+  }
+  if (holdings.length === 0) return null;
+
+  holdings.sort((a, b) => b.adj_mv - a.adj_mv);
+  const safeN = Math.min(Math.max(n, 1), 1000);
+
+  return {
+    teo,
+    aum_reported: aumReported,
+    aum_erm3: aumErm3,
+    n_holdings_returned: Math.min(safeN, holdings.length),
+    n_total_holdings: holdings.length,
+    holdings: holdings.slice(0, safeN),
+  };
 }

--- a/lib/dal/funds-zarr-reader.ts
+++ b/lib/dal/funds-zarr-reader.ts
@@ -409,3 +409,93 @@ export async function readFundHoldingsTopN(
     holdings: holdings.slice(0, safeN),
   };
 }
+
+// ---------------------------------------------------------------------------
+// Hedge ratios — ds_hr.zarr (Slice 7)
+//
+// Layout: coords (teo, symbol = ETF symbol); data_vars L1_HR / L2_HR / L3_HR
+// each (teo, symbol). Many entries are NaN (an ETF only has a non-NaN HR
+// at the level where it's the matched factor ETF). At the latest teo we
+// return per-level lists of { etf, hr } dropping NaN entries.
+// ---------------------------------------------------------------------------
+
+/** Read all symbols at one teo from a (teo, symbol) float var. */
+async function readFloatRowAtTeo(
+  grp: Group<Readable>,
+  varName: string,
+  teoIdx: number,
+  nSymbols: number,
+): Promise<(number | null)[] | null> {
+  try {
+    const loc = grp.resolve(varName);
+    const arr = await open.v2(loc, { kind: "array" });
+    const ch = await get(arr, [teoIdx, slice(0, nSymbols)]);
+    const d = ch?.data;
+    if (d instanceof Float32Array || d instanceof Float64Array) {
+      return Array.from(d, (x) => (Number.isFinite(x) ? x : null));
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export interface HedgeLeg {
+  etf: string;
+  hr: number;
+}
+
+export interface FundHedgeSnapshot {
+  teo: string;
+  L1: HedgeLeg[];
+  L2: HedgeLeg[];
+  L3: HedgeLeg[];
+}
+
+/**
+ * Latest L1/L2/L3 hedge ratios for a fund. Returns null when the per-fund
+ * `ds_hr.zarr` is missing or empty.
+ */
+export async function readFundHedgeLatest(
+  bwFundId: string,
+): Promise<FundHedgeSnapshot | null> {
+  const grp = await openFundZarrGroup(bwFundId, "ds_hr.zarr");
+  if (!grp) return null;
+
+  const teos = await readTeoStrings(grp);
+  if (!teos || teos.length === 0) return null;
+
+  const symbols = await readSymbolStrings(grp);
+  if (!symbols || symbols.length === 0) return null;
+
+  const teoIdx = teos.length - 1;
+  const teo = teos[teoIdx]!;
+
+  const [l1, l2, l3] = await Promise.all([
+    readFloatRowAtTeo(grp, "L1_HR", teoIdx, symbols.length),
+    readFloatRowAtTeo(grp, "L2_HR", teoIdx, symbols.length),
+    readFloatRowAtTeo(grp, "L3_HR", teoIdx, symbols.length),
+  ]);
+
+  const symbolNames = symbols;
+  function pack(row: (number | null)[] | null): HedgeLeg[] {
+    if (!row) return [];
+    const legs: HedgeLeg[] = [];
+    for (let i = 0; i < row.length; i++) {
+      const v = row[i];
+      if (v != null) legs.push({ etf: symbolNames[i]!, hr: v });
+    }
+    return legs;
+  }
+
+  const out: FundHedgeSnapshot = {
+    teo,
+    L1: pack(l1),
+    L2: pack(l2),
+    L3: pack(l3),
+  };
+  if (out.L1.length === 0 && out.L2.length === 0 && out.L3.length === 0) {
+    return null;
+  }
+  return out;
+}

--- a/lib/dal/funds-zarr-reader.ts
+++ b/lib/dal/funds-zarr-reader.ts
@@ -1,0 +1,268 @@
+/**
+ * Funds-side Zarr reader on GCS.
+ *
+ * Per-fund stores live at:
+ *   gs://{bucket}/{basePath}/bw_fund_id/{BW-FUND-...}/ds_portfolio.zarr
+ *   gs://{bucket}/{basePath}/bw_fund_id/{BW-FUND-...}/ds_ph.zarr        (B.2.b)
+ *   gs://{bucket}/{basePath}/bw_fund_id/{BW-FUND-...}/ds_hr.zarr        (B.2.c)
+ *
+ * Default GCS prefix is `rm_api_data/ERM3_Funds` (env override:
+ * `ZARR_FUNDS_GCS_PREFIX`). The bucket is shared with the stocks-side
+ * `rm_api_data` per ARCHITECTURE_FUNDS_API.md §3.1.1; only the basePath
+ * differs.
+ *
+ * Stage B.2.a ships `readFundPortfolioSeries` only — Slice 8's per-fund
+ * `ds_portfolio.zarr` (dim `(teo,)`, ten data_vars). Holdings (ds_ph) and
+ * hedge (ds_hr) follow in B.2.b / B.2.c.
+ *
+ * Internal-only: never expose bucket names, gs:// URLs, or zarr paths in
+ * thrown errors or API JSON.
+ *
+ * TODO(dedup): the GCS plumbing here (getGcs, GcsZarrStore, openFundZarrGroup,
+ * readTeoStrings) is structurally identical to lib/dal/zarr-reader.ts.
+ * Extract to lib/dal/zarr-gcs.ts as a follow-up — kept duplicated in B.2.a
+ * so the stocks-side module stays untouched.
+ */
+
+import { Storage, type Bucket } from "@google-cloud/storage";
+import {
+  get,
+  open,
+  root,
+  slice,
+  tryWithConsolidated,
+} from "zarrita";
+import type { AbsolutePath, Readable } from "@zarrita/storage";
+import type { Group } from "zarrita";
+
+let _storage: Storage | null = null;
+
+function getGcs(): Storage {
+  if (!_storage) {
+    const raw = process.env.GCP_SERVICE_ACCOUNT_JSON?.trim();
+    if (raw) {
+      try {
+        const credentials = JSON.parse(raw) as Record<string, unknown>;
+        _storage = new Storage({ credentials });
+      } catch {
+        console.error("[funds-zarr] GCP_SERVICE_ACCOUNT_JSON parse failed");
+        _storage = new Storage();
+      }
+    } else {
+      const keyFile = process.env.RISKMODELS_GCS_KEYFILE?.trim();
+      _storage = keyFile ? new Storage({ keyFilename: keyFile }) : new Storage();
+    }
+  }
+  return _storage;
+}
+
+class GcsZarrStore {
+  constructor(
+    private readonly bucket: Bucket,
+    private readonly objectPrefix: string,
+  ) {}
+
+  async get(key: AbsolutePath): Promise<Uint8Array | undefined> {
+    const rel = key.startsWith("/") ? key.slice(1) : key;
+    const objectName = `${this.objectPrefix}/${rel}`.replace(/\/+/g, "/");
+    try {
+      const [buf] = await this.bucket.file(objectName).download();
+      return new Uint8Array(buf);
+    } catch (e: unknown) {
+      const err = e as { code?: number };
+      if (err?.code === 404) return undefined;
+      console.error("[funds-zarr] storage read failed");
+      throw new Error("Zarr read failed");
+    }
+  }
+}
+
+function parseFundsZarrPrefix(): { bucket: string; basePath: string } {
+  const raw = (process.env.ZARR_FUNDS_GCS_PREFIX ?? "rm_api_data/ERM3_Funds").trim();
+  const i = raw.indexOf("/");
+  if (i <= 0) return { bucket: raw || "rm_api_data", basePath: "" };
+  return { bucket: raw.slice(0, i), basePath: raw.slice(i + 1).replace(/\/$/, "") };
+}
+
+async function openFundZarrGroup(
+  bwFundId: string,
+  basename: string,
+): Promise<Group<Readable> | null> {
+  const { bucket: bucketName, basePath } = parseFundsZarrPrefix();
+  const fullPrefix = `${basePath}/bw_fund_id/${bwFundId}/${basename}`
+    .replace(/\/+/g, "/")
+    .replace(/^\//, "");
+  try {
+    const bucket = getGcs().bucket(bucketName);
+    const raw = new GcsZarrStore(bucket, fullPrefix);
+    const consolidated = await tryWithConsolidated(raw);
+    const store = consolidated as unknown as Readable;
+    return (await open.v2(root(store), { kind: "group" })) as Group<Readable>;
+  } catch {
+    console.error("[funds-zarr] open group failed");
+    return null;
+  }
+}
+
+function nsToIsoDate(ns: bigint): string {
+  const ms = Number(ns / 1_000_000n);
+  const d = new Date(ms);
+  if (!Number.isFinite(d.getTime())) return "";
+  return d.toISOString().slice(0, 10);
+}
+
+async function readTeoStrings(
+  grp: Group<Readable>,
+): Promise<string[] | null> {
+  try {
+    const loc = grp.resolve("teo");
+    const arr = await open.v2(loc, { kind: "array" });
+    const ch = await get(arr, null);
+    const d = ch?.data;
+
+    const attrs = (arr.attrs ?? {}) as Record<string, unknown>;
+    const units = typeof attrs.units === "string" ? attrs.units : "";
+    const cfMatch = units.match(
+      /^days since (\d{4}-\d{2}-\d{2})(?:[T ]\d{2}:\d{2}:\d{2})?/,
+    );
+
+    if (d instanceof BigInt64Array && cfMatch) {
+      const baseMs = Date.parse(`${cfMatch[1]}T00:00:00Z`);
+      if (!Number.isFinite(baseMs)) return null;
+      const MS_PER_DAY = 86_400_000;
+      return Array.from(d, (v) => {
+        const t = baseMs + Number(v) * MS_PER_DAY;
+        const dt = new Date(t);
+        return Number.isFinite(dt.getTime())
+          ? dt.toISOString().slice(0, 10)
+          : "";
+      });
+    }
+    if (d instanceof BigInt64Array) {
+      return Array.from(d, (v) => nsToIsoDate(v));
+    }
+    if (ArrayBuffer.isView(d) && !(d instanceof Uint8Array)) {
+      const nums = d as unknown as ArrayLike<number>;
+      return Array.from(nums, (v) => {
+        const ms = Number(v) / 1_000_000;
+        const dt = new Date(ms);
+        return Number.isFinite(dt.getTime())
+          ? dt.toISOString().slice(0, 10)
+          : "";
+      });
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+async function readFloatSlice1d(
+  grp: Group<Readable>,
+  varName: string,
+  t0: number,
+  t1: number,
+): Promise<(number | null)[] | null> {
+  try {
+    const loc = grp.resolve(varName);
+    const arr = await open.v2(loc, { kind: "array" });
+    const ch = await get(arr, [slice(t0, t1)]);
+    const d = ch?.data;
+    if (d instanceof Float32Array || d instanceof Float64Array) {
+      return Array.from(d, (x) => (Number.isFinite(x) ? x : null));
+    }
+    if (d instanceof Int32Array || d instanceof Int16Array) {
+      return Array.from(d, (x) => x);
+    }
+    if (d instanceof BigInt64Array) {
+      return Array.from(d, (v) => Number(v));
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public reads
+// ---------------------------------------------------------------------------
+
+/** One row of the per-fund portfolio time series — keys mirror the zarr data_vars. */
+export interface FundPortfolioRow {
+  teo: string;
+  portfolio_gross_return: number | null;
+  portfolio_market_return: number | null;
+  portfolio_sector_return: number | null;
+  portfolio_subsector_return: number | null;
+  portfolio_idiosyncratic_return: number | null;
+  identity_residual: number | null;
+  weight_sum: number | null;
+  n_holdings_active: number | null;
+  effective_n: number | null;
+  top10_weight_sum: number | null;
+}
+
+export interface FundPortfolioOptions {
+  /** Inclusive lower bound, YYYY-MM-DD. Trims teos before this date. */
+  startDate?: string;
+  /** Inclusive upper bound, YYYY-MM-DD. Trims teos after this date. */
+  endDate?: string;
+}
+
+const PORTFOLIO_VARS = [
+  "portfolio_gross_return",
+  "portfolio_market_return",
+  "portfolio_sector_return",
+  "portfolio_subsector_return",
+  "portfolio_idiosyncratic_return",
+  "identity_residual",
+  "weight_sum",
+  "n_holdings_active",
+  "effective_n",
+  "top10_weight_sum",
+] as const;
+
+/**
+ * Read the per-fund portfolio time series from GCS.
+ * Returns [] when the fund has no zarr or no overlap with the date window.
+ */
+export async function readFundPortfolioSeries(
+  bwFundId: string,
+  options: FundPortfolioOptions = {},
+): Promise<FundPortfolioRow[]> {
+  const grp = await openFundZarrGroup(bwFundId, "ds_portfolio.zarr");
+  if (!grp) return [];
+
+  const teos = await readTeoStrings(grp);
+  if (!teos || teos.length === 0) return [];
+
+  // Apply inclusive date range. Teos are sorted month-ends (YYYY-MM-DD).
+  let t0 = 0;
+  let t1 = teos.length;
+  if (options.startDate) {
+    while (t0 < t1 && teos[t0]! < options.startDate) t0++;
+  }
+  if (options.endDate) {
+    while (t1 > t0 && teos[t1 - 1]! > options.endDate) t1--;
+  }
+  if (t0 >= t1) return [];
+
+  // Read each var's [t0, t1) slice in parallel. Per-fund ds_portfolio.zarr is
+  // tiny (one chunk per var, T ≤ ~250), so this is one chunk fetch per var.
+  const series = await Promise.all(
+    PORTFOLIO_VARS.map(async (varName) => ({
+      name: varName,
+      data: await readFloatSlice1d(grp, varName, t0, t1),
+    })),
+  );
+
+  const rows: FundPortfolioRow[] = [];
+  for (let i = 0; i < t1 - t0; i++) {
+    const row: Record<string, unknown> = { teo: teos[t0 + i]! };
+    for (const s of series) {
+      row[s.name] = s.data?.[i] ?? null;
+    }
+    rows.push(row as unknown as FundPortfolioRow);
+  }
+  return rows;
+}

--- a/lib/funds/format.ts
+++ b/lib/funds/format.ts
@@ -1,0 +1,91 @@
+/**
+ * Response shaping for the public funds metrics surface.
+ *
+ * Pure function: takes a registry row + funds_latest row + risk metadata,
+ * returns the API response body. Mirrors the stocks-side shape under
+ * `/metrics/{ticker}` — nested return / diagnostics / meta groups, plus a
+ * `_metadata` block carrying lineage.
+ *
+ * Knowledge-mode only in v1; no `?as_of=` / `?mode=` (deferred to v2).
+ */
+
+import type { FundLatestRow, FundRow } from "@/lib/dal/funds-engine";
+
+export interface FundMetricsResponse {
+  bw_fund_id: string;
+  ticker: string | null;
+  fund_name: string | null;
+  equity_style_9box: string | null;
+  report_date: string;
+  filing_date: string;
+  extracted_at: string;
+  returns: {
+    gross: number | null;
+    market: number | null;
+    sector: number | null;
+    subsector: number | null;
+    idiosyncratic: number | null;
+    identity_residual: number | null;
+  };
+  diagnostics: {
+    weight_sum: number | null;
+    n_holdings_active: number | null;
+    effective_n: number | null;
+    top10_weight_sum: number | null;
+  };
+  meta: {
+    total_adj_mv: number | null;
+    n_funds_in_cell_at_report_date: number | null;
+    morningstar_category: string | null;
+    primary_bw_fund_id: string | null;
+  };
+  _metadata: {
+    model_version: string | null;
+    factor_set_id: string | null;
+    data_as_of: string;
+    data_freshness: string;
+    last_synced_at: string;
+  };
+}
+
+export function formatFundMetrics(
+  fund: FundRow,
+  latest: FundLatestRow,
+): FundMetricsResponse {
+  return {
+    bw_fund_id: fund.bw_fund_id,
+    ticker: fund.ticker,
+    fund_name: fund.fund_name,
+    equity_style_9box: fund.equity_style_9box ?? latest.equity_style_9box,
+    report_date: latest.report_date,
+    filing_date: latest.filing_date,
+    extracted_at: latest.extracted_at,
+    returns: {
+      gross: latest.portfolio_gross_return,
+      market: latest.portfolio_market_return,
+      sector: latest.portfolio_sector_return,
+      subsector: latest.portfolio_subsector_return,
+      idiosyncratic: latest.portfolio_idiosyncratic_return,
+      identity_residual: latest.identity_residual,
+    },
+    diagnostics: {
+      weight_sum: latest.weight_sum,
+      n_holdings_active: latest.n_holdings_active,
+      effective_n: latest.effective_n,
+      top10_weight_sum: latest.top10_weight_sum,
+    },
+    meta: {
+      total_adj_mv: latest.total_adj_mv,
+      n_funds_in_cell_at_report_date: latest.n_funds_in_cell_at_report_date,
+      morningstar_category: fund.morningstar_category,
+      primary_bw_fund_id: fund.primary_bw_fund_id,
+    },
+    _metadata: {
+      model_version: latest.model_version,
+      factor_set_id: latest.factor_set_id,
+      data_as_of: latest.report_date,
+      data_freshness: latest.last_synced_at,
+      last_synced_at: latest.last_synced_at,
+    },
+  };
+}

--- a/mcp/data/openapi.json
+++ b/mcp/data/openapi.json
@@ -2213,6 +2213,115 @@
           }
         }
       },
+      "FundPortfolioRow": {
+        "type": "object",
+        "description": "One teo (month-end) of a fund's portfolio time series.",
+        "required": [
+          "teo"
+        ],
+        "properties": {
+          "teo": {
+            "type": "string",
+            "format": "date",
+            "example": "2026-04-30"
+          },
+          "portfolio_gross_return": {
+            "type": "number",
+            "format": "float",
+            "nullable": true
+          },
+          "portfolio_market_return": {
+            "type": "number",
+            "format": "float",
+            "nullable": true
+          },
+          "portfolio_sector_return": {
+            "type": "number",
+            "format": "float",
+            "nullable": true
+          },
+          "portfolio_subsector_return": {
+            "type": "number",
+            "format": "float",
+            "nullable": true
+          },
+          "portfolio_idiosyncratic_return": {
+            "type": "number",
+            "format": "float",
+            "nullable": true
+          },
+          "identity_residual": {
+            "type": "number",
+            "format": "float",
+            "nullable": true
+          },
+          "weight_sum": {
+            "type": "number",
+            "format": "float",
+            "nullable": true
+          },
+          "n_holdings_active": {
+            "type": "integer",
+            "nullable": true
+          },
+          "effective_n": {
+            "type": "number",
+            "format": "float",
+            "nullable": true
+          },
+          "top10_weight_sum": {
+            "type": "number",
+            "format": "float",
+            "nullable": true
+          }
+        }
+      },
+      "FundPortfolioHistoryResponse": {
+        "type": "object",
+        "description": "Per-fund portfolio time series. Long-form rows indexed by teo (month-end). The `start_teo` / `end_teo` summary fields reflect the post-filter window, not the full panel.\n",
+        "required": [
+          "bw_fund_id",
+          "n_periods",
+          "start_teo",
+          "end_teo",
+          "rows"
+        ],
+        "properties": {
+          "bw_fund_id": {
+            "type": "string"
+          },
+          "ticker": {
+            "type": "string",
+            "nullable": true
+          },
+          "fund_name": {
+            "type": "string",
+            "nullable": true
+          },
+          "equity_style_9box": {
+            "type": "string",
+            "nullable": true
+          },
+          "n_periods": {
+            "type": "integer",
+            "example": 85
+          },
+          "start_teo": {
+            "type": "string",
+            "format": "date"
+          },
+          "end_teo": {
+            "type": "string",
+            "format": "date"
+          },
+          "rows": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FundPortfolioRow"
+            }
+          }
+        }
+      },
       "FundMetricsResponse": {
         "type": "object",
         "description": "Latest knowledge-mode metrics for a single mutual fund. Joins `public.funds` (registry) with `public.funds_latest` (the wide-row snapshot) and groups return components / diagnostics / meta into nested objects. Bitemporal triple is at the top level; lineage in `_metadata`.\n",
@@ -7706,6 +7815,126 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/funds/{bw_fund_id}/portfolio": {
+      "get": {
+        "summary": "Per-fund portfolio time series",
+        "description": "Time series of portfolio-level return components and diagnostics from Slice 8's per-fund `ds_portfolio.zarr` on GCS. One row per teo (month-end). Optional inclusive `start_date` / `end_date` params trim the panel.\n\nBitemporal: `X-Data-As-Of` reflects the latest teo in the returned slice; `X-Data-Filing-Date` carries the registry's `latest_filing_date`.\n",
+        "operationId": "getFundPortfolioHistory",
+        "tags": [
+          "Funds"
+        ],
+        "x-pricing": {
+          "capability_id": "fund-portfolio-history",
+          "tier": "baseline",
+          "cost_usd": 0.005,
+          "billing_code": "fund_portfolio_history_v1"
+        },
+        "parameters": [
+          {
+            "name": "bw_fund_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "BW-FUND-S000004310"
+          },
+          {
+            "name": "start_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date"
+            },
+            "description": "Inclusive lower bound (YYYY-MM-DD). Default = first teo in the fund's panel."
+          },
+          {
+            "name": "end_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date"
+            },
+            "description": "Inclusive upper bound (YYYY-MM-DD). Default = latest teo in the fund's panel."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Time series rows.",
+            "headers": {
+              "X-Data-As-Of": {
+                "schema": {
+                  "type": "string",
+                  "format": "date"
+                },
+                "description": "Latest teo in the returned slice."
+              },
+              "X-Data-Filing-Date": {
+                "schema": {
+                  "type": "string",
+                  "format": "date"
+                },
+                "description": "funds.latest_filing_date for the fund."
+              },
+              "X-API-Cost-USD": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FundPortfolioHistoryResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Malformed date params or start_date > end_date.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Insufficient prepaid balance.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InsufficientBalance"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Fund not found, or zarr returned no rows for the date window.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RateLimitExceeded"
                 }
               }
             }

--- a/mcp/data/openapi.json
+++ b/mcp/data/openapi.json
@@ -2212,6 +2212,176 @@
             "type": "integer"
           }
         }
+      },
+      "FundMetricsResponse": {
+        "type": "object",
+        "description": "Latest knowledge-mode metrics for a single mutual fund. Joins `public.funds` (registry) with `public.funds_latest` (the wide-row snapshot) and groups return components / diagnostics / meta into nested objects. Bitemporal triple is at the top level; lineage in `_metadata`.\n",
+        "required": [
+          "bw_fund_id",
+          "report_date",
+          "filing_date",
+          "extracted_at",
+          "returns",
+          "diagnostics",
+          "meta",
+          "_metadata"
+        ],
+        "properties": {
+          "bw_fund_id": {
+            "type": "string",
+            "example": "BW-FUND-S000004310"
+          },
+          "ticker": {
+            "type": "string",
+            "nullable": true,
+            "example": "VFINX"
+          },
+          "fund_name": {
+            "type": "string",
+            "nullable": true
+          },
+          "equity_style_9box": {
+            "type": "string",
+            "nullable": true,
+            "enum": [
+              "Large Value",
+              "Large Blend",
+              "Large Growth",
+              "Mid Value",
+              "Mid Blend",
+              "Mid Growth",
+              "Small Value",
+              "Small Blend",
+              "Small Growth"
+            ]
+          },
+          "report_date": {
+            "type": "string",
+            "format": "date",
+            "example": "2026-04-30"
+          },
+          "filing_date": {
+            "type": "string",
+            "format": "date",
+            "example": "2026-07-14"
+          },
+          "extracted_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "returns": {
+            "type": "object",
+            "description": "Portfolio-level return components from the per-fund Slice 8 zarr.",
+            "properties": {
+              "gross": {
+                "type": "number",
+                "format": "float",
+                "nullable": true
+              },
+              "market": {
+                "type": "number",
+                "format": "float",
+                "nullable": true
+              },
+              "sector": {
+                "type": "number",
+                "format": "float",
+                "nullable": true
+              },
+              "subsector": {
+                "type": "number",
+                "format": "float",
+                "nullable": true
+              },
+              "idiosyncratic": {
+                "type": "number",
+                "format": "float",
+                "nullable": true
+              },
+              "identity_residual": {
+                "type": "number",
+                "format": "float",
+                "nullable": true,
+                "description": "L3 noise diagnostic (gross − sum of layer returns)."
+              }
+            }
+          },
+          "diagnostics": {
+            "type": "object",
+            "properties": {
+              "weight_sum": {
+                "type": "number",
+                "format": "float",
+                "nullable": true,
+                "description": "ERM3 universe coverage (fraction of fund AUM in mapped symbols)."
+              },
+              "n_holdings_active": {
+                "type": "integer",
+                "nullable": true
+              },
+              "effective_n": {
+                "type": "number",
+                "format": "float",
+                "nullable": true,
+                "description": "HHI-derived diversification (1 / sum(w_i^2))."
+              },
+              "top10_weight_sum": {
+                "type": "number",
+                "format": "float",
+                "nullable": true
+              }
+            }
+          },
+          "meta": {
+            "type": "object",
+            "properties": {
+              "total_adj_mv": {
+                "type": "number",
+                "format": "float",
+                "nullable": true
+              },
+              "n_funds_in_cell_at_report_date": {
+                "type": "integer",
+                "nullable": true
+              },
+              "morningstar_category": {
+                "type": "string",
+                "nullable": true
+              },
+              "primary_bw_fund_id": {
+                "type": "string",
+                "nullable": true
+              }
+            }
+          },
+          "_metadata": {
+            "type": "object",
+            "properties": {
+              "model_version": {
+                "type": "string",
+                "nullable": true,
+                "example": "funds_dag.v20260502"
+              },
+              "factor_set_id": {
+                "type": "string",
+                "nullable": true,
+                "example": "uni_mc_3000_SPY"
+              },
+              "data_as_of": {
+                "type": "string",
+                "format": "date"
+              },
+              "data_freshness": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "last_synced_at": {
+                "type": "string",
+                "format": "date-time"
+              }
+            }
+          }
+        }
       }
     }
   },
@@ -7542,6 +7712,102 @@
           }
         }
       }
+    },
+    "/funds/{bw_fund_id}": {
+      "get": {
+        "summary": "Latest fund metrics",
+        "description": "Knowledge-mode portfolio return decomposition + diagnostics for a single mutual fund. Returns the gross / market / sector / subsector / idiosyncratic return components from the per-fund Slice 8 zarr (materialized in `public.funds_latest`), plus diagnostics (`weight_sum`, `n_holdings_active`, `effective_n`, `top10_weight_sum`) and registry-side meta. Bitemporal lineage on response headers (`X-Data-As-Of`, `X-Data-Filing-Date`).\n\nPer-fund time series, holdings panel, and hedge ratios live in GCS Zarr and ship under `/funds/{bw_fund_id}/portfolio`, `/holdings`, `/hedge` in Stage B.2.\n\nv1 returns the latest knowledge-mode answer only — `?as_of=` / `?mode=` is deferred to v2 (schema is forward-compatible).\n",
+        "operationId": "getFundMetrics",
+        "tags": [
+          "Funds"
+        ],
+        "x-pricing": {
+          "capability_id": "fund-metrics",
+          "tier": "baseline",
+          "cost_usd": 0.005,
+          "billing_code": "fund_metrics_v1"
+        },
+        "parameters": [
+          {
+            "name": "bw_fund_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "BW-FUND-S000004310"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Latest fund metrics.",
+            "headers": {
+              "X-Data-As-Of": {
+                "schema": {
+                  "type": "string",
+                  "format": "date"
+                },
+                "description": "funds_latest.report_date (period end of the snapshot)."
+              },
+              "X-Data-Filing-Date": {
+                "schema": {
+                  "type": "string",
+                  "format": "date"
+                },
+                "description": "funds_latest.filing_date (SEC acceptance date)."
+              },
+              "X-Risk-Model-Version": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-API-Cost-USD": {
+                "schema": {
+                  "type": "string"
+                },
+                "description": "USD cost deducted from prepaid balance for this request."
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FundMetricsResponse"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Insufficient prepaid balance.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InsufficientBalance"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Fund not found, or registry exists but no funds_latest row yet.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RateLimitExceeded"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "tags": [
@@ -7588,6 +7854,10 @@
     {
       "name": "Funds Data Plane",
       "description": "Raw-shape reads against the funds Supabase tables (`funds`, `funds_latest`). Latest knowledge-mode snapshot only — history reads via the per-fund Zarr endpoints in later stages. Public; soft Bearer auth; not metered. The compute-bearing `/funds/*`, `/funds/style/*`, and `/funds/snapshot/*` surfaces ship in subsequent stages.\n"
+    },
+    {
+      "name": "Funds",
+      "description": "Compute-bearing fund endpoints. Latest metrics (Stage B.1) join `public.funds` with `public.funds_latest` and return a shaped response with bitemporal lineage. Per-fund time series, holdings, and hedge ratios (Stage B.2) read from GCS Zarr. Style-cohort surfaces (Stage C) and snapshot tearsheets (Stage D) follow. Billable per request.\n"
     }
   ]
 }

--- a/mcp/data/openapi.json
+++ b/mcp/data/openapi.json
@@ -2213,6 +2213,88 @@
           }
         }
       },
+      "FundHolding": {
+        "type": "object",
+        "description": "One holding (security) within a fund's top-N snapshot.",
+        "required": [
+          "bw_sym_id",
+          "adj_mv"
+        ],
+        "properties": {
+          "bw_sym_id": {
+            "type": "string",
+            "description": "Internal symbol id. Resolve to ticker via /api/data/symbols/batch.",
+            "example": "BW-BBG000B9XRY4"
+          },
+          "adj_mv": {
+            "type": "number",
+            "format": "float",
+            "description": "Adjusted market value of this position at the snapshot teo."
+          },
+          "weight": {
+            "type": "number",
+            "format": "float",
+            "nullable": true,
+            "description": "Fraction of `aum_erm3`. Null when aum_erm3 is null/0."
+          }
+        }
+      },
+      "FundHoldingsResponse": {
+        "type": "object",
+        "description": "Top-N current holdings for a fund at the latest teo. Sourced from per-fund `ds_ph.zarr` (Slice 5). `aum_reported` is sum(adj_mv) BEFORE universe filter; `aum_erm3` is sum AFTER (ERM3-mapped symbols only — the denominator for `weight`).\n",
+        "required": [
+          "bw_fund_id",
+          "teo",
+          "n_holdings_returned",
+          "n_total_holdings",
+          "holdings"
+        ],
+        "properties": {
+          "bw_fund_id": {
+            "type": "string"
+          },
+          "ticker": {
+            "type": "string",
+            "nullable": true
+          },
+          "fund_name": {
+            "type": "string",
+            "nullable": true
+          },
+          "equity_style_9box": {
+            "type": "string",
+            "nullable": true
+          },
+          "teo": {
+            "type": "string",
+            "format": "date"
+          },
+          "aum_reported": {
+            "type": "number",
+            "format": "float",
+            "nullable": true
+          },
+          "aum_erm3": {
+            "type": "number",
+            "format": "float",
+            "nullable": true
+          },
+          "n_holdings_returned": {
+            "type": "integer",
+            "example": 25
+          },
+          "n_total_holdings": {
+            "type": "integer",
+            "example": 503
+          },
+          "holdings": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FundHolding"
+            }
+          }
+        }
+      },
       "FundPortfolioRow": {
         "type": "object",
         "description": "One teo (month-end) of a fund's portfolio time series.",
@@ -7815,6 +7897,117 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/funds/{bw_fund_id}/holdings": {
+      "get": {
+        "summary": "Top-N current fund holdings",
+        "description": "Top-N holdings for a fund at the latest teo. Reads `adj_mv (symbol, teo)` and `aum_erm3 (teo,)` from Slice 5's per-fund `ds_ph.zarr` on GCS, sorts by `adj_mv` descending, and returns `bw_sym_id` + `adj_mv` + `weight = adj_mv / aum_erm3`. Resolve `bw_sym_id` to ticker via `/api/data/symbols/batch` if needed.\n",
+        "operationId": "getFundHoldings",
+        "tags": [
+          "Funds"
+        ],
+        "x-pricing": {
+          "capability_id": "fund-holdings",
+          "tier": "baseline",
+          "cost_usd": 0.005,
+          "billing_code": "fund_holdings_v1"
+        },
+        "parameters": [
+          {
+            "name": "bw_fund_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "BW-FUND-S000004310"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 1000,
+              "default": 25
+            },
+            "description": "Max holdings to return (default 25)."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Top-N holdings snapshot.",
+            "headers": {
+              "X-Data-As-Of": {
+                "schema": {
+                  "type": "string",
+                  "format": "date"
+                },
+                "description": "Latest teo in the per-fund holdings panel."
+              },
+              "X-Data-Filing-Date": {
+                "schema": {
+                  "type": "string",
+                  "format": "date"
+                }
+              },
+              "X-API-Cost-USD": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FundHoldingsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Malformed limit param.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Insufficient prepaid balance.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InsufficientBalance"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Fund not found, or no holdings panel.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RateLimitExceeded"
                 }
               }
             }

--- a/mcp/data/openapi.json
+++ b/mcp/data/openapi.json
@@ -2213,6 +2213,75 @@
           }
         }
       },
+      "FundHedgeLeg": {
+        "type": "object",
+        "description": "One ETF hedge leg at a given factor level.",
+        "required": [
+          "etf",
+          "hr"
+        ],
+        "properties": {
+          "etf": {
+            "type": "string",
+            "description": "ETF symbol (e.g. SPY, XLK, SMH)."
+          },
+          "hr": {
+            "type": "number",
+            "format": "float",
+            "description": "Hedge ratio (dollar_ratio) — ETF notional per $1 of fund exposure at this level."
+          }
+        }
+      },
+      "FundHedgeResponse": {
+        "type": "object",
+        "description": "Latest L1/L2/L3 hedge ratios for a fund. Empty arrays are emitted for levels with no non-NaN entries (e.g. small / niche funds may only have an L1 market hedge). Composing a full hedge basket means concatenating L1 + L2 + L3 entries.\n",
+        "required": [
+          "bw_fund_id",
+          "teo",
+          "L1",
+          "L2",
+          "L3"
+        ],
+        "properties": {
+          "bw_fund_id": {
+            "type": "string"
+          },
+          "ticker": {
+            "type": "string",
+            "nullable": true
+          },
+          "fund_name": {
+            "type": "string",
+            "nullable": true
+          },
+          "equity_style_9box": {
+            "type": "string",
+            "nullable": true
+          },
+          "teo": {
+            "type": "string",
+            "format": "date"
+          },
+          "L1": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FundHedgeLeg"
+            }
+          },
+          "L2": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FundHedgeLeg"
+            }
+          },
+          "L3": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FundHedgeLeg"
+            }
+          }
+        }
+      },
       "FundHolding": {
         "type": "object",
         "description": "One holding (security) within a fund's top-N snapshot.",
@@ -7897,6 +7966,94 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/funds/{bw_fund_id}/hedge": {
+      "get": {
+        "summary": "Latest fund hedge ratios (L1 / L2 / L3)",
+        "description": "Latest L1/L2/L3 ETF hedge ratios for a fund. Reads `L{1,2,3}_HR (teo, symbol)` from Slice 7's per-fund `ds_hr.zarr` at the latest teo. Empty arrays are emitted for levels with no non-NaN entries (small / niche funds may only have an L1 market hedge).\n",
+        "operationId": "getFundHedge",
+        "tags": [
+          "Funds"
+        ],
+        "x-pricing": {
+          "capability_id": "fund-hedge",
+          "tier": "baseline",
+          "cost_usd": 0.005,
+          "billing_code": "fund_hedge_v1"
+        },
+        "parameters": [
+          {
+            "name": "bw_fund_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "BW-FUND-S000004310"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Per-level hedge legs.",
+            "headers": {
+              "X-Data-As-Of": {
+                "schema": {
+                  "type": "string",
+                  "format": "date"
+                }
+              },
+              "X-Data-Filing-Date": {
+                "schema": {
+                  "type": "string",
+                  "format": "date"
+                }
+              },
+              "X-API-Cost-USD": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FundHedgeResponse"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Insufficient prepaid balance.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InsufficientBalance"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Fund not found, or no hedge ratio panel.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RateLimitExceeded"
                 }
               }
             }

--- a/tests/funds-format.test.ts
+++ b/tests/funds-format.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import { formatFundMetrics } from "@/lib/funds/format";
+import type { FundLatestRow, FundRow } from "@/lib/dal/funds-engine";
+
+const FUND: FundRow = {
+  bw_fund_id: "BW-FUND-S000004310",
+  series_id: "S000004310",
+  ticker: "VFINX",
+  cik: "0000036405",
+  fund_name: "Vanguard 500 Index Fund Investor Shares",
+  morningstar_category: "Large Blend",
+  equity_style_9box: "Large Blend",
+  style_link_method: "ticker_match",
+  primary_bw_fund_id: null,
+  latest_report_date: "2026-04-30",
+  latest_filing_date: "2026-07-14",
+  latest_extracted_at: "2026-05-02T16:38:21.330085+00:00",
+  latest_total_adj_mv: 25_000_000_000,
+  latest_n_holdings: 503,
+  latest_effective_n: 102.4,
+  last_in_eligible_universe_at: null,
+  metadata: {},
+};
+
+const LATEST: FundLatestRow = {
+  bw_fund_id: "BW-FUND-S000004310",
+  report_date: "2026-04-30",
+  filing_date: "2026-07-14",
+  extracted_at: "2026-05-02T16:38:21.330085+00:00",
+  portfolio_gross_return: 0.071,
+  portfolio_market_return: 0.099,
+  portfolio_sector_return: -0.01,
+  portfolio_subsector_return: -0.01,
+  portfolio_idiosyncratic_return: -0.005,
+  identity_residual: -0.003,
+  weight_sum: 0.99,
+  n_holdings_active: 503,
+  effective_n: 102.4,
+  top10_weight_sum: 0.34,
+  total_adj_mv: 25_000_000_000,
+  equity_style_9box: "Large Blend",
+  n_funds_in_cell_at_report_date: 1234,
+  model_version: "funds_dag.v20260502",
+  factor_set_id: "uni_mc_3000_SPY",
+  last_synced_at: "2026-05-02T16:41:31.441605+00:00",
+  metadata: {},
+};
+
+describe("formatFundMetrics", () => {
+  it("nests return components under `returns` and diagnostics under `diagnostics`", () => {
+    const r = formatFundMetrics(FUND, LATEST);
+    expect(r.returns.gross).toBeCloseTo(0.071);
+    expect(r.returns.market).toBeCloseTo(0.099);
+    expect(r.returns.identity_residual).toBeCloseTo(-0.003);
+    expect(r.diagnostics.effective_n).toBeCloseTo(102.4);
+    expect(r.diagnostics.top10_weight_sum).toBeCloseTo(0.34);
+  });
+
+  it("surfaces the bitemporal triple at the top level", () => {
+    const r = formatFundMetrics(FUND, LATEST);
+    expect(r.report_date).toBe("2026-04-30");
+    expect(r.filing_date).toBe("2026-07-14");
+    expect(r.extracted_at).toBe("2026-05-02T16:38:21.330085+00:00");
+  });
+
+  it("composes _metadata with model_version + data_as_of from latest row", () => {
+    const r = formatFundMetrics(FUND, LATEST);
+    expect(r._metadata.model_version).toBe("funds_dag.v20260502");
+    expect(r._metadata.factor_set_id).toBe("uni_mc_3000_SPY");
+    expect(r._metadata.data_as_of).toBe("2026-04-30");
+    expect(r._metadata.last_synced_at).toBe(
+      "2026-05-02T16:41:31.441605+00:00",
+    );
+  });
+
+  it("falls back to latest.equity_style_9box when registry row's column is null", () => {
+    const fundNoStyle = { ...FUND, equity_style_9box: null };
+    const r = formatFundMetrics(fundNoStyle, LATEST);
+    expect(r.equity_style_9box).toBe("Large Blend");
+  });
+
+  it("preserves null returns / diagnostics rather than substituting zero", () => {
+    const sparseLatest = {
+      ...LATEST,
+      portfolio_gross_return: null,
+      effective_n: null,
+      identity_residual: null,
+    };
+    const r = formatFundMetrics(FUND, sparseLatest);
+    expect(r.returns.gross).toBeNull();
+    expect(r.returns.identity_residual).toBeNull();
+    expect(r.diagnostics.effective_n).toBeNull();
+  });
+
+  it("includes registry-side meta (morningstar_category, primary_bw_fund_id)", () => {
+    const r = formatFundMetrics(FUND, LATEST);
+    expect(r.meta.morningstar_category).toBe("Large Blend");
+    expect(r.meta.primary_bw_fund_id).toBeNull();
+    expect(r.meta.total_adj_mv).toBe(25_000_000_000);
+    expect(r.meta.n_funds_in_cell_at_report_date).toBe(1234);
+  });
+});

--- a/tests/funds-hedge-route.test.ts
+++ b/tests/funds-hedge-route.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest, type NextResponse } from "next/server";
+
+vi.mock("@/lib/agent/billing-middleware", () => ({
+  withBilling: <T extends (...args: unknown[]) => unknown>(handler: T) => handler,
+}));
+
+vi.mock("@/lib/dal/funds-engine", () => ({
+  fetchFund: vi.fn(),
+}));
+
+vi.mock("@/lib/dal/funds-zarr-reader", () => ({
+  readFundHedgeLatest: vi.fn(),
+}));
+
+import { fetchFund } from "@/lib/dal/funds-engine";
+import { readFundHedgeLatest } from "@/lib/dal/funds-zarr-reader";
+import type { BillingContext } from "@/lib/agent/billing-middleware";
+import { GET as wrappedGET } from "@/app/api/funds/[bw_fund_id]/hedge/route";
+
+const GET = wrappedGET as unknown as (
+  req: NextRequest,
+  ctx: BillingContext,
+) => Promise<NextResponse>;
+
+const FUND = {
+  bw_fund_id: "BW-FUND-X",
+  series_id: "SX",
+  ticker: "VFINX",
+  cik: null,
+  fund_name: "Test Fund",
+  morningstar_category: null,
+  equity_style_9box: "Large Blend",
+  style_link_method: null,
+  primary_bw_fund_id: null,
+  latest_report_date: "2026-04-30",
+  latest_filing_date: "2026-07-14",
+  latest_extracted_at: null,
+  latest_total_adj_mv: 1000,
+  latest_n_holdings: 10,
+  latest_effective_n: 5,
+  last_in_eligible_universe_at: null,
+  metadata: {},
+};
+
+const SNAPSHOT = {
+  teo: "2026-04-30",
+  L1: [{ etf: "SPY", hr: 0.85 }],
+  L2: [{ etf: "XLK", hr: 0.32 }, { etf: "XLF", hr: 0.18 }],
+  L3: [{ etf: "SMH", hr: 0.15 }],
+};
+
+const fakeContext: BillingContext = {
+  userId: "test-user",
+  requestId: "test-req",
+  capabilityId: "fund-hedge",
+  costUsd: 0.005,
+  startTime: Date.now(),
+};
+
+function req(path: string): NextRequest {
+  return new NextRequest(new Request(`http://localhost${path}`));
+}
+
+beforeEach(() => {
+  vi.mocked(fetchFund).mockReset();
+  vi.mocked(readFundHedgeLatest).mockReset();
+});
+
+describe("GET /api/funds/[bw_fund_id]/hedge", () => {
+  it("returns 200 with per-level ETF lists + bitemporal headers", async () => {
+    vi.mocked(fetchFund).mockResolvedValue(FUND);
+    vi.mocked(readFundHedgeLatest).mockResolvedValue(SNAPSHOT);
+    const res = await GET(req("/api/funds/BW-FUND-X/hedge"), fakeContext);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("X-Data-As-Of")).toBe("2026-04-30");
+    expect(res.headers.get("X-Data-Filing-Date")).toBe("2026-07-14");
+    const body = await res.json();
+    expect(body.bw_fund_id).toBe("BW-FUND-X");
+    expect(body.teo).toBe("2026-04-30");
+    expect(body.L1).toEqual([{ etf: "SPY", hr: 0.85 }]);
+    expect(body.L2).toHaveLength(2);
+    expect(body.L3[0].etf).toBe("SMH");
+  });
+
+  it("returns 404 when fund registry row missing", async () => {
+    vi.mocked(fetchFund).mockResolvedValue(null);
+    const res = await GET(
+      req("/api/funds/BW-FUND-MISSING/hedge"),
+      fakeContext,
+    );
+    expect(res.status).toBe(404);
+    expect(vi.mocked(readFundHedgeLatest)).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when zarr returns null (no hedge panel)", async () => {
+    vi.mocked(fetchFund).mockResolvedValue(FUND);
+    vi.mocked(readFundHedgeLatest).mockResolvedValue(null);
+    const res = await GET(req("/api/funds/BW-FUND-X/hedge"), fakeContext);
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toBe("No hedge ratio panel available for this fund");
+  });
+});

--- a/tests/funds-holdings-route.test.ts
+++ b/tests/funds-holdings-route.test.ts
@@ -1,0 +1,154 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest, type NextResponse } from "next/server";
+
+vi.mock("@/lib/agent/billing-middleware", () => ({
+  withBilling: <T extends (...args: unknown[]) => unknown>(handler: T) => handler,
+}));
+
+vi.mock("@/lib/dal/funds-engine", () => ({
+  fetchFund: vi.fn(),
+}));
+
+vi.mock("@/lib/dal/funds-zarr-reader", () => ({
+  readFundHoldingsTopN: vi.fn(),
+}));
+
+import { fetchFund } from "@/lib/dal/funds-engine";
+import { readFundHoldingsTopN } from "@/lib/dal/funds-zarr-reader";
+import type { BillingContext } from "@/lib/agent/billing-middleware";
+import { GET as wrappedGET } from "@/app/api/funds/[bw_fund_id]/holdings/route";
+
+const GET = wrappedGET as unknown as (
+  req: NextRequest,
+  ctx: BillingContext,
+) => Promise<NextResponse>;
+
+const FUND = {
+  bw_fund_id: "BW-FUND-X",
+  series_id: "SX",
+  ticker: "VFINX",
+  cik: null,
+  fund_name: "Test Fund",
+  morningstar_category: null,
+  equity_style_9box: "Large Blend",
+  style_link_method: null,
+  primary_bw_fund_id: null,
+  latest_report_date: "2026-04-30",
+  latest_filing_date: "2026-07-14",
+  latest_extracted_at: null,
+  latest_total_adj_mv: 1000,
+  latest_n_holdings: 10,
+  latest_effective_n: 5,
+  last_in_eligible_universe_at: null,
+  metadata: {},
+};
+
+const SNAPSHOT = {
+  teo: "2026-04-30",
+  aum_reported: 1_000_000,
+  aum_erm3: 950_000,
+  n_holdings_returned: 3,
+  n_total_holdings: 503,
+  holdings: [
+    { bw_sym_id: "BW-A", adj_mv: 100_000, weight: 100_000 / 950_000 },
+    { bw_sym_id: "BW-B", adj_mv: 50_000, weight: 50_000 / 950_000 },
+    { bw_sym_id: "BW-C", adj_mv: 25_000, weight: 25_000 / 950_000 },
+  ],
+};
+
+const fakeContext: BillingContext = {
+  userId: "test-user",
+  requestId: "test-req",
+  capabilityId: "fund-holdings",
+  costUsd: 0.005,
+  startTime: Date.now(),
+};
+
+function req(path: string): NextRequest {
+  return new NextRequest(new Request(`http://localhost${path}`));
+}
+
+beforeEach(() => {
+  vi.mocked(fetchFund).mockReset();
+  vi.mocked(readFundHoldingsTopN).mockReset();
+});
+
+describe("GET /api/funds/[bw_fund_id]/holdings", () => {
+  it("returns 200 with snapshot + bitemporal headers; default limit 25", async () => {
+    vi.mocked(fetchFund).mockResolvedValue(FUND);
+    vi.mocked(readFundHoldingsTopN).mockResolvedValue(SNAPSHOT);
+    const res = await GET(
+      req("/api/funds/BW-FUND-X/holdings"),
+      fakeContext,
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("X-Data-As-Of")).toBe("2026-04-30");
+    expect(res.headers.get("X-Data-Filing-Date")).toBe("2026-07-14");
+    expect(vi.mocked(readFundHoldingsTopN)).toHaveBeenCalledWith(
+      "BW-FUND-X",
+      25,
+    );
+    const body = await res.json();
+    expect(body.bw_fund_id).toBe("BW-FUND-X");
+    expect(body.holdings).toHaveLength(3);
+    expect(body.aum_erm3).toBe(950_000);
+    expect(body.n_total_holdings).toBe(503);
+  });
+
+  it("forwards custom ?limit=50", async () => {
+    vi.mocked(fetchFund).mockResolvedValue(FUND);
+    vi.mocked(readFundHoldingsTopN).mockResolvedValue(SNAPSHOT);
+    await GET(
+      req("/api/funds/BW-FUND-X/holdings?limit=50"),
+      fakeContext,
+    );
+    expect(vi.mocked(readFundHoldingsTopN)).toHaveBeenCalledWith(
+      "BW-FUND-X",
+      50,
+    );
+  });
+
+  it("clamps limit at 1000", async () => {
+    vi.mocked(fetchFund).mockResolvedValue(FUND);
+    vi.mocked(readFundHoldingsTopN).mockResolvedValue(SNAPSHOT);
+    await GET(
+      req("/api/funds/BW-FUND-X/holdings?limit=99999"),
+      fakeContext,
+    );
+    expect(vi.mocked(readFundHoldingsTopN)).toHaveBeenCalledWith(
+      "BW-FUND-X",
+      1000,
+    );
+  });
+
+  it("rejects non-positive limit", async () => {
+    const res = await GET(
+      req("/api/funds/BW-FUND-X/holdings?limit=0"),
+      fakeContext,
+    );
+    expect(res.status).toBe(400);
+    expect(vi.mocked(fetchFund)).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when fund registry row missing", async () => {
+    vi.mocked(fetchFund).mockResolvedValue(null);
+    const res = await GET(
+      req("/api/funds/BW-FUND-MISSING/holdings"),
+      fakeContext,
+    );
+    expect(res.status).toBe(404);
+    expect(vi.mocked(readFundHoldingsTopN)).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when zarr returns null (no holdings panel)", async () => {
+    vi.mocked(fetchFund).mockResolvedValue(FUND);
+    vi.mocked(readFundHoldingsTopN).mockResolvedValue(null);
+    const res = await GET(
+      req("/api/funds/BW-FUND-X/holdings"),
+      fakeContext,
+    );
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toBe("No holdings panel available for this fund");
+  });
+});

--- a/tests/funds-metrics-route.test.ts
+++ b/tests/funds-metrics-route.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+// Make withBilling a passthrough so we can test the inner handler directly.
+// The wrapper is exercised by integration / manual testing, not unit tests.
+vi.mock("@/lib/agent/billing-middleware", () => ({
+  withBilling: <T extends (...args: unknown[]) => unknown>(handler: T) => handler,
+}));
+
+vi.mock("@/lib/dal/funds-engine", () => ({
+  resolveFundById: vi.fn(),
+}));
+
+import { resolveFundById } from "@/lib/dal/funds-engine";
+import { GET as wrappedGET } from "@/app/api/funds/[bw_fund_id]/route";
+import type { BillingContext } from "@/lib/agent/billing-middleware";
+import type { NextResponse } from "next/server";
+
+// withBilling is mocked above to be identity, so the exported GET is really
+// the inner (req, ctx) handler at runtime — but TypeScript still sees the
+// wrapped 1-arg signature. Cast back to the inner shape for tests.
+const GET = wrappedGET as unknown as (
+  req: NextRequest,
+  ctx: BillingContext,
+) => Promise<NextResponse>;
+
+const FUND = {
+  bw_fund_id: "BW-FUND-S000004310",
+  series_id: "S000004310",
+  ticker: "VFINX",
+  cik: null,
+  fund_name: "Vanguard 500 Index Fund",
+  morningstar_category: "Large Blend",
+  equity_style_9box: "Large Blend",
+  style_link_method: "ticker_match",
+  primary_bw_fund_id: null,
+  latest_report_date: "2026-04-30",
+  latest_filing_date: "2026-07-14",
+  latest_extracted_at: null,
+  latest_total_adj_mv: 1000,
+  latest_n_holdings: 10,
+  latest_effective_n: 5,
+  last_in_eligible_universe_at: null,
+  metadata: {},
+};
+
+const LATEST = {
+  bw_fund_id: "BW-FUND-S000004310",
+  report_date: "2026-04-30",
+  filing_date: "2026-07-14",
+  extracted_at: "2026-05-02T16:38:21.330085+00:00",
+  portfolio_gross_return: 0.05,
+  portfolio_market_return: 0.04,
+  portfolio_sector_return: 0.005,
+  portfolio_subsector_return: 0.003,
+  portfolio_idiosyncratic_return: 0.002,
+  identity_residual: null,
+  weight_sum: 1,
+  n_holdings_active: 10,
+  effective_n: 5,
+  top10_weight_sum: 0.5,
+  total_adj_mv: 1000,
+  equity_style_9box: "Large Blend",
+  n_funds_in_cell_at_report_date: 100,
+  model_version: "funds_dag.v20260502",
+  factor_set_id: "uni_mc_3000_SPY",
+  last_synced_at: "2026-05-02T16:41:31.441605+00:00",
+  metadata: {},
+};
+
+const fakeContext = {
+  userId: "test-user",
+  requestId: "test-req",
+  capabilityId: "fund-metrics",
+  costUsd: 0.005,
+  startTime: Date.now(),
+};
+
+function req(path: string): NextRequest {
+  return new NextRequest(new Request(`http://localhost${path}`));
+}
+
+beforeEach(() => {
+  vi.mocked(resolveFundById).mockReset();
+});
+
+describe("GET /api/funds/[bw_fund_id]", () => {
+  it("returns 200 with shaped body and bitemporal headers", async () => {
+    vi.mocked(resolveFundById).mockResolvedValue({ fund: FUND, latest: LATEST });
+    const res = await GET(
+      req("/api/funds/BW-FUND-S000004310"),
+      fakeContext,
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("X-Data-As-Of")).toBe("2026-04-30");
+    expect(res.headers.get("X-Data-Filing-Date")).toBe("2026-07-14");
+    expect(res.headers.get("X-Risk-Model-Version")).toBe("funds_dag.v20260502");
+    const body = await res.json();
+    expect(body.bw_fund_id).toBe("BW-FUND-S000004310");
+    expect(body.ticker).toBe("VFINX");
+    expect(body.returns.gross).toBeCloseTo(0.05);
+    expect(body.diagnostics.effective_n).toBe(5);
+    expect(body._metadata.factor_set_id).toBe("uni_mc_3000_SPY");
+  });
+
+  it("returns 404 when DAL returns null", async () => {
+    vi.mocked(resolveFundById).mockResolvedValue(null);
+    const res = await GET(req("/api/funds/BW-FUND-MISSING"), fakeContext);
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toBe("Fund not found");
+  });
+
+  it("returns 404 with hint when registry exists but no funds_latest row", async () => {
+    vi.mocked(resolveFundById).mockResolvedValue({ fund: FUND, latest: null });
+    const res = await GET(req("/api/funds/BW-FUND-S000004310"), fakeContext);
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toBe("No funds_latest row for this fund");
+    expect(body.bw_fund_id).toBe("BW-FUND-S000004310");
+  });
+});

--- a/tests/funds-portfolio-route.test.ts
+++ b/tests/funds-portfolio-route.test.ts
@@ -1,0 +1,157 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest, type NextResponse } from "next/server";
+
+vi.mock("@/lib/agent/billing-middleware", () => ({
+  withBilling: <T extends (...args: unknown[]) => unknown>(handler: T) => handler,
+}));
+
+vi.mock("@/lib/dal/funds-engine", () => ({
+  fetchFund: vi.fn(),
+}));
+
+vi.mock("@/lib/dal/funds-zarr-reader", () => ({
+  readFundPortfolioSeries: vi.fn(),
+}));
+
+import { fetchFund } from "@/lib/dal/funds-engine";
+import { readFundPortfolioSeries } from "@/lib/dal/funds-zarr-reader";
+import type { BillingContext } from "@/lib/agent/billing-middleware";
+import { GET as wrappedGET } from "@/app/api/funds/[bw_fund_id]/portfolio/route";
+
+const GET = wrappedGET as unknown as (
+  req: NextRequest,
+  ctx: BillingContext,
+) => Promise<NextResponse>;
+
+const FUND = {
+  bw_fund_id: "BW-FUND-X",
+  series_id: "SX",
+  ticker: "VFINX",
+  cik: null,
+  fund_name: "Test Fund",
+  morningstar_category: null,
+  equity_style_9box: "Large Blend",
+  style_link_method: null,
+  primary_bw_fund_id: null,
+  latest_report_date: "2026-04-30",
+  latest_filing_date: "2026-07-14",
+  latest_extracted_at: null,
+  latest_total_adj_mv: 1000,
+  latest_n_holdings: 10,
+  latest_effective_n: 5,
+  last_in_eligible_universe_at: null,
+  metadata: {},
+};
+
+const ROW = (teo: string) => ({
+  teo,
+  portfolio_gross_return: 0.05,
+  portfolio_market_return: 0.04,
+  portfolio_sector_return: 0.005,
+  portfolio_subsector_return: 0.003,
+  portfolio_idiosyncratic_return: 0.002,
+  identity_residual: null,
+  weight_sum: 0.99,
+  n_holdings_active: 503,
+  effective_n: 102.4,
+  top10_weight_sum: 0.34,
+});
+
+const fakeContext: BillingContext = {
+  userId: "test-user",
+  requestId: "test-req",
+  capabilityId: "fund-portfolio-history",
+  costUsd: 0.005,
+  startTime: Date.now(),
+};
+
+function req(path: string): NextRequest {
+  return new NextRequest(new Request(`http://localhost${path}`));
+}
+
+beforeEach(() => {
+  vi.mocked(fetchFund).mockReset();
+  vi.mocked(readFundPortfolioSeries).mockReset();
+});
+
+describe("GET /api/funds/[bw_fund_id]/portfolio", () => {
+  it("returns 200 with rows + summary when both DALs return data", async () => {
+    vi.mocked(fetchFund).mockResolvedValue(FUND);
+    vi.mocked(readFundPortfolioSeries).mockResolvedValue([
+      ROW("2026-02-29"),
+      ROW("2026-03-31"),
+      ROW("2026-04-30"),
+    ]);
+    const res = await GET(
+      req("/api/funds/BW-FUND-X/portfolio"),
+      fakeContext,
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("X-Data-As-Of")).toBe("2026-04-30");
+    expect(res.headers.get("X-Data-Filing-Date")).toBe("2026-07-14");
+    const body = await res.json();
+    expect(body.bw_fund_id).toBe("BW-FUND-X");
+    expect(body.ticker).toBe("VFINX");
+    expect(body.n_periods).toBe(3);
+    expect(body.start_teo).toBe("2026-02-29");
+    expect(body.end_teo).toBe("2026-04-30");
+    expect(body.rows).toHaveLength(3);
+    expect(body.rows[0].portfolio_gross_return).toBeCloseTo(0.05);
+  });
+
+  it("returns 404 when fund registry row missing (skips zarr open)", async () => {
+    vi.mocked(fetchFund).mockResolvedValue(null);
+    const res = await GET(
+      req("/api/funds/BW-FUND-MISSING/portfolio"),
+      fakeContext,
+    );
+    expect(res.status).toBe(404);
+    expect(vi.mocked(readFundPortfolioSeries)).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when zarr returns empty rows (registry exists)", async () => {
+    vi.mocked(fetchFund).mockResolvedValue(FUND);
+    vi.mocked(readFundPortfolioSeries).mockResolvedValue([]);
+    const res = await GET(
+      req("/api/funds/BW-FUND-X/portfolio"),
+      fakeContext,
+    );
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toBe("No portfolio history available for this fund");
+  });
+
+  it("forwards start_date / end_date to the DAL", async () => {
+    vi.mocked(fetchFund).mockResolvedValue(FUND);
+    vi.mocked(readFundPortfolioSeries).mockResolvedValue([ROW("2026-04-30")]);
+    await GET(
+      req(
+        "/api/funds/BW-FUND-X/portfolio?start_date=2026-01-31&end_date=2026-04-30",
+      ),
+      fakeContext,
+    );
+    expect(vi.mocked(readFundPortfolioSeries)).toHaveBeenCalledWith(
+      "BW-FUND-X",
+      { startDate: "2026-01-31", endDate: "2026-04-30" },
+    );
+  });
+
+  it("rejects malformed date params", async () => {
+    const res = await GET(
+      req("/api/funds/BW-FUND-X/portfolio?start_date=01-31-2026"),
+      fakeContext,
+    );
+    expect(res.status).toBe(400);
+    expect(vi.mocked(fetchFund)).not.toHaveBeenCalled();
+  });
+
+  it("rejects start_date > end_date", async () => {
+    const res = await GET(
+      req(
+        "/api/funds/BW-FUND-X/portfolio?start_date=2026-04-30&end_date=2026-01-31",
+      ),
+      fakeContext,
+    );
+    expect(res.status).toBe(400);
+  });
+});


### PR DESCRIPTION
Stage B.1 of the funds-side API build. Stacked on top of #22 (Stage A); base will retarget to \`main\` once #22 merges.

## Summary

First public **compute-bearing** endpoint on the funds side. Pure Supabase read (joins \`funds\` + \`funds_latest\`), wrapped in \`withBilling\` at $0.005 per request. Mirrors stocks-side \`/metrics/{ticker}\` shape — nested \`returns\` / \`diagnostics\` / \`meta\` groups plus a \`_metadata\` lineage block.

### Route

\`GET /api/funds/{bw_fund_id}\` → \`FundMetricsResponse\`

Response example:
\`\`\`json
{
  "bw_fund_id": "BW-FUND-S000004310",
  "ticker": "VFINX",
  "fund_name": "Vanguard 500 Index Fund",
  "equity_style_9box": "Large Blend",
  "report_date": "2026-04-30",
  "filing_date": "2026-07-14",
  "extracted_at": "2026-05-02T16:38:21.330085+00:00",
  "returns": { "gross": 0.071, "market": 0.099, "sector": -0.01, ... },
  "diagnostics": { "weight_sum": 0.99, "n_holdings_active": 503, ... },
  "meta": { "total_adj_mv": 25000000000, ... },
  "_metadata": { "model_version": "funds_dag.v20260502", ... }
}
\`\`\`

### Bitemporal headers

Every 200 sets:
- \`X-Data-As-Of: <report_date>\`
- \`X-Data-Filing-Date: <filing_date>\`
- \`X-Risk-Model-Version: <model_version>\`

v1 returns the latest knowledge-mode answer only — \`?as_of=\` / \`?mode=\` deferred to v2 (schema is forward-compatible).

### New code

- \`lib/funds/format.ts\` — pure \`formatFundMetrics(fund, latest)\` helper
- \`app/api/funds/[bw_fund_id]/route.ts\` — \`withBilling\`-wrapped GET
- \`lib/agent/capabilities.ts\` — \`fund-metrics\` capability ($0.005, \`fund_metrics_v1\`)
- OpenAPI: \`FundMetricsResponse\` schema, \`/funds/{bw_fund_id}\` path, new "Funds" tag

### Tests

- \`tests/funds-format.test.ts\` — 6 unit tests
- \`tests/funds-metrics-route.test.ts\` — 3 route handler tests (\`withBilling\` mocked as passthrough)
- Full suite: 126/126

### Deliberately out of scope

| Stage | What |
|---|---|
| B.2 | \`/portfolio\`, \`/holdings\`, \`/hedge\` (Zarr-backed) |
| C   | \`/funds/style/{slug}/*\` cohort routes |
| D   | \`/funds/snapshot/*\` |
| E   | AOM extensions + SDK |
| F   | \`/api/13f/*\` |

## Test plan

- [x] \`npm test\` — 126/126 (9 new in B.1)
- [x] \`npm run typecheck\` — clean
- [x] \`npm run lint\` — clean
- [x] \`npm run cli:openapi-check\` — 19 paths (45 spec total)
- [x] \`npm run build:openapi\` — yaml→json regenerates without error
- [ ] Mirror PR on Risk_Models for the regenerated \`mcp/data/openapi.json\` (will open with this PR; needs to merge first to clear \`detect-drift\`)
- [ ] Smoke against staging once #22 merges and the funds tables have data: \`GET /api/funds/BW-FUND-S000004310\` → 200 with bitemporal headers
- [ ] Once \`#22\` merges to \`main\`, retarget this PR's base to \`main\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)