### PR TITLE
Funds Stage C.0 + C.1: style cohort metrics + rankings

### DIFF
--- a/OPENAPI_SPEC.yaml
+++ b/OPENAPI_SPEC.yaml
@@ -1855,6 +1855,90 @@ components:
         count:
           type: integer
 
+    StyleCohortReturnsBlock:
+      type: object
+      description: Portfolio return components + diagnostics for one weighting in a cohort.
+      properties:
+        portfolio_gross_return: { type: number, format: float, nullable: true }
+        portfolio_market_return: { type: number, format: float, nullable: true }
+        portfolio_sector_return: { type: number, format: float, nullable: true }
+        portfolio_subsector_return: { type: number, format: float, nullable: true }
+        portfolio_idiosyncratic_return: { type: number, format: float, nullable: true }
+        identity_residual: { type: number, format: float, nullable: true }
+        weight_sum:
+          type: number
+          format: float
+          nullable: true
+          description: Cohort coverage (fraction of cohort AUM in mapped symbols).
+        n_holdings_active: { type: integer, nullable: true }
+        effective_n: { type: number, format: float, nullable: true }
+        top10_weight_sum: { type: number, format: float, nullable: true }
+
+    StyleCohortMetricsResponse:
+      type: object
+      description: >
+        Latest cohort metrics for a 9-box style cell. Both equal-weight (EW)
+        and market-value-weighted (MV) cohort portfolios are returned
+        side-by-side under `weightings`. Bitemporal lineage at top level.
+      required: [equity_style_9box, slug, report_date, weightings, _metadata]
+      properties:
+        equity_style_9box:
+          type: string
+          example: Large Blend
+        slug:
+          type: string
+          example: large-blend
+        report_date: { type: string, format: date }
+        filing_date_max: { type: string, format: date, nullable: true }
+        n_funds_in_cell: { type: integer, nullable: true }
+        weightings:
+          type: object
+          properties:
+            ew: { $ref: "#/components/schemas/StyleCohortReturnsBlock" }
+            mv: { $ref: "#/components/schemas/StyleCohortReturnsBlock" }
+        _metadata:
+          type: object
+          properties:
+            model_version: { type: string, nullable: true }
+            data_as_of: { type: string, format: date }
+            data_freshness: { type: string, format: date-time }
+            last_synced_at: { type: string, format: date-time }
+
+    StyleCohortRankingRow:
+      type: object
+      required: [rank, entity_id]
+      properties:
+        rank: { type: integer, example: 1 }
+        entity_id:
+          type: string
+          description: bw_sym_id (cohort=symbol), sector code (cohort=sector), or bw_fund_id (cohort=fund).
+        value: { type: number, format: float, nullable: true }
+        cohort_size: { type: integer, nullable: true }
+
+    StyleCohortRankingsResponse:
+      type: object
+      required: [equity_style_9box, slug, cohort_type, metric, period_window, weighting, report_date, n_returned, rows]
+      properties:
+        equity_style_9box: { type: string }
+        slug: { type: string }
+        cohort_type:
+          type: string
+          enum: [symbol, sector, fund]
+        metric: { type: string }
+        period_window:
+          type: string
+          enum: ["1m", "3m", "12m", "36m"]
+        weighting:
+          type: string
+          enum: [ew, mv]
+        report_date: { type: string, format: date }
+        filing_date_max: { type: string, format: date, nullable: true }
+        n_returned: { type: integer }
+        rows:
+          type: array
+          items:
+            $ref: "#/components/schemas/StyleCohortRankingRow"
+
     FundHedgeLeg:
       type: object
       description: One ETF hedge leg at a given factor level.
@@ -5513,6 +5597,161 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+
+  /funds/style/{slug}:
+    get:
+      summary: Latest cohort metrics for a 9-box style cell
+      description: >
+        Latest portfolio return decomposition + diagnostics for a 9-box
+        style cell, aggregated across all funds in the cell. Both EW and
+        MV cohort portfolios are returned side-by-side under
+        `weightings`.
+
+
+        The differentiated wedge: Morningstar reports per-fund metrics
+        but doesn't expose cohort aggregates with this attribution
+        depth.
+      operationId: getStyleCohortMetrics
+      tags: [Funds]
+      x-pricing:
+        capability_id: style-cohort-metrics
+        tier: baseline
+        cost_usd: 0.005
+        billing_code: style_cohort_metrics_v1
+      parameters:
+        - name: slug
+          in: path
+          required: true
+          schema:
+            type: string
+            enum:
+              - large-value
+              - large-blend
+              - large-growth
+              - mid-value
+              - mid-blend
+              - mid-growth
+              - small-value
+              - small-blend
+              - small-growth
+      responses:
+        "200":
+          description: Latest cohort metrics (both weightings).
+          headers:
+            X-Data-As-Of: { schema: { type: string, format: date } }
+            X-Data-Filing-Date: { schema: { type: string, format: date } }
+            X-Risk-Model-Version: { schema: { type: string } }
+            X-API-Cost-USD: { schema: { type: string } }
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StyleCohortMetricsResponse"
+        "400":
+          description: Invalid style slug.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/ErrorResponse" }
+        "402":
+          description: Insufficient prepaid balance.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/InsufficientBalance" }
+        "404":
+          description: No cohort metrics available for this cell.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/ErrorResponse" }
+        "429":
+          description: Rate limit exceeded.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/RateLimitExceeded" }
+
+  /funds/style/{slug}/rankings/{cohort_type}:
+    get:
+      summary: Top-N rankings within a 9-box style cell
+      description: >
+        Top-N rankings within a 9-box style cell × cohort_type × metric
+        × period_window × weighting. `cohort_type` selects what gets
+        ranked: symbols (holdings), sector codes, or funds.
+
+
+        For `cohort_type=fund`, the `weighting` parameter is ignored
+        (writer stores `'ew'` placeholder since fund returns are
+        scalar). Top-N is capped at 50 — the data ceiling per Slice 9.
+      operationId: getStyleCohortRankings
+      tags: [Funds]
+      x-pricing:
+        capability_id: style-cohort-rankings
+        tier: baseline
+        cost_usd: 0.005
+        billing_code: style_cohort_rankings_v1
+      parameters:
+        - name: slug
+          in: path
+          required: true
+          schema: { type: string }
+        - name: cohort_type
+          in: path
+          required: true
+          schema:
+            type: string
+            enum: [symbol, sector, fund]
+        - name: metric
+          in: query
+          required: true
+          schema: { type: string }
+          description: Metric to rank by (e.g. weight, gross_return, n_funds_holding).
+        - name: period_window
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: ["1m", "3m", "12m", "36m"]
+            default: "1m"
+        - name: weighting
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [ew, mv]
+            default: mv
+          description: Ignored for cohort_type=fund.
+        - name: limit
+          in: query
+          required: false
+          schema: { type: integer, minimum: 1, maximum: 50, default: 25 }
+      responses:
+        "200":
+          description: Top-N ranked rows.
+          headers:
+            X-Data-As-Of: { schema: { type: string, format: date } }
+            X-Data-Filing-Date: { schema: { type: string, format: date } }
+            X-API-Cost-USD: { schema: { type: string } }
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StyleCohortRankingsResponse"
+        "400":
+          description: Invalid slug, cohort_type, period_window, weighting, or missing metric.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/ErrorResponse" }
+        "402":
+          description: Insufficient prepaid balance.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/InsufficientBalance" }
+        "404":
+          description: No rankings for this combination.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/ErrorResponse" }
+        "429":
+          description: Rate limit exceeded.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/RateLimitExceeded" }
 
   /funds/{bw_fund_id}/hedge:
     get:

