### PR TITLE
docs: Funds API build status (A–D.1 shipped, D.2+ planned)

### DIFF
--- a/docs/FUNDS_API_BUILD_STATUS.md
+++ b/docs/FUNDS_API_BUILD_STATUS.md
@@ -1,0 +1,128 @@
+# Funds API Build Status
+
+> Working document for the funds-side API surface. Pairs with
+> `Funds_DAG/docs/ARCHITECTURE_FUNDS_API.md` (the canonical design doc,
+> sibling repo) which defines Stages A–F. This file tracks what's
+> actually shipped vs planned in *this* repo.
+>
+> Last updated: 2026-05-03.
+
+## Status
+
+| Stage | Endpoint(s) | Status | PRs | Notes |
+|:---|:---|:---|:---|:---|
+| **A** | `GET /api/data/funds/{bw_fund_id}` | **✅ Shipped** | #22 | Data plane (raw shape) — public, free, soft Bearer auth |
+| A | `POST /api/data/funds/batch` | **✅ Shipped** | #22 | ≤1000 ids per call |
+| A | `GET /api/data/funds/search` | **✅ Shipped** | #22 | q + style + primary filters |
+| A | `GET /api/data/funds/style/{slug}/members` | **✅ Shipped** | #22 | fund_ids in a 9-box cell |
+| A | `GET /api/data/funds-latest/{bw_fund_id}` | **✅ Shipped** | #22 | just the funds_latest row |
+| **B.1** | `GET /api/funds/{bw_fund_id}` | **✅ Shipped** | #23 | Latest metrics, $0.005 |
+| **B.2.a** | `GET /api/funds/{bw_fund_id}/portfolio` | **✅ Shipped** | #23 | Per-fund time series from `ds_portfolio.zarr`, $0.005 |
+| **B.2.b** | `GET /api/funds/{bw_fund_id}/holdings` | **✅ Shipped** | #23 | Top-N from `ds_ph.zarr`, $0.005 |
+| **B.2.c** | `GET /api/funds/{bw_fund_id}/hedge` | **✅ Shipped** | #23 | L1/L2/L3 from `ds_hr.zarr`, $0.005 |
+| **C.0** | `GET /api/funds/style/{slug}` | **✅ Shipped** | #24 | Latest cohort metrics (EW + MV), $0.005 |
+| **C.1** | `GET /api/funds/style/{slug}/rankings/{cohort_type}` | **✅ Shipped** | #24 | Top-N rankings, $0.005 |
+| **C.2** | `GET /api/funds/style/{slug}/portfolio` | **✅ Shipped** | #26 | Per-cell time series from Slice 6 zarr, $0.005 |
+| **C.3** | `GET /api/funds/style/{slug}/holdings` | **✅ Shipped** | #26 | Top-N cohort holdings from Slice 5b zarr, $0.005 |
+| **D.1** | `GET /api/funds/snapshot/{bw_fund_id}` | **✅ Shipped** | #28 | Composed JSON tearsheet, $0.01 |
+| D.1 | `GET /api/funds/style/{slug}/snapshot` | **✅ Shipped** | #28 | Composed cohort JSON, $0.005 — the differentiated wedge |
+| **D.2** | `GET /api/funds/snapshot.pdf/{bw_fund_id}` | Planned | — | Server-rendered PDF via Playwright (mirrors `metrics/[ticker]/snapshot.pdf`), $0.25 |
+| D.2 | `GET /api/funds/style/{slug}/snapshot.pdf` | Planned | — | Server-rendered cohort PDF, $0.10 |
+| **D.3** | SDK `riskmodels.snapshots.f1_fund_tearsheet` | Planned | — | Public Python renderer (mirrors `r1_risk_profile.py`) |
+| D.3 | SDK `riskmodels.snapshots.c1_cohort_report` | Planned | — | Public Python cohort renderer |
+| **E** | AOM extensions: `subject:fund:*`, `subject:style:*` | Planned | — | New public intent presets (`compare_to_cohort`, `analyze_fund_attribution`, `screen_fund_universe`, `decompose_cohort_return`) |
+| E | MCP tool registrations | Planned | — | `post_fund_snapshot`, `post_cohort_snapshot` |
+| E | SDK `funds.py` (TypeScript + Python) | Planned | — | Convenience wrappers around primitives + snapshots |
+| **F** | `GET /api/13f/filers/{bw_filer_id}` + family | Planned | — | Mirrors funds; depends on Funds_DAG Slice 13c+ filer panels |
+
+## Cross-repo mirror convention
+
+`mcp/data/openapi.json` is canonical here. **Every** PR that touches
+`OPENAPI_SPEC.yaml` requires a paired byte-for-byte copy on
+`Risk_Models/riskmodels_com/mcp-server/data/openapi.json`. The
+`detect-drift` CI workflow blocks the RiskModels_API PR until the
+mirror is on Risk_Models main.
+
+Convention used so far:
+
+```
+1. RiskModels_API: feat/<branch> with code + spec changes
+2. Risk_Models:   mirror/<branch>-openapi  with just openapi.json
+3. CI on RiskModels_API blocks on detect-drift until step 2 merges
+4. Re-run detect-drift after step 2's merge → step 1 can merge
+```
+
+Mirror PRs landed during the funds build: #27 (A), #28 (B.1+B.2.a),
+#30 (B.2.b+B.2.c), #31 (C.0+C.1), #32 (C.2+C.3), #33 (D.1).
+
+If `mcp/data/schemas/*.json` changes too, those must be mirrored
+similarly. See `BWMACRO/docs/AGENTS_CROSS_REPO.md` §1–3.
+
+## Known cross-repo CI hazards (history)
+
+The Risk_Models e2e job blocks mirror PRs and has had pre-existing
+flakes during this build. Failures observed:
+
+- `redirects.spec.ts:11` — `/cli` redirects to `/installation`, not
+  `/quickstart`, after the CLI install rename on RiskModels_API
+  (#21–22 era). **Fixed in Risk_Models#29** (the `/cli` regex was
+  updated and the broken signup tests were `test.skip()`'d with
+  TODOs).
+- `auth.spec.ts:81/93/106` and `forms.spec.ts:91/137` — five Signup
+  form tests timing out at 30s on `locator.click`. Suspected DOM /
+  modal restructure from the landing-attribution rollout. Skipped
+  with TODOs in #29; needs a live signup-page selector audit before
+  re-enable.
+
+Future mirror PRs should expect these to stay skipped until someone
+audits the live signup page.
+
+## Effort estimates for remaining stages
+
+These are agent-time estimates assuming the same fixture-driven,
+PR-per-slice cadence used for A–D.1.
+
+| Stage | Effort | Notes |
+|:---|:---|:---|
+| D.2 | 4–6 hours | Server PDF templates (Playwright HTML), 2 routes, Redis cache, capability + OpenAPI. Gating decision: 1-page tearsheet HTML structure for fund + cohort — design taste call needed before building. |
+| D.3 | 6–8 hours | SDK Python F1 + C1 (~600 LOC each), Plotly compositions, fetch/render separation, tests using cached JSON, new pip release. The "differentiated wedge" cohort tearsheet visual is the meatiest part. |
+| E | 4–5 hours | AOM `subject` extensions, 4 new public intent presets, MCP tool registrations, TS/Python SDK convenience wrappers. Mostly mechanical; the AOM compiler already handles new subject types. |
+| F | 6–8 hours | 13F endpoints. Mirrors funds with `bw_filer_id` instead of `bw_fund_id`. **Blocked on Funds_DAG Slice 13c+** materializing filer panels (registry exists; per-filer ds_portfolio + ds_ph + rankings still pending per Funds_DAG main). |
+
+Total to reach feature-complete public funds API + 13F: **~20–27 hours
+of focused work**, naturally splitting across 4–6 sessions.
+
+## Pickup recipe for the next session
+
+1. Read `Funds_DAG/docs/ARCHITECTURE_FUNDS_API.md` §6 (public/private
+   boundary) and §7.2 (Stage list).
+2. Read this file's status table to confirm what's on `main`.
+3. For Stage D.2: inspect the existing
+   `app/api/metrics/[ticker]/snapshot.pdf/route.ts` and
+   `lib/portfolio/risk-snapshot-pdf.ts` — Playwright pattern is in
+   place; the new work is the HTML templates + 2 new routes.
+4. For Stage D.3: mirror `sdk/riskmodels/snapshots/r1_risk_profile.py`
+   one-to-one. Both R1 and the new F1 follow the same fetch/render
+   separation + JSON handshake pattern.
+5. Real fixtures for tests live at `tests/fixtures/funds/*.json` —
+   extend with a 13F sample when Stage F starts.
+
+## Constraints to remember (lessons from A–D.1)
+
+- **No synthetic test data when real fixtures exist** — pull from
+  `Funds_DAG/data/sync/funds/*.json`.
+- **No `/Users/...` paths in committed files** — the `Public safety
+  audit` CI step blocks them. Reference paths relative to repo root or
+  by repo name only.
+- **`app/api/data/...` route files require `git add -f`** — the
+  `data/` glob in `.gitignore:100` (intended for Zarr stores) catches
+  them. Existing `app/api/data/symbols/*` follows this pattern too.
+- **Bitemporal headers** — every endpoint returning a `funds_latest`
+  row must set `X-Data-As-Of` (= `report_date`) and `X-Data-Filing-Date`
+  (= `filing_date`). Per arch doc §3.5.
+- **No `?as_of=` / `?mode=` query params yet** — deferred to v2 even
+  though the columns exist.
+- **Sync writer behavior** — Slice 11b reads zarrs ~6 min then bursts
+  upserts ~25s; mid-sync polls look stuck but aren't. The
+  `funds_sync_state_v1` row is stamped *after* the burst, so it's
+  authoritative.

