### PR TITLE
B.2.d: per-fund NAV reader + GET /api/funds/[id]/nav

### DIFF
--- a/app/api/funds/[bw_fund_id]/nav/route.ts
+++ b/app/api/funds/[bw_fund_id]/nav/route.ts
@@ -1,0 +1,93 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { withBilling, type BillingContext } from "@/lib/agent/billing-middleware";
+import { fetchFund } from "@/lib/dal/funds-engine";
+import { readFundNavSeries } from "@/lib/dal/funds-zarr-reader";
+
+export const dynamic = "force-dynamic";
+
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * GET /api/funds/{bw_fund_id}/nav?start_date=YYYY-MM-DD&end_date=YYYY-MM-DD
+ *
+ * Per-fund NAV time series from Funds_DAG's `ds_nav.zarr` on GCS. One row per
+ * teo (month-end) with `nav_close` (resampled month-end close) and
+ * `nav_return_monthly` (pct_change of consecutive month-end closes). Date
+ * params are inclusive and optional (default = the full panel for this fund).
+ *
+ * Pairs with `/portfolio`: portfolio returns are derived from quarterly 13F
+ * holdings, NAV returns are what investors actually realised. The gap
+ * surfaces intra-quarter trading, fees, and cash drag not visible in 13F.
+ */
+export const GET = withBilling(
+  async (request: NextRequest, _context: BillingContext) => {
+    const segments = request.nextUrl.pathname.split("/");
+    const bwFundId = segments[segments.length - 2];
+    if (!bwFundId) {
+      return NextResponse.json(
+        { error: "bw_fund_id is required" },
+        { status: 400 },
+      );
+    }
+
+    const { searchParams } = request.nextUrl;
+    const startDate = searchParams.get("start_date") ?? undefined;
+    const endDate = searchParams.get("end_date") ?? undefined;
+    if (startDate && !ISO_DATE.test(startDate)) {
+      return NextResponse.json(
+        { error: "start_date must be YYYY-MM-DD" },
+        { status: 400 },
+      );
+    }
+    if (endDate && !ISO_DATE.test(endDate)) {
+      return NextResponse.json(
+        { error: "end_date must be YYYY-MM-DD" },
+        { status: 400 },
+      );
+    }
+    if (startDate && endDate && startDate > endDate) {
+      return NextResponse.json(
+        { error: "start_date must be <= end_date" },
+        { status: 400 },
+      );
+    }
+
+    const fund = await fetchFund(bwFundId);
+    if (!fund) {
+      return NextResponse.json({ error: "Fund not found" }, { status: 404 });
+    }
+
+    const rows = await readFundNavSeries(bwFundId, { startDate, endDate });
+    if (rows.length === 0) {
+      return NextResponse.json(
+        {
+          error: "No NAV history available for this fund",
+          bw_fund_id: bwFundId,
+        },
+        { status: 404 },
+      );
+    }
+
+    const headers = new Headers({
+      "X-Data-As-Of": rows[rows.length - 1]!.teo,
+    });
+    if (fund.latest_filing_date) {
+      headers.set("X-Data-Filing-Date", fund.latest_filing_date);
+    }
+
+    return NextResponse.json(
+      {
+        bw_fund_id: bwFundId,
+        ticker: fund.ticker,
+        fund_name: fund.fund_name,
+        equity_style_9box: fund.equity_style_9box,
+        n_periods: rows.length,
+        start_teo: rows[0]!.teo,
+        end_teo: rows[rows.length - 1]!.teo,
+        rows,
+      },
+      { headers },
+    );
+  },
+  { capabilityId: "fund-nav-history" },
+);