--- a/app/api/funds/style/[slug]/rankings/[cohort_type]/route.ts
+++ b/app/api/funds/style/[slug]/rankings/[cohort_type]/route.ts
@@ -1,0 +1,140 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { withBilling, type BillingContext } from "@/lib/agent/billing-middleware";
+import {
+  fetchStyleRankings,
+  type CohortType,
+  type RankPeriodWindow,
+  type Weighting,
+} from "@/lib/dal/funds-engine";
+import { styleSlugToName } from "@/lib/funds/style-slug";
+
+export const dynamic = "force-dynamic";
+
+const COHORT_TYPES = new Set<CohortType>(["symbol", "sector", "fund"]);
+const PERIOD_WINDOWS = new Set<RankPeriodWindow>(["1m", "3m", "12m", "36m"]);
+const WEIGHTINGS = new Set<Weighting>(["ew", "mv"]);
+
+/**
+ * GET /api/funds/style/{slug}/rankings/{cohort_type}
+ *
+ * Top-N rankings within a 9-box style cell × cohort_type × metric ×
+ * period_window × weighting. The cohort axis runs over `symbol` (rank
+ * holdings), `sector` (rank sector codes), or `fund` (rank funds).
+ *
+ * Required: ?metric (e.g. "weight", "gross_return"). Defaults: period_window=1m,
+ * weighting=mv, limit=25 (capped 50 — Slice 9 storage ceiling).
+ *
+ * For cohort_type=fund, weighting is ignored (writer stores 'ew' placeholder
+ * since fund returns are scalar).
+ */
+export const GET = withBilling(
+  async (request: NextRequest, _context: BillingContext) => {
+    const segments = request.nextUrl.pathname.split("/");
+    const cohortType = segments[segments.length - 1] as CohortType;
+    const slug = segments[segments.length - 3];
+
+    const cellName = styleSlugToName(slug ?? "");
+    if (!cellName) {
+      return NextResponse.json(
+        { error: `Invalid style slug: ${slug}` },
+        { status: 400 },
+      );
+    }
+    if (!cohortType || !COHORT_TYPES.has(cohortType)) {
+      return NextResponse.json(
+        { error: `cohort_type must be one of: symbol, sector, fund` },
+        { status: 400 },
+      );
+    }
+
+    const sp = request.nextUrl.searchParams;
+    const metric = sp.get("metric")?.trim();
+    if (!metric) {
+      return NextResponse.json(
+        { error: "metric query param is required" },
+        { status: 400 },
+      );
+    }
+
+    const periodWindow = (sp.get("period_window") ?? "1m") as RankPeriodWindow;
+    if (!PERIOD_WINDOWS.has(periodWindow)) {
+      return NextResponse.json(
+        { error: "period_window must be one of: 1m, 3m, 12m, 36m" },
+        { status: 400 },
+      );
+    }
+
+    const requestedWeighting = (sp.get("weighting") ?? "mv") as Weighting;
+    if (!WEIGHTINGS.has(requestedWeighting)) {
+      return NextResponse.json(
+        { error: "weighting must be one of: ew, mv" },
+        { status: 400 },
+      );
+    }
+
+    let limit = 25;
+    const limitParam = sp.get("limit");
+    if (limitParam !== null) {
+      const parsed = Number(limitParam);
+      if (!Number.isFinite(parsed) || parsed < 1) {
+        return NextResponse.json(
+          { error: "limit must be a positive integer" },
+          { status: 400 },
+        );
+      }
+      limit = Math.min(Math.floor(parsed), 50);
+    }
+
+    const rows = await fetchStyleRankings(cellName, {
+      metric,
+      cohortType,
+      periodWindow,
+      weighting: requestedWeighting,
+      limit,
+    });
+
+    if (rows.length === 0) {
+      return NextResponse.json(
+        {
+          error:
+            "No rankings available for this (cell, cohort_type, metric, period_window, weighting)",
+          equity_style_9box: cellName,
+          slug,
+          cohort_type: cohortType,
+          metric,
+          period_window: periodWindow,
+        },
+        { status: 404 },
+      );
+    }
+
+    const reportDate = rows[0]!.report_date;
+    const filingDateMax = rows[0]!.filing_date_max;
+    const effectiveWeighting = rows[0]!.weighting;
+
+    const headers = new Headers({ "X-Data-As-Of": reportDate });
+    if (filingDateMax) headers.set("X-Data-Filing-Date", filingDateMax);
+
+    return NextResponse.json(
+      {
+        equity_style_9box: cellName,
+        slug,
+        cohort_type: cohortType,
+        metric,
+        period_window: periodWindow,
+        weighting: effectiveWeighting,
+        report_date: reportDate,
+        filing_date_max: filingDateMax,
+        n_returned: rows.length,
+        rows: rows.map((r) => ({
+          rank: r.rank,
+          entity_id: r.entity_id,
+          value: r.value,
+          cohort_size: r.cohort_size,
+        })),
+      },
+      { headers },
+    );
+  },
+  { capabilityId: "style-cohort-rankings" },
+);

