### PR TITLE
Funds Stage C.2 + C.3: cohort portfolio history + top-N holdings (Zarr)

### DIFF
--- a/OPENAPI_SPEC.yaml
+++ b/OPENAPI_SPEC.yaml
@@ -1855,6 +1855,68 @@ components:
         count:
           type: integer
 
+    CohortPortfolioRow:
+      type: object
+      description: One teo of a cohort portfolio time series. Both EW + MV blocks side-by-side.
+      required: [teo]
+      properties:
+        teo: { type: string, format: date, example: "2026-04-30" }
+        ew: { $ref: "#/components/schemas/StyleCohortReturnsBlock" }
+        mv: { $ref: "#/components/schemas/StyleCohortReturnsBlock" }
+
+    CohortPortfolioHistoryResponse:
+      type: object
+      description: >
+        Per-cell cohort portfolio time series from Slice 6's per-cell
+        ds_portfolio.zarr. Each row carries both EW and MV blocks.
+      required: [equity_style_9box, slug, n_periods, start_teo, end_teo, rows]
+      properties:
+        equity_style_9box: { type: string }
+        slug: { type: string }
+        n_periods: { type: integer }
+        start_teo: { type: string, format: date }
+        end_teo: { type: string, format: date }
+        rows:
+          type: array
+          items: { $ref: "#/components/schemas/CohortPortfolioRow" }
+
+    CohortHolding:
+      type: object
+      description: One cohort-aggregated holding within a 9-box cell.
+      required: [bw_sym_id, weight]
+      properties:
+        bw_sym_id:
+          type: string
+          description: Internal symbol id. Resolve via /api/data/symbols/batch.
+        weight:
+          type: number
+          format: float
+          description: Cohort weight at this teo (sums to 1.0 within the chosen weighting).
+        contribution_gross: { type: number, format: float, nullable: true }
+        contribution_market: { type: number, format: float, nullable: true }
+        contribution_sector: { type: number, format: float, nullable: true }
+        contribution_subsector: { type: number, format: float, nullable: true }
+        contribution_idiosyncratic: { type: number, format: float, nullable: true }
+        n_funds_holding:
+          type: integer
+          nullable: true
+          description: Number of funds in the cell holding this symbol.
+
+    CohortHoldingsResponse:
+      type: object
+      description: Top-N cohort holdings at the latest teo for the chosen weighting.
+      required: [equity_style_9box, slug, teo, weighting, n_returned, n_total_holdings, holdings]
+      properties:
+        equity_style_9box: { type: string }
+        slug: { type: string }
+        teo: { type: string, format: date }
+        weighting: { type: string, enum: [ew, mv] }
+        n_returned: { type: integer }
+        n_total_holdings: { type: integer }
+        holdings:
+          type: array
+          items: { $ref: "#/components/schemas/CohortHolding" }
+
     StyleCohortReturnsBlock:
       type: object
       description: Portfolio return components + diagnostics for one weighting in a cohort.
@@ -5597,6 +5659,126 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+
+  /funds/style/{slug}/portfolio:
+    get:
+      summary: Per-cell cohort portfolio time series
+      description: >
+        Time series of cohort portfolio metrics from Slice 6's per-cell
+        `ds_portfolio.zarr` on GCS. Each row carries both EW and MV
+        blocks side-by-side. Optional inclusive `start_date` / `end_date`
+        params trim the panel.
+      operationId: getStyleCohortPortfolioHistory
+      tags: [Funds]
+      x-pricing:
+        capability_id: style-cohort-portfolio-history
+        tier: baseline
+        cost_usd: 0.005
+        billing_code: style_cohort_portfolio_history_v1
+      parameters:
+        - name: slug
+          in: path
+          required: true
+          schema: { type: string }
+        - name: start_date
+          in: query
+          required: false
+          schema: { type: string, format: date }
+        - name: end_date
+          in: query
+          required: false
+          schema: { type: string, format: date }
+      responses:
+        "200":
+          description: Cohort time series rows.
+          headers:
+            X-Data-As-Of: { schema: { type: string, format: date } }
+            X-API-Cost-USD: { schema: { type: string } }
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/CohortPortfolioHistoryResponse" }
+        "400":
+          description: Invalid slug or malformed date params.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/ErrorResponse" }
+        "402":
+          description: Insufficient prepaid balance.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/InsufficientBalance" }
+        "404":
+          description: No cohort portfolio history available for this cell.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/ErrorResponse" }
+        "429":
+          description: Rate limit exceeded.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/RateLimitExceeded" }
+
+  /funds/style/{slug}/holdings:
+    get:
+      summary: Top-N cohort holdings within a 9-box style cell
+      description: >
+        Top-N cohort holdings at the latest teo. Reads `weight (teo, symbol,
+        weighting)` and `contribution_*` / `n_funds_holding` from Slice 5b's
+        per-cell `ds_symbols.zarr`. Sorted by `weight` descending.
+
+
+        `?weighting` defaults to `mv` (market-cap-weighted, Morningstar-
+        comparable). Switch to `ew` to see equal-weight cohort exposures —
+        radically different top-N lists for non-uniform cells.
+      operationId: getStyleCohortHoldings
+      tags: [Funds]
+      x-pricing:
+        capability_id: style-cohort-holdings
+        tier: baseline
+        cost_usd: 0.005
+        billing_code: style_cohort_holdings_v1
+      parameters:
+        - name: slug
+          in: path
+          required: true
+          schema: { type: string }
+        - name: weighting
+          in: query
+          required: false
+          schema: { type: string, enum: [ew, mv], default: mv }
+        - name: limit
+          in: query
+          required: false
+          schema: { type: integer, minimum: 1, maximum: 100, default: 25 }
+      responses:
+        "200":
+          description: Top-N cohort holdings snapshot.
+          headers:
+            X-Data-As-Of: { schema: { type: string, format: date } }
+            X-API-Cost-USD: { schema: { type: string } }
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/CohortHoldingsResponse" }
+        "400":
+          description: Invalid slug, weighting, or limit.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/ErrorResponse" }
+        "402":
+          description: Insufficient prepaid balance.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/InsufficientBalance" }
+        "404":
+          description: No cohort holdings panel available.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/ErrorResponse" }
+        "429":
+          description: Rate limit exceeded.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/RateLimitExceeded" }
 
   /funds/style/{slug}:
     get:

