### PR TITLE
API: overlay PIT ds_market_cap on legacy ds_daily.market_cap

### DIFF
--- a/sdk/riskmodels/snapshots/zarr_context.py
+++ b/sdk/riskmodels/snapshots/zarr_context.py
@@ -397,6 +397,13 @@ def fetch_stock_context_zarr(
     ds_erm = xr.open_zarr(root / "ds_erm3_hedge_weights_SPY_uni_mc_3000.zarr", consolidated=True)
     ds_etf = xr.open_zarr(root / "ds_etf.zarr", consolidated=True)
     ds_rank = xr.open_zarr(root / "ds_rankings_SPY_uni_mc_3000.zarr", consolidated=True)
+    # PIT survivorship-corrected market_cap (shares × close from EDGAR-sourced
+    # shares_history). When present, supersedes ds_daily.market_cap which is
+    # only populated for currently-listed entities (fundamentals.csv path).
+    # Critical for historical context queries on names that delisted before
+    # the snapshot — Lehman, Kraft pre-merger, etc. now have correct mcap.
+    _market_cap_zarr = root / "ds_market_cap.zarr"
+    ds_market_cap = xr.open_zarr(_market_cap_zarr, consolidated=True) if _market_cap_zarr.is_dir() else None
     # ds_erm3_returns has the daily L*_cfr / L*_rr series indexed by (teo, symbol, level)
     # where level ∈ {market, sector, subsector}. Required for the Section I 5-line
     # bridge — without these, build_p1_data_from_stock_context falls back to gross
@@ -423,6 +430,22 @@ def fetch_stock_context_zarr(
     else:
         sub_d = ds_daily.sel(symbol=sym).isel(teo=slice(-n_days, None))
         sub_e = ds_erm.sel(symbol=sym).isel(teo=slice(-n_days, None))
+    # PIT survivorship-corrected market_cap: prefer ds_market_cap.zarr where
+    # available, fall back to sub_d.market_cap. Reindex onto sub_d's teo
+    # range so the merge below stays aligned.
+    if ds_market_cap is not None and "market_cap" in ds_market_cap.data_vars:
+        try:
+            sub_mc = ds_market_cap.sel(symbol=sym).reindex(teo=sub_d.teo.values, method=None)
+            mc_pit = sub_mc["market_cap"].values
+            mc_legacy = sub_d["market_cap"].values
+            # Where PIT has a value, use it; otherwise keep legacy (currently-listed names
+            # often have legacy values where PIT is NaN — we want both populated).
+            import numpy as _np
+            mc_merged = _np.where(_np.isnan(mc_pit), mc_legacy, mc_pit)
+            sub_d = sub_d.assign(market_cap=("teo", mc_merged.astype(sub_d["market_cap"].dtype)))
+        except Exception:
+            # Any failure → fall back to legacy. No silent corruption.
+            pass
     merged = xr.merge(
         [
             sub_d[["return", "close", "market_cap", "volatility", "bw_sector_code", "fs_industry_code"]],

--- a/sdk/riskmodels/snapshots/zarr_peer_analytics.py
+++ b/sdk/riskmodels/snapshots/zarr_peer_analytics.py
@@ -46,6 +46,24 @@ def _open_zarr_stores(zarr_root: Path) -> tuple[xr.Dataset, xr.Dataset, xr.Datas
     )
     ret_path = zarr_root / "ds_erm3_returns_SPY_uni_mc_3000.zarr"
     ds_returns = xr.open_zarr(ret_path, consolidated=True) if ret_path.is_dir() else None
+    # PIT survivorship-corrected market_cap (used by peer-cap weighting). When
+    # available, supersedes ds_daily.market_cap for symbols that have shares
+    # in shares_history but were missing from fundamentals.csv.
+    mc_path = zarr_root / "ds_market_cap.zarr"
+    if mc_path.is_dir():
+        ds_market_cap = xr.open_zarr(mc_path, consolidated=True)
+        # Overlay PIT mc onto ds_daily for the rest of this module.
+        try:
+            mc_pit = ds_market_cap["market_cap"].reindex(
+                teo=ds_daily.teo.values,
+                symbol=ds_daily.symbol.values,
+                method=None,
+            ).values
+            mc_legacy = ds_daily["market_cap"].values
+            mc_merged = np.where(np.isnan(mc_pit), mc_legacy, mc_pit)
+            ds_daily = ds_daily.assign(market_cap=(("teo", "symbol"), mc_merged.astype(ds_daily["market_cap"].dtype)))
+        except Exception:
+            pass  # graceful fallback; legacy ds_daily.market_cap stays in place
     return ds_daily, ds_erm, ds_returns
 
 


### PR DESCRIPTION
## Summary
- Closes the survivorship gap on API endpoints that read `market_cap` from `ds_daily` directly. ERM3's new `ds_market_cap.zarr` (shares × close from EDGAR-sourced shares_history) carries correct mcap for delisted entities (Lehman 2008-09-12, Kraft pre-merger 2015, etc.) where `ds_daily.market_cap` was NaN.
- `zarr_context.py`: `build_stock_context_from_zarr()` opens `ds_market_cap.zarr` alongside `ds_daily.zarr` and prefers PIT mcap where present, falling back to `ds_daily.market_cap`. Wrapped in try/except so any failure silently keeps the legacy path.
- `zarr_peer_analytics.py`: `_open_zarr_stores()` applies the same overlay at load time so `build_peer_comparison_from_zarr`'s cap-weighted peer discovery uses the union mcap.
- Both changes are no-ops if `ds_market_cap.zarr` isn't present in the zarr_root tree — backwards-compatible with deployments that haven't pulled the ERM3 PR yet.

## Companion PR
ERM3: `feat/edgar-phase-3-survivorship` (BlueWaterCorp/ERM3#20) — produces the `ds_market_cap.zarr` this PR consumes.

## Test plan
- [ ] Confirm `ds_market_cap.zarr` exists in the deployed zarr_root (or the API gracefully falls back without it)
- [ ] Query historical context for a delisted name (BW-LEH on 2008-09-12) — expect mcap ≈ \$1.94B (was NaN before)
- [ ] Query peer-cap weighting for a currently-listed name with a recent SPAC merger predecessor — expect peer mcap consistent across endpoints
- [ ] Run existing test_csv_exports / test_peer_group suites — they should pass unchanged (no ds_market_cap.zarr in fixtures means legacy path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)