--- a/app/api/funds/style/[slug]/route.ts
+++ b/app/api/funds/style/[slug]/route.ts
@@ -1,0 +1,96 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { withBilling, type BillingContext } from "@/lib/agent/billing-middleware";
+import { fetchStyleCohortLatest } from "@/lib/dal/funds-engine";
+import { styleSlugToName } from "@/lib/funds/style-slug";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/funds/style/{slug}
+ *
+ * Latest cohort metrics for a 9-box style cell. Returns both EW and MV
+ * weightings side-by-side under a `weightings` map (Slice 6 emits both).
+ * Bitemporal lineage on response headers from `report_date` /
+ * `filing_date_max`.
+ *
+ * The "differentiated wedge" surface — Morningstar reports per-fund metrics
+ * but doesn't expose cohort-level aggregates with this attribution depth.
+ */
+export const GET = withBilling(
+  async (request: NextRequest, _context: BillingContext) => {
+    const segments = request.nextUrl.pathname.split("/");
+    const slug = segments[segments.length - 1];
+    const cellName = styleSlugToName(slug ?? "");
+    if (!cellName) {
+      return NextResponse.json(
+        { error: `Invalid style slug: ${slug}` },
+        { status: 400 },
+      );
+    }
+
+    const rows = await fetchStyleCohortLatest(cellName);
+    if (rows.length === 0) {
+      return NextResponse.json(
+        {
+          error: "No cohort metrics available for this cell",
+          equity_style_9box: cellName,
+          slug,
+        },
+        { status: 404 },
+      );
+    }
+
+    const byWeighting: Record<string, unknown> = {};
+    let reportDate = rows[0]!.report_date;
+    let filingDateMax = rows[0]!.filing_date_max;
+    let modelVersion = rows[0]!.model_version;
+    let lastSyncedAt = rows[0]!.last_synced_at;
+    let nFundsInCell = rows[0]!.n_funds_in_cell;
+
+    for (const r of rows) {
+      byWeighting[r.weighting] = {
+        portfolio_gross_return: r.portfolio_gross_return,
+        portfolio_market_return: r.portfolio_market_return,
+        portfolio_sector_return: r.portfolio_sector_return,
+        portfolio_subsector_return: r.portfolio_subsector_return,
+        portfolio_idiosyncratic_return: r.portfolio_idiosyncratic_return,
+        identity_residual: r.identity_residual,
+        weight_sum: r.weight_sum,
+        n_holdings_active: r.n_holdings_active,
+        effective_n: r.effective_n,
+        top10_weight_sum: r.top10_weight_sum,
+      };
+      // Use the freshest report_date / filing_date_max across rows.
+      if (r.report_date > reportDate) reportDate = r.report_date;
+      if (r.filing_date_max && (!filingDateMax || r.filing_date_max > filingDateMax)) {
+        filingDateMax = r.filing_date_max;
+      }
+      if (r.last_synced_at > lastSyncedAt) lastSyncedAt = r.last_synced_at;
+      if (r.model_version) modelVersion = r.model_version;
+      if (r.n_funds_in_cell != null) nFundsInCell = r.n_funds_in_cell;
+    }
+
+    const headers = new Headers({ "X-Data-As-Of": reportDate });
+    if (filingDateMax) headers.set("X-Data-Filing-Date", filingDateMax);
+    if (modelVersion) headers.set("X-Risk-Model-Version", modelVersion);
+
+    return NextResponse.json(
+      {
+        equity_style_9box: cellName,
+        slug,
+        report_date: reportDate,
+        filing_date_max: filingDateMax,
+        n_funds_in_cell: nFundsInCell,
+        weightings: byWeighting,
+        _metadata: {
+          model_version: modelVersion,
+          data_as_of: reportDate,
+          data_freshness: lastSyncedAt,
+          last_synced_at: lastSyncedAt,
+        },
+      },
+      { headers },
+    );
+  },
+  { capabilityId: "style-cohort-metrics" },
+);

--- a/lib/agent/capabilities.ts
+++ b/lib/agent/capabilities.ts
@@ -1164,6 +1164,116 @@ export const CAPABILITIES: Capability[] = [
     },
     tags: ["funds", "hedge-ratios", "knowledge-mode"],
   },