--- a/lib/agent/capabilities.ts
+++ b/lib/agent/capabilities.ts
@@ -1080,6 +1080,56 @@ export const CAPABILITIES: Capability[] = [
     tags: ["funds", "history", "time-series"],
   },
   {
+    id: "fund-nav-history",
+    name: "Fund NAV History",
+    description:
+      "Per-fund NAV time series from yfinance (Funds_DAG fund_nav_zarr asset). One row per teo " +
+      "(month-end) with nav_close (month-end close) and nav_return_monthly (pct_change of " +
+      "consecutive closes). Pairs with /portfolio: portfolio returns are derived from quarterly " +
+      "13F holdings; NAV returns are what investors actually realised. The gap surfaces " +
+      "intra-quarter trading, fees, and cash drag not visible in 13F. Optional ?start_date and " +
+      "?end_date trim the panel; default returns the full history.",
+    endpoint: "/api/funds/{bw_fund_id}/nav",
+    method: "GET",
+    parameters: {
+      bw_fund_id: {
+        type: "string",
+        required: true,
+        description:
+          "Funds_DAG canonical fund id (format: BW-FUND-{series_id})",
+      },
+      start_date: {
+        type: "string",
+        required: false,
+        description: "Inclusive lower bound, YYYY-MM-DD",
+      },
+      end_date: {
+        type: "string",
+        required: false,
+        description: "Inclusive upper bound, YYYY-MM-DD",
+      },
+    },
+    pricing: {
+      model: "per_request",
+      tier: "baseline",
+      cost_usd: 0.005,
+      currency: "USD",
+      billing_code: "fund_nav_history_v1",
+    },
+    performance: {
+      avg_latency_ms: 200,
+      p95_latency_ms: 500,
+      availability_sla: 99.9,
+      rate_limit_per_minute: 60,
+    },
+    confidence: {
+      data_quality_score: 0.95,
+      update_frequency: "daily",
+      sources: ["ds_nav.zarr", "funds"],
+    },
+    tags: ["funds", "history", "time-series", "nav"],
+  },
+  {
     id: "fund-holdings",
     name: "Fund Top-N Holdings",
     description:

--- a/lib/dal/funds-zarr-reader.ts
+++ b/lib/dal/funds-zarr-reader.ts
@@ -284,6 +284,66 @@ export async function readFundPortfolioSeries(
 }
 
 // ---------------------------------------------------------------------------
+// NAV — ds_nav.zarr (per-fund yfinance NAV time series)
+//
+// Layout: coords (teo,); data_vars nav_close (teo,) and nav_return_monthly
+// (teo,). Produced by Funds_DAG's fund_nav_zarr v3 asset, which pulls daily
+// NAV by ticker_primary and resamples to month-end. Replaces the legacy
+// step_1b factset_fund_id-keyed multi-fund yf_nav_returns zarr at the API
+// surface — the API only ever sees bw_fund_id-keyed per-fund layouts.
+// ---------------------------------------------------------------------------
+
+export interface FundNavRow {
+  teo: string;
+  nav_close: number | null;
+  nav_return_monthly: number | null;
+}
+
+const NAV_VARS = ["nav_close", "nav_return_monthly"] as const;
+
+/**
+ * Read the per-fund NAV time series from GCS.
+ * Returns [] when the fund has no zarr or no overlap with the date window.
+ */
+export async function readFundNavSeries(
+  bwFundId: string,
+  options: FundPortfolioOptions = {},
+): Promise<FundNavRow[]> {
+  const grp = await openFundZarrGroup(bwFundId, "ds_nav.zarr");
+  if (!grp) return [];
+
+  const teos = await readTeoStrings(grp);
+  if (!teos || teos.length === 0) return [];
+
+  let t0 = 0;
+  let t1 = teos.length;
+  if (options.startDate) {
+    while (t0 < t1 && teos[t0]! < options.startDate) t0++;
+  }
+  if (options.endDate) {
+    while (t1 > t0 && teos[t1 - 1]! > options.endDate) t1--;
+  }
+  if (t0 >= t1) return [];
+
+  const series = await Promise.all(
+    NAV_VARS.map(async (varName) => ({
+      name: varName,
+      data: await readFloatSlice1d(grp, varName, t0, t1),
+    })),
+  );
+
+  const rows: FundNavRow[] = [];
+  for (let i = 0; i < t1 - t0; i++) {
+    const row: Record<string, unknown> = { teo: teos[t0 + i]! };
+    for (const s of series) {
+      row[s.name] = s.data?.[i] ?? null;
+    }
+    rows.push(row as unknown as FundNavRow);
+  }
+  return rows;
+}
+
+// ---------------------------------------------------------------------------
 // Holdings — ds_ph.zarr (Slice 5)
 //
 // Layout: coords (symbol = bw_sym_id, teo); data_vars adj_mv (symbol, teo),

--- a/tests/funds-nav-route.test.ts
+++ b/tests/funds-nav-route.test.ts
@@ -1,0 +1,154 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest, type NextResponse } from "next/server";
+
+vi.mock("@/lib/agent/billing-middleware", () => ({
+  withBilling: <T extends (...args: unknown[]) => unknown>(handler: T) => handler,
+}));
+
+vi.mock("@/lib/dal/funds-engine", () => ({
+  fetchFund: vi.fn(),
+}));
+
+vi.mock("@/lib/dal/funds-zarr-reader", () => ({
+  readFundNavSeries: vi.fn(),
+}));
+
+import { fetchFund } from "@/lib/dal/funds-engine";
+import { readFundNavSeries } from "@/lib/dal/funds-zarr-reader";
+import type { BillingContext } from "@/lib/agent/billing-middleware";
+import { GET as wrappedGET } from "@/app/api/funds/[bw_fund_id]/nav/route";
+
+const GET = wrappedGET as unknown as (
+  req: NextRequest,
+  ctx: BillingContext,
+) => Promise<NextResponse>;
+
+const FUND = {
+  bw_fund_id: "BW-FUND-S000001243",
+  series_id: "S000001243",
+  ticker: "NOLCX",
+  cik: "0000916620",
+  fund_name: "Northern Large Cap Core Fund",
+  morningstar_category: null,
+  equity_style_9box: "Large Blend",
+  style_link_method: null,
+  primary_bw_fund_id: null,
+  latest_report_date: "2026-04-30",
+  latest_filing_date: "2026-07-14",
+  latest_extracted_at: null,
+  latest_total_adj_mv: 1000,
+  latest_n_holdings: 100,
+  latest_effective_n: 50,
+  last_in_eligible_universe_at: null,
+  metadata: {},
+};
+
+const ROW = (teo: string, close: number, ret: number | null) => ({
+  teo,
+  nav_close: close,
+  nav_return_monthly: ret,
+});
+
+const fakeContext: BillingContext = {
+  userId: "test-user",
+  requestId: "test-req",
+  capabilityId: "fund-nav-history",
+  costUsd: 0.005,
+  startTime: Date.now(),
+};
+
+function req(path: string): NextRequest {
+  return new NextRequest(new Request(`http://localhost${path}`));
+}
+
+beforeEach(() => {
+  vi.mocked(fetchFund).mockReset();
+  vi.mocked(readFundNavSeries).mockReset();
+});
+
+describe("GET /api/funds/[bw_fund_id]/nav", () => {
+  it("returns 200 with rows + summary when both DALs return data", async () => {
+    vi.mocked(fetchFund).mockResolvedValue(FUND);
+    vi.mocked(readFundNavSeries).mockResolvedValue([
+      ROW("2026-02-29", 100.0, 0.02),
+      ROW("2026-03-31", 102.0, 0.02),
+      ROW("2026-04-30", 99.0, -0.0294),
+    ]);
+    const res = await GET(
+      req("/api/funds/BW-FUND-S000001243/nav"),
+      fakeContext,
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("X-Data-As-Of")).toBe("2026-04-30");
+    expect(res.headers.get("X-Data-Filing-Date")).toBe("2026-07-14");
+    const body = await res.json();
+    expect(body.bw_fund_id).toBe("BW-FUND-S000001243");
+    expect(body.ticker).toBe("NOLCX");
+    expect(body.fund_name).toBe("Northern Large Cap Core Fund");
+    expect(body.equity_style_9box).toBe("Large Blend");
+    expect(body.n_periods).toBe(3);
+    expect(body.start_teo).toBe("2026-02-29");
+    expect(body.end_teo).toBe("2026-04-30");
+    expect(body.rows).toHaveLength(3);
+    expect(body.rows[0].nav_close).toBeCloseTo(100.0);
+    expect(body.rows[0].nav_return_monthly).toBeCloseTo(0.02);
+  });
+
+  it("returns 404 when fund registry row missing (skips zarr open)", async () => {
+    vi.mocked(fetchFund).mockResolvedValue(null);
+    const res = await GET(
+      req("/api/funds/BW-FUND-MISSING/nav"),
+      fakeContext,
+    );
+    expect(res.status).toBe(404);
+    expect(vi.mocked(readFundNavSeries)).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when zarr returns empty rows (registry exists)", async () => {
+    vi.mocked(fetchFund).mockResolvedValue(FUND);
+    vi.mocked(readFundNavSeries).mockResolvedValue([]);
+    const res = await GET(
+      req("/api/funds/BW-FUND-S000001243/nav"),
+      fakeContext,
+    );
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toBe("No NAV history available for this fund");
+  });
+
+  it("forwards start_date / end_date to the DAL", async () => {
+    vi.mocked(fetchFund).mockResolvedValue(FUND);
+    vi.mocked(readFundNavSeries).mockResolvedValue([
+      ROW("2026-04-30", 99.0, null),
+    ]);
+    await GET(
+      req(
+        "/api/funds/BW-FUND-S000001243/nav?start_date=2026-01-31&end_date=2026-04-30",
+      ),
+      fakeContext,
+    );
+    expect(vi.mocked(readFundNavSeries)).toHaveBeenCalledWith(
+      "BW-FUND-S000001243",
+      { startDate: "2026-01-31", endDate: "2026-04-30" },
+    );
+  });
+
+  it("rejects malformed date params", async () => {
+    const res = await GET(
+      req("/api/funds/BW-FUND-S000001243/nav?start_date=01-31-2026"),
+      fakeContext,
+    );
+    expect(res.status).toBe(400);
+    expect(vi.mocked(fetchFund)).not.toHaveBeenCalled();
+  });
+
+  it("rejects start_date > end_date", async () => {
+    const res = await GET(
+      req(
+        "/api/funds/BW-FUND-S000001243/nav?start_date=2026-04-30&end_date=2026-01-31",
+      ),
+      fakeContext,
+    );
+    expect(res.status).toBe(400);
+  });
+});


