### PR TITLE
B.2.d: extend D.1 fund snapshot with nav_history block

### DIFF
--- a/app/api/funds/snapshot/[bw_fund_id]/route.ts
+++ b/app/api/funds/snapshot/[bw_fund_id]/route.ts
@@ -8,6 +8,7 @@ import {
 import {
   readFundHedgeLatest,
   readFundHoldingsTopN,
+  readFundNavSeries,
   readFundPortfolioSeries,
 } from "@/lib/dal/funds-zarr-reader";
 import { composeFundSnapshot } from "@/lib/funds/snapshot-composer";
@@ -66,11 +67,15 @@ export const GET = withBilling(
       ? fetchStyleCohortLatest(fund.equity_style_9box)
       : Promise.resolve([]);
 
-    const [holdings, hedge, portfolioHistory, cohortRanks, cohortMetrics] =
+    const [holdings, hedge, portfolioHistory, navHistory, cohortRanks, cohortMetrics] =
       await Promise.all([
         readFundHoldingsTopN(bwFundId, HOLDINGS_TOP_N),
         readFundHedgeLatest(bwFundId),
         readFundPortfolioSeries(bwFundId, {
+          startDate,
+          endDate: latest.report_date,
+        }),
+        readFundNavSeries(bwFundId, {
           startDate,
           endDate: latest.report_date,
         }),
@@ -84,6 +89,7 @@ export const GET = withBilling(
       holdings,
       hedge,
       portfolioHistory,
+      navHistory,
       cohortRanks,
       cohortMetrics,
     });

--- a/lib/funds/snapshot-composer.ts
+++ b/lib/funds/snapshot-composer.ts
@@ -24,6 +24,7 @@ import type {
   CohortPortfolioRow,
   FundHedgeSnapshot,
   FundHoldingsSnapshot,
+  FundNavRow,
   FundPortfolioRow,
 } from "@/lib/dal/funds-zarr-reader";
 import { formatFundMetrics, type FundMetricsResponse } from "@/lib/funds/format";
@@ -41,6 +42,12 @@ export interface FundSnapshotPrimitives {
   holdings: FundHoldingsSnapshot | null;
   hedge: FundHedgeSnapshot | null;
   portfolioHistory: FundPortfolioRow[];
+  /**
+   * yfinance NAV history for this fund (Funds_DAG fund_nav_zarr asset).
+   * Optional — funds without a yfinance-resolvable ticker won't have a
+   * ds_nav.zarr, in which case the composer drops the nav_history block.
+   */
+  navHistory: FundNavRow[];
   cohortRanks: StyleRankingRow[];
   /** Optional cell metrics (e.g. for n_funds_in_cell when the fund's cell row exists). */
   cohortMetrics: StylePortfolioRow[];
@@ -73,6 +80,18 @@ export interface FundSnapshot {
     n_periods: number;
     rows: FundPortfolioRow[];
   };
+  /**
+   * Actual fund NAV (yfinance) over the same lookback window as
+   * portfolio_history. Pairs with portfolio_history so consumers can
+   * overlay 13F-derived attribution against realised NAV — the gap
+   * surfaces intra-quarter trading, fees, and cash drag. Null when the
+   * fund has no yfinance ticker or no NAV zarr.
+   */
+  nav_history: {
+    lookback_months: number;
+    n_periods: number;
+    rows: FundNavRow[];
+  } | null;
   cohort_context: {
     equity_style_9box: string | null;
     n_funds_in_cell: number | null;
@@ -87,9 +106,10 @@ export interface FundSnapshot {
 }
 
 export function composeFundSnapshot(p: FundSnapshotPrimitives): FundSnapshot {
-  const { fund, latest, holdings, hedge, portfolioHistory, cohortRanks } = p;
+  const { fund, latest, holdings, hedge, portfolioHistory, navHistory, cohortRanks } = p;
 
   const trimmed = trimToLookbackMonths(portfolioHistory, FUND_LOOKBACK_MONTHS);
+  const navTrimmed = trimNavToLookbackMonths(navHistory, FUND_LOOKBACK_MONTHS);
 
   const ranks: FundCohortRankEntry[] = cohortRanks.map((r) => ({
     metric: r.metric,
@@ -131,6 +151,13 @@ export function composeFundSnapshot(p: FundSnapshotPrimitives): FundSnapshot {
       n_periods: trimmed.length,
       rows: trimmed,
     },
+    nav_history: navTrimmed.length > 0
+      ? {
+          lookback_months: FUND_LOOKBACK_MONTHS,
+          n_periods: navTrimmed.length,
+          rows: navTrimmed,
+        }
+      : null,
     cohort_context: fund.equity_style_9box
       ? {
           equity_style_9box: fund.equity_style_9box,
@@ -294,6 +321,14 @@ function trimToLookbackMonths(
   rows: FundPortfolioRow[],
   months: number,
 ): FundPortfolioRow[] {
+  if (rows.length <= months) return rows;
+  return rows.slice(rows.length - months);
+}
+
+function trimNavToLookbackMonths(
+  rows: FundNavRow[],
+  months: number,
+): FundNavRow[] {
   if (rows.length <= months) return rows;
   return rows.slice(rows.length - months);
 }

--- a/tests/funds-snapshot-composer.test.ts
+++ b/tests/funds-snapshot-composer.test.ts
@@ -38,6 +38,7 @@ describe("composeFundSnapshot (real fixtures: NOLCX / Northern Large Cap Core)",
     holdings: null,
     hedge: null,
     portfolioHistory: [],
+    navHistory: [],
     cohortRanks: FUND_COHORT_RANKS,
     cohortMetrics: COHORT_METRICS,
   };
@@ -121,6 +122,42 @@ describe("composeFundSnapshot (real fixtures: NOLCX / Northern Large Cap Core)",
     expect(snap.portfolio_history.n_periods).toBe(12);
     expect(snap.portfolio_history.rows[0].teo).toBe(teos[6]);
     expect(snap.portfolio_history.rows[11].teo).toBe(teos[17]);
+  });
+
+  it("nav_history is null when navHistory is empty (fund has no yfinance ticker / zarr)", () => {
+    const snap = composeFundSnapshot(basePrimitives);
+    expect(snap.nav_history).toBeNull();
+  });
+
+  it("populates nav_history with the rows + lookback_months when navHistory is provided", () => {
+    const navRows = [
+      { teo: "2026-03-31", nav_close: 32.5, nav_return_monthly: 0.012 },
+      { teo: "2026-04-30", nav_close: 33.16, nav_return_monthly: 0.0203 },
+    ];
+    const snap = composeFundSnapshot({ ...basePrimitives, navHistory: navRows });
+    expect(snap.nav_history).not.toBeNull();
+    expect(snap.nav_history!.lookback_months).toBe(12);
+    expect(snap.nav_history!.n_periods).toBe(2);
+    expect(snap.nav_history!.rows).toEqual(navRows);
+  });
+
+  it("trims nav_history to the trailing 12 months when more is provided", () => {
+    const teos: string[] = [];
+    for (let m = 1; m <= 18; m++) {
+      const d = new Date(Date.UTC(2025, m - 1, 1));
+      d.setUTCMonth(d.getUTCMonth() + 1);
+      d.setUTCDate(0);
+      teos.push(d.toISOString().slice(0, 10));
+    }
+    const synthetic = teos.map((teo) => ({
+      teo,
+      nav_close: 100,
+      nav_return_monthly: 0.01,
+    }));
+    const snap = composeFundSnapshot({ ...basePrimitives, navHistory: synthetic });
+    expect(snap.nav_history!.n_periods).toBe(12);
+    expect(snap.nav_history!.rows[0].teo).toBe(teos[6]);
+    expect(snap.nav_history!.rows[11].teo).toBe(teos[17]);
   });
 });
 

--- a/tests/funds-snapshot-routes.test.ts
+++ b/tests/funds-snapshot-routes.test.ts
@@ -18,6 +18,7 @@ vi.mock("@/lib/dal/funds-zarr-reader", () => ({
   readFundHoldingsTopN: vi.fn(),
   readFundHedgeLatest: vi.fn(),
   readFundPortfolioSeries: vi.fn(),
+  readFundNavSeries: vi.fn(),
   readStyleCohortHoldingsTopN: vi.fn(),
   readStyleCohortPortfolioSeries: vi.fn(),
 }));
@@ -31,6 +32,7 @@ import {
 import {
   readFundHedgeLatest,
   readFundHoldingsTopN,
+  readFundNavSeries,
   readFundPortfolioSeries,
   readStyleCohortHoldingsTopN,
   readStyleCohortPortfolioSeries,
@@ -87,6 +89,7 @@ beforeEach(() => {
   vi.mocked(readFundHoldingsTopN).mockReset();
   vi.mocked(readFundHedgeLatest).mockReset();
   vi.mocked(readFundPortfolioSeries).mockReset();
+  vi.mocked(readFundNavSeries).mockReset();
   vi.mocked(readStyleCohortHoldingsTopN).mockReset();
   vi.mocked(readStyleCohortPortfolioSeries).mockReset();
 });
@@ -97,6 +100,7 @@ describe("GET /api/funds/snapshot/[bw_fund_id]", () => {
     vi.mocked(readFundHoldingsTopN).mockResolvedValue(null);
     vi.mocked(readFundHedgeLatest).mockResolvedValue(null);
     vi.mocked(readFundPortfolioSeries).mockResolvedValue([]);
+    vi.mocked(readFundNavSeries).mockResolvedValue([]);
     vi.mocked(fetchFundCohortRanks).mockResolvedValue(FUND_COHORT_RANKS);
     vi.mocked(fetchStyleCohortLatest).mockResolvedValue(COHORT_METRICS);
 


### PR DESCRIPTION
## Summary

Builds on PR #31 (now merged) — pulls per-fund NAV into the composed `/api/funds/snapshot/{bw_fund_id}` JSON via a new optional `nav_history` block.

- `composeFundSnapshot()` now accepts a `navHistory: FundNavRow[]` primitive and emits `nav_history: { lookback_months, n_periods, rows } | null`. Same trimming convention as `portfolio_history` (trailing 12 months).
- The snapshot route fetches NAV alongside the other parallel reads (`Promise.all`) so wall-clock impact is one extra GCS open + slice — sub-100ms in practice.
- Block is `null` when the fund has no yfinance ticker / no `ds_nav.zarr`. The last asset materialize had 6,157 funds with NAV out of 9,701, so ~35% of the universe will see `nav_history: null` (institutional SMAs, separately-managed accounts, mutual funds without retail tickers).

## Why pair these in the snapshot

`portfolio_history` is 13F-derived holdings attribution; `nav_history` is what investors actually realised. The gap between them surfaces intra-quarter trading, fees, and cash drag — the institutional-grade insight the F1 fund tearsheet (D.2.a) plots on its cumulative-returns chart.

## Test plan

- [x] 3 new composer test cases: `nav_history` null when empty, populated when provided, trimmed to trailing 12 months when ≥12 (`tests/funds-snapshot-composer.test.ts`)
- [x] Snapshot route mock list updated to include `readFundNavSeries`; the existing happy-path test still passes
- [x] All 22 fund snapshot tests passing
- [x] Type-check clean

## Cross-repo dependency

Already-merged: Funds_DAG #2 (asset), RiskModels_API #31 (reader + endpoint). Full GCS sync of all 6,157 ds_nav.zarr files in flight (`xr.to_zarr` direct upload — `rsync_zarr_to_gcs` mangles xarray Datasets, follow-up issue worth filing on Funds_DAG).

🤖 Generated with [Claude Code](https://claude.com/claude-code)