### PR TITLE
funds_latest: add aum_erm3 column (additive)

### DIFF
--- a/supabase/migrations/20260503000000_funds_latest_aum_erm3.sql
+++ b/supabase/migrations/20260503000000_funds_latest_aum_erm3.sql
@@ -1,0 +1,26 @@
+-- Add aum_erm3 column to funds_latest (Funds_DAG additive retrofit)
+--
+-- The Slice 5 ds_ph.zarr already carries `aum_erm3` (Σ adj_mv restricted
+-- to positions in the ERM3 uni_mc_3000 universe — the apples-to-apples
+-- AUM metric for cross-fund comparisons and the basis for weight_sum
+-- diagnostic). Slice 11's writer was missing this column; this migration
+-- adds it so the funds-side sync can surface it.
+--
+-- Purely additive — does NOT rename or alter the existing `total_adj_mv`
+-- column (which API endpoints already read). The total_adj_mv field
+-- equals aum_reported semantically (Σ adj_mv across all symbols);
+-- the ERM3-filtered companion lands as a new column.
+--
+-- Pairs with Funds_DAG/src/funds_dag/sync/build_funds_rows.py:
+--   FundsLatestRow gains an `aum_erm3` field, populated from
+--   ds_ph.zarr.aum_erm3 at the latest teo.
+
+BEGIN;
+
+ALTER TABLE public.funds_latest
+    ADD COLUMN IF NOT EXISTS aum_erm3 DOUBLE PRECISION;
+
+COMMENT ON COLUMN public.funds_latest.aum_erm3 IS
+    'AUM of positions in the ERM3 uni_mc_3000 universe (Σ adj_mv restricted to ERM3-mapped symbols). Apples-to-apples metric for cross-fund comparisons and the basis for weight_sum (= aum_erm3 / total_adj_mv). Source: ds_ph.zarr.aum_erm3.';
+
+COMMIT;


### PR DESCRIPTION
## Summary
- Adds nullable `aum_erm3 DOUBLE PRECISION` column to `public.funds_latest`
- Purely additive — `total_adj_mv` unchanged (Stage B/C endpoints unaffected)
- Migration already applied to dev via psql; this PR captures it in git
- Funds_DAG-side writer change already merged on Funds_DAG main

## What's aum_erm3?
Σ adj_mv restricted to positions in the ERM3 `uni_mc_3000` universe — the apples-to-apples AUM metric for cross-fund comparisons. Source: `ds_ph.zarr.aum_erm3` (already a `(teo,)` data_var on the Slice 5 output).

`weight_sum` (already exposed) = `aum_erm3 / total_adj_mv` semantically.

## Live coverage post-sync
- 381 / 9,687 funds have `aum_erm3` populated (legacy ds_ph zarrs predate the column; remainder get NULL until rebuild)
- Top sample: `BW-FUND-S000009388` (Large Value): `total_adj_mv=$140.4B`, `aum_erm3=$140.4B`, `weight_sum=0.9829`

## Test plan
- [x] Migration validated via libpg_query
- [x] Applied to dev via psql
- [x] Funds_DAG-side `funds_supabase_sync` re-run successfully (`status=ok`, all 9,687 rows upserted)
- [x] Spot-check sampled rows show non-null `aum_erm3` matching `total_adj_mv` for high-weight_sum funds
- [ ] No-op on next `supabase db push` (already applied)

🤖 Generated with [Claude Code](https://claude.com/claude-code)