### PR DESCRIPTION
## Summary

- New `readFundNavSeries(bwFundId, options)` in `lib/dal/funds-zarr-reader.ts` — opens the per-fund `ds_nav.zarr` on GCS produced by Funds_DAG's `fund_nav_zarr` asset, returns one row per month-end with `nav_close` + `nav_return_monthly`. Mirrors `readFundPortfolioSeries` in shape, including inclusive `startDate` / `endDate` trimming.
- New route `GET /api/funds/{bw_fund_id}/nav` — capability `fund-nav-history` @ $0.005. Same shape as `/portfolio`.
- Capability registered with daily update cadence and `ds_nav.zarr` + `funds` lineage.

## Why

The fund tearsheet (Stage D.2) plots cumulative gross-fund return alongside the ERM3 L1/L2/L3/Residual layers. Without actual NAV, the chart is purely 13F-derived attribution — useful but a quant could roughly reconstruct it. Adding NAV makes the chart show "what the holdings would have done" vs "what investors actually realised"; the gap surfaces intra-quarter trading, fees, and cash drag not visible in 13F. That gap is the institutional-grade insight.

This slice ships the data plane; the F1 tearsheet template (D.2.a) consumes it.

## Test plan

- [x] 6 route tests: happy path, registry-miss 404, empty-zarr 404, date-param forwarding, malformed dates, inverted range (`tests/funds-nav-route.test.ts`)
- [x] Type-check clean (`tsc --noEmit`)
- [x] End-to-end verified: NOLCX (BW-FUND-S000001243) ds_nav.zarr is synced to `gs://rm_api_data/ERM3_Funds/bw_fund_id/.../` with the correct xarray-Dataset structure (.zgroup + nav_close/ + nav_return_monthly/ + teo/ subdirectories, .zmetadata consolidated)
- [x] Funds_DAG fund_nav_zarr asset materialized for the full universe (6,157 funds built, 0 failed) — full GCS sync running in parallel

## Cross-repo dependency

Depends on Funds_DAG #2 (fund_nav_zarr asset) — already merged. Also depends on the GCS sync of per-fund ds_nav.zarr to `gs://rm_api_data/ERM3_Funds/bw_fund_id/{BW-FUND-...}/` — NOLCX is up; full universe sync in flight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)