+  {
+    id: "style-cohort-metrics",
+    name: "Style Cohort Latest Metrics",
+    description:
+      "Latest portfolio return decomposition + diagnostics for one of the 9-box style cells, " +
+      "aggregated across all funds in the cell. Returns both equal-weight (EW) and " +
+      "market-value-weighted (MV) cohort portfolios side-by-side. Sourced from Slice 6's " +
+      "per-cell ds_portfolio.zarr (latest snapshot in style_portfolios_latest). " +
+      "The differentiated wedge — Morningstar reports per-fund metrics but doesn't expose " +
+      "cohort aggregates with this attribution depth.",
+    endpoint: "/api/funds/style/{slug}",
+    method: "GET",
+    parameters: {
+      slug: {
+        type: "string",
+        required: true,
+        description:
+          "9-box style slug (large-value, large-blend, large-growth, mid-*, small-*).",
+      },
+    },
+    pricing: {
+      model: "per_request",
+      tier: "baseline",
+      cost_usd: 0.005,
+      currency: "USD",
+      billing_code: "style_cohort_metrics_v1",
+    },
+    performance: {
+      avg_latency_ms: 80,
+      p95_latency_ms: 150,
+      availability_sla: 99.9,
+      rate_limit_per_minute: 120,
+    },
+    confidence: {
+      data_quality_score: 0.95,
+      update_frequency: "monthly",
+      sources: ["style_portfolios_latest"],
+    },
+    tags: ["funds", "cohort", "knowledge-mode", "differentiated-wedge"],
+  },
+  {
+    id: "style-cohort-rankings",
+    name: "Style Cohort Top-N Rankings",
+    description:
+      "Top-N rankings within a 9-box style cell × cohort_type × metric × period_window × " +
+      "weighting. cohort_type ∈ {symbol, sector, fund}. period_window ∈ {1m, 3m, 12m, 36m}. " +
+      "weighting ∈ {ew, mv} — ignored for cohort_type=fund (writer stores 'ew' placeholder). " +
+      "Top-N capped at 50 (Slice 9 storage ceiling).",
+    endpoint: "/api/funds/style/{slug}/rankings/{cohort_type}",
+    method: "GET",
+    parameters: {
+      slug: {
+        type: "string",
+        required: true,
+        description: "9-box style slug",
+      },
+      cohort_type: {
+        type: "string",
+        required: true,
+        description: "One of: symbol, sector, fund",
+        enum: ["symbol", "sector", "fund"],
+      },
+      metric: {
+        type: "string",
+        required: true,
+        description: "Metric to rank by (e.g. weight, gross_return, n_funds_holding).",
+      },
+      period_window: {
+        type: "string",
+        required: false,
+        description: "Trailing window (1m / 3m / 12m / 36m). Default 1m.",
+        default: "1m",
+        enum: ["1m", "3m", "12m", "36m"],
+      },
+      weighting: {
+        type: "string",
+        required: false,
+        description: "Cohort weighting (ew / mv). Default mv. Ignored for cohort_type=fund.",
+        default: "mv",
+        enum: ["ew", "mv"],
+      },
+      limit: {
+        type: "integer",
+        required: false,
+        description: "Max rows to return (default 25, capped 50).",
+        default: 25,
+        min: 1,
+        max: 50,
+      },
+    },
+    pricing: {
+      model: "per_request",
+      tier: "baseline",
+      cost_usd: 0.005,
+      currency: "USD",
+      billing_code: "style_cohort_rankings_v1",
+    },
+    performance: {
+      avg_latency_ms: 80,
+      p95_latency_ms: 150,
+      availability_sla: 99.9,
+      rate_limit_per_minute: 120,
+    },
+    confidence: {
+      data_quality_score: 0.95,
+      update_frequency: "monthly",
+      sources: ["style_rankings_top"],
+    },
+    tags: ["funds", "cohort", "rankings", "differentiated-wedge"],
+  },
 ];
 
 export async function getCapabilities(): Promise<Capability[]> {

--- a/lib/dal/funds-engine.ts
+++ b/lib/dal/funds-engine.ts
@@ -217,6 +217,131 @@ export async function searchFunds(
   }
 }
 
+// ---------------------------------------------------------------------------
+// Cohort tables — style_portfolios_latest, style_rankings_top
+// ---------------------------------------------------------------------------
+
+export interface StylePortfolioRow {
+  equity_style_9box: string;
+  weighting: "ew" | "mv";
+  report_date: string;
+  filing_date_max: string | null;
+  extracted_at: string | null;
+  portfolio_gross_return: number | null;
+  portfolio_market_return: number | null;
+  portfolio_sector_return: number | null;
+  portfolio_subsector_return: number | null;
+  portfolio_idiosyncratic_return: number | null;
+  identity_residual: number | null;
+  weight_sum: number | null;
+  n_holdings_active: number | null;
+  effective_n: number | null;
+  top10_weight_sum: number | null;
+  n_funds_in_cell: number | null;
+  model_version: string | null;
+  last_synced_at: string;
+  metadata: Record<string, unknown> | null;
+}
+
+const STYLE_PORTFOLIO_COLUMNS =
+  "equity_style_9box, weighting, report_date, filing_date_max, extracted_at, portfolio_gross_return, portfolio_market_return, portfolio_sector_return, portfolio_subsector_return, portfolio_idiosyncratic_return, identity_residual, weight_sum, n_holdings_active, effective_n, top10_weight_sum, n_funds_in_cell, model_version, last_synced_at, metadata";
+
+/**
+ * Latest cohort metrics for a 9-box cell. Returns both EW + MV rows when
+ * available (Slice 6 emits them side-by-side). Empty array if the cell has
+ * no data yet.
+ */
+export async function fetchStyleCohortLatest(
+  equityStyle9Box: string,
+): Promise<StylePortfolioRow[]> {
+  try {
+    const admin = createAdminClient();
+    const { data, error } = await admin
+      .from("style_portfolios_latest")
+      .select(STYLE_PORTFOLIO_COLUMNS)
+      .eq("equity_style_9box", equityStyle9Box);
+    if (error) {
+      console.error("[Funds DAL] fetchStyleCohortLatest error:", error);
+      return [];
+    }
+    return (data ?? []) as StylePortfolioRow[];
+  } catch (error) {
+    console.error("[Funds DAL] fetchStyleCohortLatest error:", error);
+    return [];
+  }
+}
+
+export type CohortType = "symbol" | "sector" | "fund";
+export type RankPeriodWindow = "1m" | "3m" | "12m" | "36m";
+export type Weighting = "ew" | "mv";
+
+export interface StyleRankingRow {
+  rank: number;
+  entity_id: string;
+  metric: string;
+  value: number | null;
+  cohort_size: number | null;
+  period_window: RankPeriodWindow;
+  weighting: Weighting;
+  report_date: string;
+  filing_date_max: string | null;
+}
+
+export interface FetchStyleRankingsOptions {
+  metric: string;
+  cohortType: CohortType;
+  periodWindow?: RankPeriodWindow;
+  weighting?: Weighting;
+  limit?: number;
+}
+
+const STYLE_RANKING_COLUMNS =
+  "rank, entity_id, metric, value, cohort_size, period_window, weighting, report_date, filing_date_max";
+
+/**
+ * Top-N rankings within a 9-box cell × cohort_type × metric × period_window
+ * × weighting. Always sorted by `rank` ascending. Cap N at 50 (data ceiling
+ * per Slice 9 default). For `cohort_type='fund'` the writer stores `'ew'`
+ * placeholder regardless of the requested weighting; we coerce here.
+ */
+export async function fetchStyleRankings(
+  equityStyle9Box: string,
+  options: FetchStyleRankingsOptions,
+): Promise<StyleRankingRow[]> {
+  const {
+    metric,
+    cohortType,
+    periodWindow = "1m",
+    limit = 25,
+  } = options;
+  const safeLimit = Math.min(Math.max(limit, 1), 50);
+  // For fund cohort: writer uses 'ew' as a NOT-NULL placeholder; ignore caller's choice.
+  const effectiveWeighting: Weighting =
+    cohortType === "fund" ? "ew" : options.weighting ?? "mv";
+
+  try {
+    const admin = createAdminClient();
+    const { data, error } = await admin
+      .from("style_rankings_top")
+      .select(STYLE_RANKING_COLUMNS)
+      .eq("equity_style_9box", equityStyle9Box)
+      .eq("cohort_type", cohortType)
+      .eq("metric", metric)
+      .eq("period_window", periodWindow)
+      .eq("weighting", effectiveWeighting)
+      .order("rank", { ascending: true })
+      .limit(safeLimit);
+    if (error) {
+      console.error("[Funds DAL] fetchStyleRankings error:", error);
+      return [];
+    }
+    return (data ?? []) as StyleRankingRow[];
+  } catch (error) {
+    console.error("[Funds DAL] fetchStyleRankings error:", error);
+    return [];
+  }
+}
+
 export async function getStyleCellMembers(
   equityStyle9Box: string,
   options: { primaryOnly?: boolean; limit?: number } = {},

--- a/mcp/data/openapi.json
+++ b/mcp/data/openapi.json
@@ -2213,6 +2213,221 @@
           }
         }
       },