--- a/docs/FUNDS_API_BUILD_STATUS.md
+++ b/docs/FUNDS_API_BUILD_STATUS.md
@@ -111,9 +111,11 @@ of focused work**, naturally splitting across 4–6 sessions.
 
 - **No synthetic test data when real fixtures exist** — pull from
   `Funds_DAG/data/sync/funds/*.json`.
-- **No `/Users/...` paths in committed files** — the `Public safety
-  audit` CI step blocks them. Reference paths relative to repo root or
-  by repo name only.
+- **No absolute home-directory paths in committed files** — the
+  `Public safety audit` CI step greps the working tree for the literal
+  substring `/Users` (and the Windows equivalent) and fails on a hit.
+  Reference paths relative to repo root or by repo name only — even in
+  comments and docs.
 - **`app/api/data/...` route files require `git add -f`** — the
   `data/` glob in `.gitignore:100` (intended for Zarr stores) catches
   them. Existing `app/api/data/symbols/*` follows this pattern too.


### PR DESCRIPTION
## Summary

In-repo status doc tracking what's shipped vs planned on the funds-side API surface. Mirrors the \`SNAPSHOT_ROADMAP.md\` pattern. Pairs with \`Funds_DAG/docs/ARCHITECTURE_FUNDS_API.md\` (the canonical design doc, sibling repo).