--- a/app/api/funds/style/[slug]/holdings/route.ts
+++ b/app/api/funds/style/[slug]/holdings/route.ts
@@ -1,0 +1,84 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { withBilling, type BillingContext } from "@/lib/agent/billing-middleware";
+import { readStyleCohortHoldingsTopN } from "@/lib/dal/funds-zarr-reader";
+import { styleSlugToName, styleSlugToPathComponent } from "@/lib/funds/style-slug";
+
+export const dynamic = "force-dynamic";
+
+const DEFAULT_TOP_N = 25;
+const MAX_TOP_N = 100;
+
+/**
+ * GET /api/funds/style/{slug}/holdings?weighting=mv&limit=25
+ *
+ * Top-N cohort holdings at the latest teo. Reads `weight (teo, symbol, weighting)`
+ * and contribution_* / n_funds_holding from Slice 5b's per-cell
+ * `equity_style_9box/{Cell_Name}/ds_symbols.zarr`. Sorts by `weight` desc.
+ *
+ * `?weighting` defaults to `mv` (market-cap-weighted, Morningstar-comparable).
+ * Switch to `ew` to see equal-weight cohort exposures — radically different
+ * top-N lists for non-uniform cells.
+ */
+export const GET = withBilling(
+  async (request: NextRequest, _context: BillingContext) => {
+    const segments = request.nextUrl.pathname.split("/");
+    const slug = segments[segments.length - 2];
+    const cellName = styleSlugToName(slug ?? "");
+    const pathComponent = styleSlugToPathComponent(slug ?? "");
+    if (!cellName || !pathComponent) {
+      return NextResponse.json(
+        { error: `Invalid style slug: ${slug}` },
+        { status: 400 },
+      );
+    }
+
+    const sp = request.nextUrl.searchParams;
+    const weighting = (sp.get("weighting") ?? "mv") as "ew" | "mv";
+    if (weighting !== "ew" && weighting !== "mv") {
+      return NextResponse.json(
+        { error: "weighting must be one of: ew, mv" },
+        { status: 400 },
+      );
+    }
+
+    const limitParam = sp.get("limit");
+    let limit = DEFAULT_TOP_N;
+    if (limitParam !== null) {
+      const parsed = Number(limitParam);
+      if (!Number.isFinite(parsed) || parsed < 1) {
+        return NextResponse.json(
+          { error: "limit must be a positive integer" },
+          { status: 400 },
+        );
+      }
+      limit = Math.min(Math.floor(parsed), MAX_TOP_N);
+    }
+
+    const snapshot = await readStyleCohortHoldingsTopN(pathComponent, {
+      weighting,
+      n: limit,
+    });
+    if (!snapshot) {
+      return NextResponse.json(
+        {
+          error: "No cohort holdings panel available for this cell",
+          equity_style_9box: cellName,
+          slug,
+        },
+        { status: 404 },
+      );
+    }
+
+    const headers = new Headers({ "X-Data-As-Of": snapshot.teo });
+
+    return NextResponse.json(
+      {
+        equity_style_9box: cellName,
+        slug,
+        ...snapshot,
+      },
+      { headers },
+    );
+  },
+  { capabilityId: "style-cohort-holdings" },
+);

--- a/app/api/funds/style/[slug]/portfolio/route.ts
+++ b/app/api/funds/style/[slug]/portfolio/route.ts
@@ -1,0 +1,83 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { withBilling, type BillingContext } from "@/lib/agent/billing-middleware";
+import { readStyleCohortPortfolioSeries } from "@/lib/dal/funds-zarr-reader";
+import { styleSlugToName, styleSlugToPathComponent } from "@/lib/funds/style-slug";
+
+export const dynamic = "force-dynamic";
+
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * GET /api/funds/style/{slug}/portfolio?start_date=&end_date=
+ *
+ * Per-cell cohort portfolio time series from Slice 6's
+ * `portfolio_style/{Cell_Name}/ds_portfolio.zarr` on GCS. Each row carries
+ * both `ew` and `mv` blocks side-by-side for the same teo. Optional inclusive
+ * date params trim the panel; default = full history.
+ */
+export const GET = withBilling(
+  async (request: NextRequest, _context: BillingContext) => {
+    const segments = request.nextUrl.pathname.split("/");
+    const slug = segments[segments.length - 2];
+    const cellName = styleSlugToName(slug ?? "");
+    const pathComponent = styleSlugToPathComponent(slug ?? "");
+    if (!cellName || !pathComponent) {
+      return NextResponse.json(
+        { error: `Invalid style slug: ${slug}` },
+        { status: 400 },
+      );
+    }
+
+    const sp = request.nextUrl.searchParams;
+    const startDate = sp.get("start_date") ?? undefined;
+    const endDate = sp.get("end_date") ?? undefined;
+    if (startDate && !ISO_DATE.test(startDate)) {
+      return NextResponse.json(
+        { error: "start_date must be YYYY-MM-DD" },
+        { status: 400 },
+      );
+    }
+    if (endDate && !ISO_DATE.test(endDate)) {
+      return NextResponse.json(
+        { error: "end_date must be YYYY-MM-DD" },
+        { status: 400 },
+      );
+    }
+    if (startDate && endDate && startDate > endDate) {
+      return NextResponse.json(
+        { error: "start_date must be <= end_date" },
+        { status: 400 },
+      );
+    }
+
+    const rows = await readStyleCohortPortfolioSeries(pathComponent, {
+      startDate,
+      endDate,
+    });
+    if (rows.length === 0) {
+      return NextResponse.json(
+        {
+          error: "No cohort portfolio history available for this cell",
+          equity_style_9box: cellName,
+          slug,
+        },
+        { status: 404 },
+      );
+    }
+
+    const headers = new Headers({ "X-Data-As-Of": rows[rows.length - 1]!.teo });
+
+    return NextResponse.json(
+      {
+        equity_style_9box: cellName,
+        slug,
+        n_periods: rows.length,
+        start_teo: rows[0]!.teo,
+        end_teo: rows[rows.length - 1]!.teo,
+        rows,
+      },
+      { headers },
+    );
+  },
+  { capabilityId: "style-cohort-portfolio-history" },
+);