+      "StyleCohortReturnsBlock": {
+        "type": "object",
+        "description": "Portfolio return components + diagnostics for one weighting in a cohort.",
+        "properties": {
+          "portfolio_gross_return": {
+            "type": "number",
+            "format": "float",
+            "nullable": true
+          },
+          "portfolio_market_return": {
+            "type": "number",
+            "format": "float",
+            "nullable": true
+          },
+          "portfolio_sector_return": {
+            "type": "number",
+            "format": "float",
+            "nullable": true
+          },
+          "portfolio_subsector_return": {
+            "type": "number",
+            "format": "float",
+            "nullable": true
+          },
+          "portfolio_idiosyncratic_return": {
+            "type": "number",
+            "format": "float",
+            "nullable": true
+          },
+          "identity_residual": {
+            "type": "number",
+            "format": "float",
+            "nullable": true
+          },
+          "weight_sum": {
+            "type": "number",
+            "format": "float",
+            "nullable": true,
+            "description": "Cohort coverage (fraction of cohort AUM in mapped symbols)."
+          },
+          "n_holdings_active": {
+            "type": "integer",
+            "nullable": true
+          },
+          "effective_n": {
+            "type": "number",
+            "format": "float",
+            "nullable": true
+          },
+          "top10_weight_sum": {
+            "type": "number",
+            "format": "float",
+            "nullable": true
+          }
+        }
+      },
+      "StyleCohortMetricsResponse": {
+        "type": "object",
+        "description": "Latest cohort metrics for a 9-box style cell. Both equal-weight (EW) and market-value-weighted (MV) cohort portfolios are returned side-by-side under `weightings`. Bitemporal lineage at top level.\n",
+        "required": [
+          "equity_style_9box",
+          "slug",
+          "report_date",
+          "weightings",
+          "_metadata"
+        ],
+        "properties": {
+          "equity_style_9box": {
+            "type": "string",
+            "example": "Large Blend"
+          },
+          "slug": {
+            "type": "string",
+            "example": "large-blend"
+          },
+          "report_date": {
+            "type": "string",
+            "format": "date"
+          },
+          "filing_date_max": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "n_funds_in_cell": {
+            "type": "integer",
+            "nullable": true
+          },
+          "weightings": {
+            "type": "object",
+            "properties": {
+              "ew": {
+                "$ref": "#/components/schemas/StyleCohortReturnsBlock"
+              },
+              "mv": {
+                "$ref": "#/components/schemas/StyleCohortReturnsBlock"
+              }
+            }
+          },
+          "_metadata": {
+            "type": "object",
+            "properties": {
+              "model_version": {
+                "type": "string",
+                "nullable": true
+              },
+              "data_as_of": {
+                "type": "string",
+                "format": "date"
+              },
+              "data_freshness": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "last_synced_at": {
+                "type": "string",
+                "format": "date-time"
+              }
+            }
+          }
+        }
+      },
+      "StyleCohortRankingRow": {
+        "type": "object",
+        "required": [
+          "rank",
+          "entity_id"
+        ],
+        "properties": {
+          "rank": {
+            "type": "integer",
+            "example": 1
+          },
+          "entity_id": {
+            "type": "string",
+            "description": "bw_sym_id (cohort=symbol), sector code (cohort=sector), or bw_fund_id (cohort=fund)."
+          },
+          "value": {
+            "type": "number",
+            "format": "float",
+            "nullable": true
+          },
+          "cohort_size": {
+            "type": "integer",
+            "nullable": true
+          }
+        }
+      },
+      "StyleCohortRankingsResponse": {
+        "type": "object",
+        "required": [
+          "equity_style_9box",
+          "slug",
+          "cohort_type",
+          "metric",
+          "period_window",
+          "weighting",
+          "report_date",
+          "n_returned",
+          "rows"
+        ],
+        "properties": {
+          "equity_style_9box": {
+            "type": "string"
+          },
+          "slug": {
+            "type": "string"
+          },
+          "cohort_type": {
+            "type": "string",
+            "enum": [
+              "symbol",
+              "sector",
+              "fund"
+            ]
+          },
+          "metric": {
+            "type": "string"
+          },
+          "period_window": {
+            "type": "string",
+            "enum": [
+              "1m",
+              "3m",
+              "12m",
+              "36m"
+            ]
+          },
+          "weighting": {
+            "type": "string",
+            "enum": [
+              "ew",
+              "mv"
+            ]
+          },
+          "report_date": {
+            "type": "string",
+            "format": "date"
+          },
+          "filing_date_max": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "n_returned": {
+            "type": "integer"
+          },
+          "rows": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/StyleCohortRankingRow"
+            }
+          }
+        }
+      },
       "FundHedgeLeg": {
         "type": "object",
         "description": "One ETF hedge leg at a given factor level.",
@@ -7966,6 +8181,278 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/funds/style/{slug}": {
+      "get": {
+        "summary": "Latest cohort metrics for a 9-box style cell",
+        "description": "Latest portfolio return decomposition + diagnostics for a 9-box style cell, aggregated across all funds in the cell. Both EW and MV cohort portfolios are returned side-by-side under `weightings`.\n\nThe differentiated wedge: Morningstar reports per-fund metrics but doesn't expose cohort aggregates with this attribution depth.\n",
+        "operationId": "getStyleCohortMetrics",
+        "tags": [
+          "Funds"
+        ],
+        "x-pricing": {
+          "capability_id": "style-cohort-metrics",
+          "tier": "baseline",
+          "cost_usd": 0.005,
+          "billing_code": "style_cohort_metrics_v1"
+        },
+        "parameters": [
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "large-value",
+                "large-blend",
+                "large-growth",
+                "mid-value",
+                "mid-blend",
+                "mid-growth",
+                "small-value",
+                "small-blend",
+                "small-growth"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Latest cohort metrics (both weightings).",
+            "headers": {
+              "X-Data-As-Of": {
+                "schema": {
+                  "type": "string",
+                  "format": "date"
+                }
+              },
+              "X-Data-Filing-Date": {
+                "schema": {
+                  "type": "string",
+                  "format": "date"
+                }
+              },
+              "X-Risk-Model-Version": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-API-Cost-USD": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StyleCohortMetricsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid style slug.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Insufficient prepaid balance.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InsufficientBalance"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No cohort metrics available for this cell.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RateLimitExceeded"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/funds/style/{slug}/rankings/{cohort_type}": {
+      "get": {
+        "summary": "Top-N rankings within a 9-box style cell",
+        "description": "Top-N rankings within a 9-box style cell × cohort_type × metric × period_window × weighting. `cohort_type` selects what gets ranked: symbols (holdings), sector codes, or funds.\n\nFor `cohort_type=fund`, the `weighting` parameter is ignored (writer stores `'ew'` placeholder since fund returns are scalar). Top-N is capped at 50 — the data ceiling per Slice 9.\n",
+        "operationId": "getStyleCohortRankings",
+        "tags": [
+          "Funds"
+        ],
+        "x-pricing": {
+          "capability_id": "style-cohort-rankings",
+          "tier": "baseline",
+          "cost_usd": 0.005,
+          "billing_code": "style_cohort_rankings_v1"
+        },
+        "parameters": [
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "cohort_type",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "symbol",
+                "sector",
+                "fund"
+              ]
+            }
+          },
+          {
+            "name": "metric",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Metric to rank by (e.g. weight, gross_return, n_funds_holding)."
+          },
+          {
+            "name": "period_window",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "1m",
+                "3m",
+                "12m",
+                "36m"
+              ],
+              "default": "1m"
+            }
+          },
+          {
+            "name": "weighting",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "ew",
+                "mv"
+              ],
+              "default": "mv"
+            },
+            "description": "Ignored for cohort_type=fund."
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 50,
+              "default": 25
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Top-N ranked rows.",
+            "headers": {
+              "X-Data-As-Of": {
+                "schema": {
+                  "type": "string",
+                  "format": "date"
+                }
+              },
+              "X-Data-Filing-Date": {
+                "schema": {
+                  "type": "string",
+                  "format": "date"
+                }
+              },
+              "X-API-Cost-USD": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StyleCohortRankingsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid slug, cohort_type, period_window, weighting, or missing metric.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Insufficient prepaid balance.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InsufficientBalance"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No rankings for this combination.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RateLimitExceeded"
                 }
               }
             }