Doc-only — no code changes; no OpenAPI mirror PR needed.

## Why

The funds Stage A–F build plan lives in the Funds_DAG architecture doc and in commit messages, but there was no in-repo doc on RiskModels_API capturing what's shipped vs what's next. A future session or another developer would have to cross-reference merged PRs against the architecture doc to figure out the state.

## Contents

- **Status table** by stage with merged PR refs (#22 / #23 / #24 / #26 / #28). 13 endpoints shipped; D.2 / D.3 / E / F planned.
- **Cross-repo mirror convention** — the \`detect-drift\` dance (PRs #27 / #28 / #30 / #31 / #32 / #33).
- **Known CI hazards** — the Risk_Models e2e flake set we hit during the build, fixed in #29 (signup tests skipped pending live page audit).
- **Effort estimates** for remaining stages: D.2 (4–6h), D.3 (6–8h), E (4–5h), F (6–8h, blocked on Funds_DAG Slice 13c+).
- **Pickup recipe** for the next session.
- **Constraints / lessons** from A–D.1 (no synthetic test data, no \`/Users/...\` paths, force-add for \`app/api/data/...\`, bitemporal headers required).

## Test plan

- [x] Doc-only; no code or spec changes
- [x] Force-add required (\`docs/\` is in \`.gitignore:81\` — same pattern as \`app/api/data/\` and existing \`docs/SNAPSHOT_ROADMAP.md\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)