--- a/lib/agent/capabilities.ts
+++ b/lib/agent/capabilities.ts
@@ -1274,6 +1274,88 @@ export const CAPABILITIES: Capability[] = [
     },
     tags: ["funds", "cohort", "rankings", "differentiated-wedge"],
   },
+  {
+    id: "style-cohort-portfolio-history",
+    name: "Style Cohort Portfolio History",
+    description:
+      "Per-cell cohort portfolio time series. Reads Slice 6's per-cell ds_portfolio.zarr " +
+      "(dims teo, weighting). Each row carries both EW and MV blocks side-by-side. Optional " +
+      "?start_date and ?end_date (inclusive YYYY-MM-DD) trim the panel.",
+    endpoint: "/api/funds/style/{slug}/portfolio",
+    method: "GET",
+    parameters: {
+      slug: { type: "string", required: true, description: "9-box style slug" },
+      start_date: { type: "string", required: false, description: "Inclusive lower bound YYYY-MM-DD" },
+      end_date: { type: "string", required: false, description: "Inclusive upper bound YYYY-MM-DD" },
+    },
+    pricing: {
+      model: "per_request",
+      tier: "baseline",
+      cost_usd: 0.005,
+      currency: "USD",
+      billing_code: "style_cohort_portfolio_history_v1",
+    },
+    performance: {
+      avg_latency_ms: 200,
+      p95_latency_ms: 500,
+      availability_sla: 99.9,
+      rate_limit_per_minute: 60,
+    },
+    confidence: {
+      data_quality_score: 0.95,
+      update_frequency: "monthly",
+      sources: ["portfolio_style/{Cell_Name}/ds_portfolio.zarr"],
+    },
+    tags: ["funds", "cohort", "history", "time-series"],
+  },
+  {
+    id: "style-cohort-holdings",
+    name: "Style Cohort Top-N Holdings",
+    description:
+      "Top-N cohort holdings at the latest teo. Reads weight (teo, symbol, weighting) and " +
+      "contribution_* / n_funds_holding from Slice 5b's per-cell ds_symbols.zarr. Sorted by " +
+      "weight desc. ?weighting defaults to mv (Morningstar-comparable); switch to ew for " +
+      "equal-weight cohort exposures. ?limit default 25, capped 100.",
+    endpoint: "/api/funds/style/{slug}/holdings",
+    method: "GET",
+    parameters: {
+      slug: { type: "string", required: true, description: "9-box style slug" },
+      weighting: {
+        type: "string",
+        required: false,
+        description: "ew or mv (default mv)",
+        default: "mv",
+        enum: ["ew", "mv"],
+      },
+      limit: {
+        type: "integer",
+        required: false,
+        description: "Max holdings (default 25, capped 100)",
+        default: 25,
+        min: 1,
+        max: 100,
+      },
+    },
+    pricing: {
+      model: "per_request",
+      tier: "baseline",
+      cost_usd: 0.005,
+      currency: "USD",
+      billing_code: "style_cohort_holdings_v1",
+    },
+    performance: {
+      avg_latency_ms: 200,
+      p95_latency_ms: 500,
+      availability_sla: 99.9,
+      rate_limit_per_minute: 60,
+    },
+    confidence: {
+      data_quality_score: 0.95,
+      update_frequency: "monthly",
+      sources: ["equity_style_9box/{Cell_Name}/ds_symbols.zarr"],
+    },
+    tags: ["funds", "cohort", "holdings", "differentiated-wedge"],
+  },
 ];
 
 export async function getCapabilities(): Promise<Capability[]> {

--- a/lib/dal/funds-zarr-reader.ts
+++ b/lib/dal/funds-zarr-reader.ts
@@ -85,12 +85,11 @@ function parseFundsZarrPrefix(): { bucket: string; basePath: string } {
   return { bucket: raw.slice(0, i), basePath: raw.slice(i + 1).replace(/\/$/, "") };
 }
 
-async function openFundZarrGroup(
-  bwFundId: string,
-  basename: string,
+async function openZarrGroupAt(
+  relativePath: string,
 ): Promise<Group<Readable> | null> {
   const { bucket: bucketName, basePath } = parseFundsZarrPrefix();
-  const fullPrefix = `${basePath}/bw_fund_id/${bwFundId}/${basename}`
+  const fullPrefix = `${basePath}/${relativePath}`
     .replace(/\/+/g, "/")
     .replace(/^\//, "");
   try {
@@ -103,6 +102,22 @@ async function openFundZarrGroup(
     console.error("[funds-zarr] open group failed");
     return null;
   }
+}
+
+async function openFundZarrGroup(
+  bwFundId: string,
+  basename: string,
+): Promise<Group<Readable> | null> {
+  return openZarrGroupAt(`bw_fund_id/${bwFundId}/${basename}`);
+}
+
+/** Per-cell stores: portfolio_style/{Cell_Name}/... and equity_style_9box/{Cell_Name}/... */
+async function openCohortZarrGroup(
+  kind: "portfolio_style" | "equity_style_9box",
+  pathComponent: string,
+  basename: string,
+): Promise<Group<Readable> | null> {
+  return openZarrGroupAt(`${kind}/${pathComponent}/${basename}`);
 }
 
 function nsToIsoDate(ns: bigint): string {
@@ -498,4 +513,315 @@ export async function readFundHedgeLatest(
     return null;
   }
   return out;
+}
+
+// ---------------------------------------------------------------------------
+// Per-cell cohort portfolio — Slice 6 (portfolio_style/{Cell_Name}/ds_portfolio.zarr)
+// dims (teo, weighting); weighting = ['ew', 'mv'].
+// ---------------------------------------------------------------------------
+
+/** Read coord values for `weighting` (e.g. ["ew","mv"]). */
+async function readWeightingCoord(
+  grp: Group<Readable>,
+): Promise<string[] | null> {
+  try {
+    const loc = grp.resolve("weighting");
+    const arr = await open.v2(loc, { kind: "array" });
+    const ch = await get(arr, null);
+    const d = ch?.data;
+    if (d instanceof UnicodeStringArray) {
+      const out: string[] = [];
+      for (let i = 0; i < d.length; i++) out.push(String(d.get(i)).trim());
+      return out;
+    }
+    if (Array.isArray(d)) return d.map((v) => String(v).trim());
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/** Read all (teo, weighting) values in [t0, t1) for a (teo, weighting) float var. */
+async function readFloatSliceTeoByWeighting(
+  grp: Group<Readable>,
+  varName: string,
+  t0: number,
+  t1: number,
+  nWeighting: number,
+): Promise<(number | null)[][] | null> {
+  try {
+    const loc = grp.resolve(varName);
+    const arr = await open.v2(loc, { kind: "array" });
+    const ch = await get(arr, [slice(t0, t1), slice(0, nWeighting)]);
+    const d = ch?.data;
+    if (!(d instanceof Float32Array || d instanceof Float64Array)) return null;
+    const T = t1 - t0;
+    const out: (number | null)[][] = [];
+    for (let i = 0; i < T; i++) {
+      const row: (number | null)[] = [];
+      for (let w = 0; w < nWeighting; w++) {
+        const v = d[i * nWeighting + w];
+        row.push(v != null && Number.isFinite(v) ? v : null);
+      }
+      out.push(row);
+    }
+    return out;
+  } catch {
+    return null;
+  }
+}
+
+const COHORT_PORTFOLIO_VARS = [
+  "portfolio_gross_return",
+  "portfolio_market_return",
+  "portfolio_sector_return",
+  "portfolio_subsector_return",
+  "portfolio_idiosyncratic_return",
+  "identity_residual",
+  "weight_sum",
+  "n_holdings_active",
+  "effective_n",
+  "top10_weight_sum",
+] as const;
+
+export type CohortPortfolioVarName = (typeof COHORT_PORTFOLIO_VARS)[number];
+
+export interface CohortPortfolioRowPerWeighting {
+  portfolio_gross_return: number | null;
+  portfolio_market_return: number | null;
+  portfolio_sector_return: number | null;
+  portfolio_subsector_return: number | null;
+  portfolio_idiosyncratic_return: number | null;
+  identity_residual: number | null;
+  weight_sum: number | null;
+  n_holdings_active: number | null;
+  effective_n: number | null;
+  top10_weight_sum: number | null;
+}
+
+export interface CohortPortfolioRow {
+  teo: string;
+  ew: CohortPortfolioRowPerWeighting | null;
+  mv: CohortPortfolioRowPerWeighting | null;
+}
+
+export interface CohortPortfolioOptions {
+  startDate?: string;
+  endDate?: string;
+}
+
+/**
+ * Per-cell cohort portfolio time series. Returns rows per teo with both
+ * EW + MV blocks side-by-side.
+ */
+export async function readStyleCohortPortfolioSeries(
+  pathComponent: string,
+  options: CohortPortfolioOptions = {},
+): Promise<CohortPortfolioRow[]> {
+  const grp = await openCohortZarrGroup(
+    "portfolio_style",
+    pathComponent,
+    "ds_portfolio.zarr",
+  );
+  if (!grp) return [];
+
+  const teos = await readTeoStrings(grp);
+  if (!teos || teos.length === 0) return [];
+
+  const weightings = await readWeightingCoord(grp);
+  if (!weightings || weightings.length === 0) return [];
+
+  let t0 = 0;
+  let t1 = teos.length;
+  if (options.startDate) {
+    while (t0 < t1 && teos[t0]! < options.startDate) t0++;
+  }
+  if (options.endDate) {
+    while (t1 > t0 && teos[t1 - 1]! > options.endDate) t1--;
+  }
+  if (t0 >= t1) return [];
+
+  const series = await Promise.all(
+    COHORT_PORTFOLIO_VARS.map(async (varName) => ({
+      name: varName,
+      data: await readFloatSliceTeoByWeighting(
+        grp,
+        varName,
+        t0,
+        t1,
+        weightings.length,
+      ),
+    })),
+  );
+
+  const rows: CohortPortfolioRow[] = [];
+  for (let i = 0; i < t1 - t0; i++) {
+    const row: CohortPortfolioRow = {
+      teo: teos[t0 + i]!,
+      ew: null,
+      mv: null,
+    };
+    for (let w = 0; w < weightings.length; w++) {
+      const wKey = weightings[w]!.toLowerCase();
+      if (wKey !== "ew" && wKey !== "mv") continue;
+      const block: Record<string, number | null> = {};
+      for (const s of series) {
+        block[s.name] = s.data?.[i]?.[w] ?? null;
+      }
+      row[wKey as "ew" | "mv"] = block as unknown as CohortPortfolioRowPerWeighting;
+    }
+    rows.push(row);
+  }
+  return rows;
+}
+
+// ---------------------------------------------------------------------------
+// Per-cell cohort holdings — Slice 5b (equity_style_9box/{Cell_Name}/ds_symbols.zarr)
+// dims (teo, symbol, weighting) for weight + contribution_*; (teo, symbol)
+// for n_funds_holding. Top-N at latest teo for one weighting.
+// ---------------------------------------------------------------------------
+
+/** Read a single (teoIdx, *, weightingIdx) slice from a (teo, symbol, weighting) float var. */
+async function readFloat3dSlice(
+  grp: Group<Readable>,
+  varName: string,
+  teoIdx: number,
+  nSymbols: number,
+  weightingIdx: number,
+): Promise<(number | null)[] | null> {
+  try {
+    const loc = grp.resolve(varName);
+    const arr = await open.v2(loc, { kind: "array" });
+    const ch = await get(arr, [teoIdx, slice(0, nSymbols), weightingIdx]);
+    const d = ch?.data;
+    if (!(d instanceof Float32Array || d instanceof Float64Array)) return null;
+    return Array.from(d, (x) => (Number.isFinite(x) ? x : null));
+  } catch {
+    return null;
+  }
+}
+
+/** Read all symbols at one teo for a (teo, symbol) integer var (e.g. n_funds_holding). */
+async function readIntRowAtTeoSymbol(
+  grp: Group<Readable>,
+  varName: string,
+  teoIdx: number,
+  nSymbols: number,
+): Promise<(number | null)[] | null> {
+  try {
+    const loc = grp.resolve(varName);
+    const arr = await open.v2(loc, { kind: "array" });
+    const ch = await get(arr, [teoIdx, slice(0, nSymbols)]);
+    const d = ch?.data;
+    if (
+      d instanceof Int32Array ||
+      d instanceof Int16Array ||
+      d instanceof Float32Array ||
+      d instanceof Float64Array
+    ) {
+      return Array.from(d, (x) => (Number.isFinite(x) ? x : null));
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export interface CohortHolding {
+  bw_sym_id: string;
+  weight: number;
+  contribution_gross: number | null;
+  contribution_market: number | null;
+  contribution_sector: number | null;
+  contribution_subsector: number | null;
+  contribution_idiosyncratic: number | null;
+  n_funds_holding: number | null;
+}
+
+export interface CohortHoldingsSnapshot {
+  teo: string;
+  weighting: "ew" | "mv";
+  n_returned: number;
+  n_total_holdings: number;
+  holdings: CohortHolding[];
+}
+
+/**
+ * Top-N cohort holdings at the latest teo for the chosen weighting. Sorted
+ * by `weight` descending. Returns null when the per-cell zarr is missing
+ * or the requested weighting isn't present.
+ */
+export async function readStyleCohortHoldingsTopN(
+  pathComponent: string,
+  options: { weighting?: "ew" | "mv"; n?: number } = {},
+): Promise<CohortHoldingsSnapshot | null> {
+  const requestedWeighting = options.weighting ?? "mv";
+  const n = options.n ?? 25;
+  const safeN = Math.min(Math.max(n, 1), 100);
+
+  const grp = await openCohortZarrGroup(
+    "equity_style_9box",
+    pathComponent,
+    "ds_symbols.zarr",
+  );
+  if (!grp) return null;
+
+  const teos = await readTeoStrings(grp);
+  if (!teos || teos.length === 0) return null;
+  const symbols = await readSymbolStrings(grp);
+  if (!symbols || symbols.length === 0) return null;
+  const weightings = await readWeightingCoord(grp);
+  if (!weightings || weightings.length === 0) return null;
+
+  const teoIdx = teos.length - 1;
+  const teo = teos[teoIdx]!;
+  const wIdx = weightings.findIndex((w) => w.toLowerCase() === requestedWeighting);
+  if (wIdx < 0) return null;
+
+  const [
+    weightVec,
+    contribGross,
+    contribMarket,
+    contribSector,
+    contribSubsector,
+    contribIdio,
+    nFundsHolding,
+  ] = await Promise.all([
+    readFloat3dSlice(grp, "weight", teoIdx, symbols.length, wIdx),
+    readFloat3dSlice(grp, "contribution_gross", teoIdx, symbols.length, wIdx),
+    readFloat3dSlice(grp, "contribution_market", teoIdx, symbols.length, wIdx),
+    readFloat3dSlice(grp, "contribution_sector", teoIdx, symbols.length, wIdx),
+    readFloat3dSlice(grp, "contribution_subsector", teoIdx, symbols.length, wIdx),
+    readFloat3dSlice(grp, "contribution_idiosyncratic", teoIdx, symbols.length, wIdx),
+    readIntRowAtTeoSymbol(grp, "n_funds_holding", teoIdx, symbols.length),
+  ]);
+  if (!weightVec) return null;
+
+  const all: CohortHolding[] = [];
+  for (let i = 0; i < weightVec.length; i++) {
+    const w = weightVec[i];
+    if (w != null && w > 0) {
+      all.push({
+        bw_sym_id: symbols[i]!,
+        weight: w,
+        contribution_gross: contribGross?.[i] ?? null,
+        contribution_market: contribMarket?.[i] ?? null,
+        contribution_sector: contribSector?.[i] ?? null,
+        contribution_subsector: contribSubsector?.[i] ?? null,
+        contribution_idiosyncratic: contribIdio?.[i] ?? null,
+        n_funds_holding: nFundsHolding?.[i] ?? null,
+      });
+    }
+  }
+  if (all.length === 0) return null;
+
+  all.sort((a, b) => b.weight - a.weight);
+
+  return {
+    teo,
+    weighting: requestedWeighting,
+    n_returned: Math.min(safeN, all.length),
+    n_total_holdings: all.length,
+    holdings: all.slice(0, safeN),
+  };
 }

--- a/lib/funds/style-slug.ts
+++ b/lib/funds/style-slug.ts
@@ -40,3 +40,15 @@ export function styleNameToSlug(name: string): string | null {
 export function isValidStyleSlug(slug: string): boolean {
   return SLUG_TO_NAME.has(slug.trim().toLowerCase());
 }
+
+/**
+ * Convert a slug into the underscore-separated path component used by the
+ * Funds_DAG GCS layout (`portfolio_style/{Large_Blend}/...`,
+ * `equity_style_9box/{Large_Blend}/...`). Per ARCHITECTURE_FUNDS_API.md
+ * §3.1.1.
+ */
+export function styleSlugToPathComponent(slug: string): string | null {
+  const name = styleSlugToName(slug);
+  if (!name) return null;
+  return name.replace(/\s+/g, "_");
+}

--- a/mcp/data/openapi.json
+++ b/mcp/data/openapi.json
@@ -2213,6 +2213,156 @@
           }
         }
       },
+      "CohortPortfolioRow": {
+        "type": "object",
+        "description": "One teo of a cohort portfolio time series. Both EW + MV blocks side-by-side.",
+        "required": [
+          "teo"
+        ],
+        "properties": {
+          "teo": {
+            "type": "string",
+            "format": "date",
+            "example": "2026-04-30"
+          },
+          "ew": {
+            "$ref": "#/components/schemas/StyleCohortReturnsBlock"
+          },
+          "mv": {
+            "$ref": "#/components/schemas/StyleCohortReturnsBlock"
+          }
+        }
+      },
+      "CohortPortfolioHistoryResponse": {
+        "type": "object",
+        "description": "Per-cell cohort portfolio time series from Slice 6's per-cell ds_portfolio.zarr. Each row carries both EW and MV blocks.\n",
+        "required": [
+          "equity_style_9box",
+          "slug",
+          "n_periods",
+          "start_teo",
+          "end_teo",
+          "rows"
+        ],
+        "properties": {
+          "equity_style_9box": {
+            "type": "string"
+          },
+          "slug": {
+            "type": "string"
+          },
+          "n_periods": {
+            "type": "integer"
+          },
+          "start_teo": {
+            "type": "string",
+            "format": "date"
+          },
+          "end_teo": {
+            "type": "string",
+            "format": "date"
+          },
+          "rows": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CohortPortfolioRow"
+            }
+          }
+        }
+      },
+      "CohortHolding": {
+        "type": "object",
+        "description": "One cohort-aggregated holding within a 9-box cell.",
+        "required": [
+          "bw_sym_id",
+          "weight"
+        ],
+        "properties": {
+          "bw_sym_id": {
+            "type": "string",
+            "description": "Internal symbol id. Resolve via /api/data/symbols/batch."
+          },
+          "weight": {
+            "type": "number",
+            "format": "float",
+            "description": "Cohort weight at this teo (sums to 1.0 within the chosen weighting)."
+          },
+          "contribution_gross": {
+            "type": "number",
+            "format": "float",
+            "nullable": true
+          },
+          "contribution_market": {
+            "type": "number",
+            "format": "float",
+            "nullable": true
+          },
+          "contribution_sector": {
+            "type": "number",
+            "format": "float",
+            "nullable": true
+          },
+          "contribution_subsector": {
+            "type": "number",
+            "format": "float",
+            "nullable": true
+          },
+          "contribution_idiosyncratic": {
+            "type": "number",
+            "format": "float",
+            "nullable": true
+          },
+          "n_funds_holding": {
+            "type": "integer",
+            "nullable": true,
+            "description": "Number of funds in the cell holding this symbol."
+          }
+        }
+      },
+      "CohortHoldingsResponse": {
+        "type": "object",
+        "description": "Top-N cohort holdings at the latest teo for the chosen weighting.",
+        "required": [
+          "equity_style_9box",
+          "slug",
+          "teo",
+          "weighting",
+          "n_returned",
+          "n_total_holdings",
+          "holdings"
+        ],
+        "properties": {
+          "equity_style_9box": {
+            "type": "string"
+          },
+          "slug": {
+            "type": "string"
+          },
+          "teo": {
+            "type": "string",
+            "format": "date"
+          },
+          "weighting": {
+            "type": "string",
+            "enum": [
+              "ew",
+              "mv"
+            ]
+          },
+          "n_returned": {
+            "type": "integer"
+          },
+          "n_total_holdings": {
+            "type": "integer"
+          },
+          "holdings": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CohortHolding"
+            }
+          }
+        }
+      },
       "StyleCohortReturnsBlock": {
         "type": "object",
         "description": "Portfolio return components + diagnostics for one weighting in a cohort.",
@@ -8181,6 +8331,230 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/funds/style/{slug}/portfolio": {
+      "get": {
+        "summary": "Per-cell cohort portfolio time series",
+        "description": "Time series of cohort portfolio metrics from Slice 6's per-cell `ds_portfolio.zarr` on GCS. Each row carries both EW and MV blocks side-by-side. Optional inclusive `start_date` / `end_date` params trim the panel.\n",
+        "operationId": "getStyleCohortPortfolioHistory",
+        "tags": [
+          "Funds"
+        ],
+        "x-pricing": {
+          "capability_id": "style-cohort-portfolio-history",
+          "tier": "baseline",
+          "cost_usd": 0.005,
+          "billing_code": "style_cohort_portfolio_history_v1"
+        },
+        "parameters": [
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "start_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          },
+          {
+            "name": "end_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Cohort time series rows.",
+            "headers": {
+              "X-Data-As-Of": {
+                "schema": {
+                  "type": "string",
+                  "format": "date"
+                }
+              },
+              "X-API-Cost-USD": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CohortPortfolioHistoryResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid slug or malformed date params.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Insufficient prepaid balance.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InsufficientBalance"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No cohort portfolio history available for this cell.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RateLimitExceeded"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/funds/style/{slug}/holdings": {
+      "get": {
+        "summary": "Top-N cohort holdings within a 9-box style cell",
+        "description": "Top-N cohort holdings at the latest teo. Reads `weight (teo, symbol, weighting)` and `contribution_*` / `n_funds_holding` from Slice 5b's per-cell `ds_symbols.zarr`. Sorted by `weight` descending.\n\n`?weighting` defaults to `mv` (market-cap-weighted, Morningstar- comparable). Switch to `ew` to see equal-weight cohort exposures — radically different top-N lists for non-uniform cells.\n",
+        "operationId": "getStyleCohortHoldings",
+        "tags": [
+          "Funds"
+        ],
+        "x-pricing": {
+          "capability_id": "style-cohort-holdings",
+          "tier": "baseline",
+          "cost_usd": 0.005,
+          "billing_code": "style_cohort_holdings_v1"
+        },
+        "parameters": [
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "weighting",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "ew",
+                "mv"
+              ],
+              "default": "mv"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 25
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Top-N cohort holdings snapshot.",
+            "headers": {
+              "X-Data-As-Of": {
+                "schema": {
+                  "type": "string",
+                  "format": "date"
+                }
+              },
+              "X-API-Cost-USD": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CohortHoldingsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid slug, weighting, or limit.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Insufficient prepaid balance.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InsufficientBalance"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No cohort holdings panel available.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RateLimitExceeded"
                 }
               }
             }

--- a/tests/funds-cohort-zarr-routes.test.ts
+++ b/tests/funds-cohort-zarr-routes.test.ts
@@ -1,0 +1,236 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest, type NextResponse } from "next/server";
+
+vi.mock("@/lib/agent/billing-middleware", () => ({
+  withBilling: <T extends (...args: unknown[]) => unknown>(handler: T) => handler,
+}));
+
+vi.mock("@/lib/dal/funds-zarr-reader", () => ({
+  readStyleCohortPortfolioSeries: vi.fn(),
+  readStyleCohortHoldingsTopN: vi.fn(),
+}));
+
+import {
+  readStyleCohortPortfolioSeries,
+  readStyleCohortHoldingsTopN,
+} from "@/lib/dal/funds-zarr-reader";
+import type { BillingContext } from "@/lib/agent/billing-middleware";
+import { GET as wrappedPortfolioGET } from "@/app/api/funds/style/[slug]/portfolio/route";
+import { GET as wrappedHoldingsGET } from "@/app/api/funds/style/[slug]/holdings/route";
+
+const portfolioGET = wrappedPortfolioGET as unknown as (
+  req: NextRequest,
+  ctx: BillingContext,
+) => Promise<NextResponse>;
+const holdingsGET = wrappedHoldingsGET as unknown as (
+  req: NextRequest,
+  ctx: BillingContext,
+) => Promise<NextResponse>;
+
+const fakeContext: BillingContext = {
+  userId: "test-user",
+  requestId: "test-req",
+  capabilityId: "style-cohort-portfolio-history",
+  costUsd: 0.005,
+  startTime: Date.now(),
+};
+
+function req(path: string): NextRequest {
+  return new NextRequest(new Request(`http://localhost${path}`));
+}
+
+const PORTFOLIO_ROW = (teo: string) => ({
+  teo,
+  ew: {
+    portfolio_gross_return: 0.071,
+    portfolio_market_return: 0.099,
+    portfolio_sector_return: -0.01,
+    portfolio_subsector_return: -0.01,
+    portfolio_idiosyncratic_return: -0.005,
+    identity_residual: -0.003,
+    weight_sum: 0.99,
+    n_holdings_active: 2325,
+    effective_n: 65.2,
+    top10_weight_sum: 0.34,
+  },
+  mv: {
+    portfolio_gross_return: 0.082,
+    portfolio_market_return: 0.105,
+    portfolio_sector_return: -0.012,
+    portfolio_subsector_return: -0.008,
+    portfolio_idiosyncratic_return: -0.003,
+    identity_residual: 0,
+    weight_sum: 1,
+    n_holdings_active: 2325,
+    effective_n: 50.1,
+    top10_weight_sum: 0.42,
+  },
+});
+
+beforeEach(() => {
+  vi.mocked(readStyleCohortPortfolioSeries).mockReset();
+  vi.mocked(readStyleCohortHoldingsTopN).mockReset();
+});
+
+describe("GET /api/funds/style/[slug]/portfolio", () => {
+  it("returns 200 with cohort time series and bitemporal header", async () => {
+    vi.mocked(readStyleCohortPortfolioSeries).mockResolvedValue([
+      PORTFOLIO_ROW("2026-02-29"),
+      PORTFOLIO_ROW("2026-03-31"),
+      PORTFOLIO_ROW("2026-04-30"),
+    ]);
+    const res = await portfolioGET(
+      req("/api/funds/style/large-blend/portfolio"),
+      fakeContext,
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("X-Data-As-Of")).toBe("2026-04-30");
+    expect(vi.mocked(readStyleCohortPortfolioSeries)).toHaveBeenCalledWith(
+      "Large_Blend",
+      { startDate: undefined, endDate: undefined },
+    );
+    const body = await res.json();
+    expect(body.equity_style_9box).toBe("Large Blend");
+    expect(body.n_periods).toBe(3);
+    expect(body.rows[2].mv.portfolio_gross_return).toBeCloseTo(0.082);
+  });
+
+  it("forwards date params (and sends Large_Blend, not Large Blend)", async () => {
+    vi.mocked(readStyleCohortPortfolioSeries).mockResolvedValue([
+      PORTFOLIO_ROW("2026-04-30"),
+    ]);
+    await portfolioGET(
+      req("/api/funds/style/small-value/portfolio?start_date=2026-01-31&end_date=2026-04-30"),
+      fakeContext,
+    );
+    expect(vi.mocked(readStyleCohortPortfolioSeries)).toHaveBeenCalledWith(
+      "Small_Value",
+      { startDate: "2026-01-31", endDate: "2026-04-30" },
+    );
+  });
+
+  it("rejects unknown slug", async () => {
+    const res = await portfolioGET(
+      req("/api/funds/style/mega-blend/portfolio"),
+      fakeContext,
+    );
+    expect(res.status).toBe(400);
+    expect(vi.mocked(readStyleCohortPortfolioSeries)).not.toHaveBeenCalled();
+  });
+
+  it("rejects malformed start_date", async () => {
+    const res = await portfolioGET(
+      req("/api/funds/style/large-blend/portfolio?start_date=01-31-2026"),
+      fakeContext,
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects start_date > end_date", async () => {
+    const res = await portfolioGET(
+      req(
+        "/api/funds/style/large-blend/portfolio?start_date=2026-04-30&end_date=2026-01-31",
+      ),
+      fakeContext,
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when zarr returns []", async () => {
+    vi.mocked(readStyleCohortPortfolioSeries).mockResolvedValue([]);
+    const res = await portfolioGET(
+      req("/api/funds/style/large-blend/portfolio"),
+      fakeContext,
+    );
+    expect(res.status).toBe(404);
+  });
+});
+
+const HOLDINGS_SNAPSHOT = {
+  teo: "2026-04-30",
+  weighting: "mv" as const,
+  n_returned: 2,
+  n_total_holdings: 503,
+  holdings: [
+    {
+      bw_sym_id: "BW-A",
+      weight: 0.05,
+      contribution_gross: 0.004,
+      contribution_market: 0.0035,
+      contribution_sector: 0.0003,
+      contribution_subsector: 0.0001,
+      contribution_idiosyncratic: 0.0001,
+      n_funds_holding: 540,
+    },
+    {
+      bw_sym_id: "BW-B",
+      weight: 0.03,
+      contribution_gross: 0.002,
+      contribution_market: 0.0018,
+      contribution_sector: 0.0001,
+      contribution_subsector: 0.0,
+      contribution_idiosyncratic: 0.0001,
+      n_funds_holding: 380,
+    },
+  ],
+};
+
+describe("GET /api/funds/style/[slug]/holdings", () => {
+  const holdCtx: BillingContext = { ...fakeContext, capabilityId: "style-cohort-holdings" };
+
+  it("returns 200 with top-N + bitemporal header; default weighting=mv, limit=25", async () => {
+    vi.mocked(readStyleCohortHoldingsTopN).mockResolvedValue(HOLDINGS_SNAPSHOT);
+    const res = await holdingsGET(
+      req("/api/funds/style/large-blend/holdings"),
+      holdCtx,
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("X-Data-As-Of")).toBe("2026-04-30");
+    expect(vi.mocked(readStyleCohortHoldingsTopN)).toHaveBeenCalledWith(
+      "Large_Blend",
+      { weighting: "mv", n: 25 },
+    );
+    const body = await res.json();
+    expect(body.equity_style_9box).toBe("Large Blend");
+    expect(body.holdings).toHaveLength(2);
+    expect(body.weighting).toBe("mv");
+  });
+
+  it("forwards ?weighting=ew + clamps limit at 100", async () => {
+    vi.mocked(readStyleCohortHoldingsTopN).mockResolvedValue(HOLDINGS_SNAPSHOT);
+    await holdingsGET(
+      req("/api/funds/style/large-blend/holdings?weighting=ew&limit=999"),
+      holdCtx,
+    );
+    expect(vi.mocked(readStyleCohortHoldingsTopN)).toHaveBeenCalledWith(
+      "Large_Blend",
+      { weighting: "ew", n: 100 },
+    );
+  });
+
+  it("rejects invalid weighting", async () => {
+    const res = await holdingsGET(
+      req("/api/funds/style/large-blend/holdings?weighting=cap"),
+      holdCtx,
+    );
+    expect(res.status).toBe(400);
+    expect(vi.mocked(readStyleCohortHoldingsTopN)).not.toHaveBeenCalled();
+  });
+
+  it("rejects unknown slug", async () => {
+    const res = await holdingsGET(
+      req("/api/funds/style/mega-blend/holdings"),
+      holdCtx,
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when zarr returns null", async () => {
+    vi.mocked(readStyleCohortHoldingsTopN).mockResolvedValue(null);
+    const res = await holdingsGET(
+      req("/api/funds/style/large-blend/holdings"),
+      holdCtx,
+    );
+    expect(res.status).toBe(404);
+  });
+});

--- a/tests/funds-style-slug.test.ts
+++ b/tests/funds-style-slug.test.ts
@@ -4,6 +4,7 @@ import {
   isValidStyleSlug,
   styleNameToSlug,
   styleSlugToName,
+  styleSlugToPathComponent,
 } from "@/lib/funds/style-slug";
 
 describe("style-slug", () => {
@@ -39,5 +40,15 @@ describe("style-slug", () => {
   it("emits hyphenated lowercase slugs", () => {
     expect(styleNameToSlug("Large Blend")).toBe("large-blend");
     expect(styleNameToSlug("Small Growth")).toBe("small-growth");
+  });
+
+  it("emits underscore path components for GCS Zarr layout", () => {
+    expect(styleSlugToPathComponent("large-blend")).toBe("Large_Blend");
+    expect(styleSlugToPathComponent("small-growth")).toBe("Small_Growth");
+    expect(styleSlugToPathComponent("MID-VALUE")).toBe("Mid_Value");
+  });
+
+  it("returns null for unknown slug in path encoder", () => {
+    expect(styleSlugToPathComponent("mega-blend")).toBeNull();
   });
 });


### PR DESCRIPTION
Final two of four Stage C endpoints — both Zarr-backed, completing the style-cohort surface.

## Routes

\`\`\`
GET /api/funds/style/{slug}/portfolio                 ($0.005)
    → per-cell time series, both EW + MV side-by-side per teo
    → ?start_date / ?end_date inclusive trim
GET /api/funds/style/{slug}/holdings                  ($0.005)
    → top-N cohort holdings (sorted by weight desc)
    → ?weighting (default mv), ?limit (default 25, max 100)
    → returns weight + 5 contribution_* + n_funds_holding per symbol
\`\`\`

## Zarr layouts

Per arch doc §3.1.1, paths use \`Cell_Name\` (underscore) form:
- \`portfolio_style/{Cell_Name}/ds_portfolio.zarr\` — dims \`(teo, weighting)\`, 10 data_vars
- \`equity_style_9box/{Cell_Name}/ds_symbols.zarr\` — dims \`(teo, symbol, weighting)\` for weight + contribution_*; dim \`(teo, symbol)\` for n_funds_holding

## New code

- \`lib/dal/funds-zarr-reader.ts\`:
  - \`readStyleCohortPortfolioSeries\` — reads \`(teo, weighting)\` 2D var slices
  - \`readStyleCohortHoldingsTopN\` — reads 3D + 2D vars at latest teo
  - Generalized \`openZarrGroupAt(relativePath)\`; new \`openCohortZarrGroup\` helper
- \`lib/funds/style-slug.ts\` — \`styleSlugToPathComponent("large-blend") → "Large_Blend"\`
- 2 new capabilities (\`style-cohort-portfolio-history\`, \`style-cohort-holdings\`)
- 4 new OpenAPI schemas (\`CohortPortfolioRow\`, \`CohortPortfolioHistoryResponse\`, \`CohortHolding\`, \`CohortHoldingsResponse\`) + 2 new paths

## Tests

- \`funds-style-slug.test.ts\` — +2 (path encoder)
- \`funds-cohort-zarr-routes.test.ts\` — 11 new route tests (DAL mocked)
- Full suite: 169/169

## Stage C complete

\`\`\`
GET /funds/style/{slug}                           (C.0, latest cohort metrics) ← shipped
GET /funds/style/{slug}/rankings/{cohort_type}     (C.1, top-N ranks)            ← shipped
GET /funds/style/{slug}/portfolio                  (C.2, time series)            ← THIS PR
GET /funds/style/{slug}/holdings                   (C.3, top-N holdings)         ← THIS PR
\`\`\`

## Test plan

- [x] \`npm test\` — 169/169 (13 new in C.2+C.3)
- [x] \`npm run typecheck\` — clean
- [x] \`npm run lint\` — clean
- [x] \`npm run build:openapi\` — yaml→json regenerates
- [ ] Mirror PR on Risk_Models for the regenerated \`mcp/data/openapi.json\`
- [ ] Smoke once mirror clears: \`GET /api/funds/style/large-blend/holdings\` should return real top-25 holdings (per-cell zarrs are on GCS already)

## Out of scope

- Stage D (snapshot tearsheets — \`/api/funds/snapshot/{id}\` and \`/api/funds/style/{slug}/snapshot\`)
- Stage E (AOM extensions, SDK additions)
- Stage F (13F endpoints)

🤖 Generated with [Claude Code](https://claude.com/claude-code)