--- a/tests/funds-cohort-routes.test.ts
+++ b/tests/funds-cohort-routes.test.ts
@@ -1,0 +1,205 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest, type NextResponse } from "next/server";
+
+vi.mock("@/lib/agent/billing-middleware", () => ({
+  withBilling: <T extends (...args: unknown[]) => unknown>(handler: T) => handler,
+}));
+
+vi.mock("@/lib/dal/funds-engine", () => ({
+  fetchStyleCohortLatest: vi.fn(),
+  fetchStyleRankings: vi.fn(),
+}));
+
+import { fetchStyleCohortLatest, fetchStyleRankings } from "@/lib/dal/funds-engine";
+import type { BillingContext } from "@/lib/agent/billing-middleware";
+import { GET as wrappedCohortGET } from "@/app/api/funds/style/[slug]/route";
+import { GET as wrappedRankingsGET } from "@/app/api/funds/style/[slug]/rankings/[cohort_type]/route";
+
+const cohortGET = wrappedCohortGET as unknown as (
+  req: NextRequest,
+  ctx: BillingContext,
+) => Promise<NextResponse>;
+const rankingsGET = wrappedRankingsGET as unknown as (
+  req: NextRequest,
+  ctx: BillingContext,
+) => Promise<NextResponse>;
+
+const fakeContext: BillingContext = {
+  userId: "test-user",
+  requestId: "test-req",
+  capabilityId: "style-cohort-metrics",
+  costUsd: 0.005,
+  startTime: Date.now(),
+};
+
+function req(path: string): NextRequest {
+  return new NextRequest(new Request(`http://localhost${path}`));
+}
+
+const STYLE_LB_EW = {
+  equity_style_9box: "Large Blend",
+  weighting: "ew" as const,
+  report_date: "2026-04-30",
+  filing_date_max: "2026-07-14",
+  extracted_at: "2026-05-02T16:41:31.441605+00:00",
+  portfolio_gross_return: 0.071,
+  portfolio_market_return: 0.099,
+  portfolio_sector_return: -0.01,
+  portfolio_subsector_return: -0.01,
+  portfolio_idiosyncratic_return: -0.005,
+  identity_residual: -0.003,
+  weight_sum: 0.99,
+  n_holdings_active: 2325,
+  effective_n: 65.2,
+  top10_weight_sum: 0.34,
+  n_funds_in_cell: 1234,
+  model_version: "funds_dag.v20260502",
+  last_synced_at: "2026-05-02T16:41:31.441605+00:00",
+  metadata: {},
+};
+const STYLE_LB_MV = {
+  ...STYLE_LB_EW,
+  weighting: "mv" as const,
+  portfolio_gross_return: 0.082,
+  effective_n: 50.1,
+};
+
+beforeEach(() => {
+  vi.mocked(fetchStyleCohortLatest).mockReset();
+  vi.mocked(fetchStyleRankings).mockReset();
+});
+
+describe("GET /api/funds/style/[slug]", () => {
+  it("returns 200 with both EW + MV under weightings; bitemporal headers", async () => {
+    vi.mocked(fetchStyleCohortLatest).mockResolvedValue([
+      STYLE_LB_EW,
+      STYLE_LB_MV,
+    ]);
+    const res = await cohortGET(req("/api/funds/style/large-blend"), fakeContext);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("X-Data-As-Of")).toBe("2026-04-30");
+    expect(res.headers.get("X-Data-Filing-Date")).toBe("2026-07-14");
+    expect(res.headers.get("X-Risk-Model-Version")).toBe("funds_dag.v20260502");
+    expect(vi.mocked(fetchStyleCohortLatest)).toHaveBeenCalledWith("Large Blend");
+    const body = await res.json();
+    expect(body.equity_style_9box).toBe("Large Blend");
+    expect(body.slug).toBe("large-blend");
+    expect(body.n_funds_in_cell).toBe(1234);
+    expect(body.weightings.ew.portfolio_gross_return).toBeCloseTo(0.071);
+    expect(body.weightings.mv.portfolio_gross_return).toBeCloseTo(0.082);
+  });
+
+  it("returns 400 for unknown slug; doesn't hit DAL", async () => {
+    const res = await cohortGET(
+      req("/api/funds/style/mega-blend"),
+      fakeContext,
+    );
+    expect(res.status).toBe(400);
+    expect(vi.mocked(fetchStyleCohortLatest)).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when DAL returns no rows", async () => {
+    vi.mocked(fetchStyleCohortLatest).mockResolvedValue([]);
+    const res = await cohortGET(req("/api/funds/style/large-blend"), fakeContext);
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("GET /api/funds/style/[slug]/rankings/[cohort_type]", () => {
+  const RANK_ROW = {
+    rank: 1,
+    entity_id: "BW-BBG000BPH459",
+    metric: "weight",
+    value: 0.04,
+    cohort_size: 3469,
+    period_window: "1m" as const,
+    weighting: "mv" as const,
+    report_date: "2026-04-30",
+    filing_date_max: "2026-07-14",
+  };
+
+  const rankCtx: BillingContext = { ...fakeContext, capabilityId: "style-cohort-rankings" };
+
+  it("returns 200 with rows + bitemporal headers; defaults applied", async () => {
+    vi.mocked(fetchStyleRankings).mockResolvedValue([RANK_ROW]);
+    const res = await rankingsGET(
+      req("/api/funds/style/large-blend/rankings/symbol?metric=weight"),
+      rankCtx,
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("X-Data-As-Of")).toBe("2026-04-30");
+    expect(vi.mocked(fetchStyleRankings)).toHaveBeenCalledWith("Large Blend", {
+      metric: "weight",
+      cohortType: "symbol",
+      periodWindow: "1m",
+      weighting: "mv",
+      limit: 25,
+    });
+    const body = await res.json();
+    expect(body.equity_style_9box).toBe("Large Blend");
+    expect(body.cohort_type).toBe("symbol");
+    expect(body.period_window).toBe("1m");
+    expect(body.weighting).toBe("mv");
+    expect(body.rows).toHaveLength(1);
+    expect(body.rows[0].entity_id).toBe("BW-BBG000BPH459");
+  });
+
+  it("forwards custom params + clamps limit at 50", async () => {
+    vi.mocked(fetchStyleRankings).mockResolvedValue([RANK_ROW]);
+    await rankingsGET(
+      req(
+        "/api/funds/style/small-value/rankings/sector?metric=gross_return&period_window=12m&weighting=ew&limit=999",
+      ),
+      rankCtx,
+    );
+    expect(vi.mocked(fetchStyleRankings)).toHaveBeenCalledWith("Small Value", {
+      metric: "gross_return",
+      cohortType: "sector",
+      periodWindow: "12m",
+      weighting: "ew",
+      limit: 50,
+    });
+  });
+
+  it("rejects missing metric", async () => {
+    const res = await rankingsGET(
+      req("/api/funds/style/large-blend/rankings/symbol"),
+      rankCtx,
+    );
+    expect(res.status).toBe(400);
+    expect(vi.mocked(fetchStyleRankings)).not.toHaveBeenCalled();
+  });
+
+  it("rejects invalid slug", async () => {
+    const res = await rankingsGET(
+      req("/api/funds/style/mega-blend/rankings/symbol?metric=weight"),
+      rankCtx,
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects invalid cohort_type", async () => {
+    const res = await rankingsGET(
+      req("/api/funds/style/large-blend/rankings/etf?metric=weight"),
+      rankCtx,
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects invalid period_window", async () => {
+    const res = await rankingsGET(
+      req("/api/funds/style/large-blend/rankings/symbol?metric=weight&period_window=2y"),
+      rankCtx,
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when DAL returns []", async () => {
+    vi.mocked(fetchStyleRankings).mockResolvedValue([]);
+    const res = await rankingsGET(
+      req("/api/funds/style/large-blend/rankings/symbol?metric=weight"),
+      rankCtx,
+    );
+    expect(res.status).toBe(404);
+  });
+});

--- a/tests/funds-engine.test.ts
+++ b/tests/funds-engine.test.ts
@@ -8,6 +8,8 @@ import { createAdminClient } from "@/lib/supabase/admin";
 import {
   fetchFund,
   fetchFundLatest,
+  fetchStyleCohortLatest,
+  fetchStyleRankings,
   getStyleCellMembers,
   resolveFundById,
   resolveFundsByIds,
@@ -235,6 +237,97 @@ describe("getStyleCellMembers", () => {
       funds: { data: null, error: { message: "fail" } },
     });
     const r = await getStyleCellMembers("Large Blend");
+    expect(r).toEqual([]);
+  });
+});
+
+const STYLE_LB_EW = {
+  equity_style_9box: "Large Blend",
+  weighting: "ew" as const,
+  report_date: "2026-04-30",
+  filing_date_max: "2026-07-14",
+  extracted_at: "2026-05-02T16:41:31.441605+00:00",
+  portfolio_gross_return: 0.071,
+  portfolio_market_return: 0.099,
+  portfolio_sector_return: -0.01,
+  portfolio_subsector_return: -0.01,
+  portfolio_idiosyncratic_return: -0.005,
+  identity_residual: -0.003,
+  weight_sum: 0.99,
+  n_holdings_active: 2325,
+  effective_n: 65.2,
+  top10_weight_sum: 0.34,
+  n_funds_in_cell: 1234,
+  model_version: "funds_dag.v20260502",
+  last_synced_at: "2026-05-02T16:41:31.441605+00:00",
+  metadata: {},
+};
+const STYLE_LB_MV = { ...STYLE_LB_EW, weighting: "mv" as const };
+
+describe("fetchStyleCohortLatest", () => {
+  it("returns both EW and MV rows when present", async () => {
+    setMockClient({
+      style_portfolios_latest: { data: [STYLE_LB_EW, STYLE_LB_MV], error: null },
+    });
+    const r = await fetchStyleCohortLatest("Large Blend");
+    expect(r).toHaveLength(2);
+    expect(r.map((x) => x.weighting).sort()).toEqual(["ew", "mv"]);
+  });
+
+  it("returns [] on error", async () => {
+    setMockClient({
+      style_portfolios_latest: { data: null, error: { message: "boom" } },
+    });
+    const r = await fetchStyleCohortLatest("Large Blend");
+    expect(r).toEqual([]);
+  });
+});
+
+describe("fetchStyleRankings", () => {
+  const RANK_ROW = {
+    rank: 1,
+    entity_id: "BW-BBG000BPH459",
+    metric: "weight",
+    value: 0.04,
+    cohort_size: 3469,
+    period_window: "1m" as const,
+    weighting: "mv" as const,
+    report_date: "2026-04-30",
+    filing_date_max: "2026-07-14",
+  };
+
+  it("returns ranked rows for valid params", async () => {
+    setMockClient({
+      style_rankings_top: { data: [RANK_ROW], error: null },
+    });
+    const r = await fetchStyleRankings("Large Blend", {
+      metric: "weight",
+      cohortType: "symbol",
+    });
+    expect(r).toHaveLength(1);
+    expect(r[0].entity_id).toBe("BW-BBG000BPH459");
+  });
+
+  it("clamps limit at 50 and returns []", async () => {
+    setMockClient({
+      style_rankings_top: { data: [], error: null },
+    });
+    const r = await fetchStyleRankings("Large Blend", {
+      metric: "weight",
+      cohortType: "symbol",
+      limit: 999,
+    });
+    expect(r).toEqual([]);
+  });
+
+  it("returns [] on error", async () => {
+    setMockClient({
+      style_rankings_top: { data: null, error: { message: "boom" } },
+    });
+    const r = await fetchStyleRankings("Large Blend", {
+      metric: "weight",
+      cohortType: "symbol",
+    });
     expect(r).toEqual([]);
   });
 });


### PR DESCRIPTION
First two of four Stage C endpoints — both are pure-Supabase reads against tables that are **already populated** (\`style_portfolios_latest\` 18 rows, \`style_rankings_top\` 35,406 rows). End-to-end smoke testable on day one.

## Routes

| Route | Source | Pricing |
|---|---|---|
| \`GET /api/funds/style/{slug}\` | \`style_portfolios_latest\` (Supabase) | $0.005 \`style-cohort-metrics\` |
| \`GET /api/funds/style/{slug}/rankings/{cohort_type}\` | \`style_rankings_top\` (Supabase) | $0.005 \`style-cohort-rankings\` |

### \`/funds/style/{slug}\` shape
Returns both EW + MV cohort portfolios side-by-side under \`weightings\`:
\`\`\`json
{
  "equity_style_9box": "Large Blend",
  "slug": "large-blend",
  "report_date": "2026-04-30",
  "filing_date_max": "2026-07-14",
  "n_funds_in_cell": 1234,
  "weightings": {
    "ew": { "portfolio_gross_return": 0.071, ... },
    "mv": { "portfolio_gross_return": 0.082, ... }
  },
  "_metadata": { "model_version": "funds_dag.v20260502", ... }
}
\`\`\`

### \`/funds/style/{slug}/rankings/{cohort_type}\` shape
\`cohort_type\` ∈ \`{symbol, sector, fund}\`. Defaults: \`period_window=1m\`, \`weighting=mv\`, \`limit=25\` (capped 50). For \`cohort_type=fund\`, \`weighting\` is ignored (writer stores \`ew\` placeholder per Slice 9).

## The differentiated wedge

Morningstar reports per-fund metrics but doesn't expose cohort aggregates with this attribution depth. \`/funds/style/large-blend\` returns *the cohort itself* as a portfolio — gross / market / sector / subsector / idiosyncratic decomposition for "the average Large Blend fund (cap-weighted)" and "the equal-weighted Large Blend cohort." That's not a Morningstar surface today.

## Bitemporal headers

Every 200 sets:
- \`X-Data-As-Of: <report_date>\`
- \`X-Data-Filing-Date: <filing_date_max>\`
- \`X-Risk-Model-Version\` (cohort metrics only — rankings table doesn't carry it)

## Tests

- \`tests/funds-engine.test.ts\` — +4 DAL tests (fetchStyleCohortLatest, fetchStyleRankings)
- \`tests/funds-cohort-routes.test.ts\` — 10 new route tests
- Full suite: 156/156 passing

## Test plan

- [x] \`npm test\` — 156/156 (15 new in C.0 + C.1)
- [x] \`npm run typecheck\` — clean
- [x] \`npm run lint\` — clean
- [x] \`npm run cli:openapi-check\` — clean
- [x] \`npm run build:openapi\` — yaml→json regenerates without error
- [ ] Mirror PR on Risk_Models for the regenerated \`mcp/data/openapi.json\` (will open with this PR; needs to merge first to clear \`detect-drift\`)
- [ ] Smoke against staging: \`GET /api/funds/style/large-blend\` and \`GET /api/funds/style/large-blend/rankings/symbol?metric=weight\` should return real data immediately (no Slice 11 dependency for these)

## Out of scope (Stage C PR 2)

- \`GET /api/funds/style/{slug}/portfolio\` (per-cell Zarr time series)
- \`GET /api/funds/style/{slug}/holdings\` (per-cell aggregated symbols, Slice 5b)

🤖 Generated with [Claude Code](https://claude.com/claude-code)