### PR TITLE
D.2.a: F1 fund tearsheet HTML template (Letter landscape)

### DIFF
--- a/app/(print)/render-snapshot/funds/[bw_fund_id]/page.tsx
+++ b/app/(print)/render-snapshot/funds/[bw_fund_id]/page.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+/**
+ * /render-snapshot/funds/[bw_fund_id] — F1 fund tearsheet print template.
+ *
+ * Mounted by Playwright in the D.2.b PDF route. The browser navigates here,
+ * the route injects `window.__FUND_SNAPSHOT__` with the composed
+ * FundSnapshot JSON, dispatches `fund-snapshot-ready`, and waits for the
+ * `[data-report-ready="true"]` sentinel before calling `page.pdf()`.
+ *
+ * The route is also useful for designers — appending the JSON via a
+ * fetch in a small dev helper renders the live tearsheet in a tab.
+ */
+
+import { useEffect, useState } from "react";
+
+import type { FundSnapshot } from "@/lib/funds/snapshot-composer";
+import { F1FundTearsheet } from "@/lib/funds/snapshot-templates/F1FundTearsheet";
+
+declare global {
+  interface Window {
+    __FUND_SNAPSHOT__?: FundSnapshot;
+  }
+}
+
+export default function RenderFundSnapshotPage() {
+  const [snap, setSnap] = useState<FundSnapshot | null>(null);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    if (window.__FUND_SNAPSHOT__) {
+      setSnap(window.__FUND_SNAPSHOT__);
+      return;
+    }
+    const handler = () => {
+      if (window.__FUND_SNAPSHOT__) {
+        setSnap(window.__FUND_SNAPSHOT__);
+      }
+    };
+    window.addEventListener("fund-snapshot-ready", handler);
+    return () => window.removeEventListener("fund-snapshot-ready", handler);
+  }, []);
+
+  if (!snap) {
+    return (
+      <div
+        style={{
+          padding: 48,
+          color: "#9ca3af",
+          fontSize: 14,
+          fontFamily: "'Inter', sans-serif",
+        }}
+      >
+        Waiting for fund snapshot data…
+      </div>
+    );
+  }
+
+  return <F1FundTearsheet snap={snap} />;
+}

--- a/lib/funds/snapshot-templates/F1FundTearsheet.tsx
+++ b/lib/funds/snapshot-templates/F1FundTearsheet.tsx
@@ -1,0 +1,497 @@
+/**
+ * F1 — Fund Tearsheet (Letter landscape, server-rendered via Playwright).
+ *
+ * Single-page institutional tearsheet for one mutual fund. Consumes the
+ * composed FundSnapshot JSON shipped by `/api/funds/snapshot/{bw_fund_id}`
+ * (Stage D.1 + B.2.d nav_history) and lays out four analytical zones plus
+ * an identity rail:
+ *
+ *   ┌──────────────────────────────────────────────────────────────┐
+ *   │  Header (fund name + ticker chip + as-of)                    │
+ *   ├──────────────┬───────────────────────────────────────────────┤
+ *   │ Identity     │ AI summary lead                                │
+ *   │  rail        ├───────────────────────────────────────────────┤
+ *   │  (24%)       │ I. Cumulative Returns (line + waterfall)      │
+ *   │              ├───────────────────────────────────────────────┤
+ *   │              │ II. Cohort Rank Card                          │
+ *   │              ├───────────────────────────────────────────────┤
+ *   │              │ III. Top Holdings                             │
+ *   ├──────────────┴───────────────────────────────────────────────┤
+ *   │ Footer (lineage + confidentiality)                           │
+ *   └──────────────────────────────────────────────────────────────┘
+ *
+ * No external chart library — all charts are pure SVG. Inline styles only;
+ * no Tailwind on this template so the print/CSS budget stays small and
+ * Playwright doesn't fight cascade resolution during PDF generation.
+ */
+
+import React from "react";
+
+import type { FundSnapshot } from "@/lib/funds/snapshot-composer";
+
+import { LAYER_COLORS, PAGE, PALETTE, SPACING } from "./_theme";
+import { buildWaterfall, computeCumulativeSeries } from "./cumulative-math";
+import { CumulativeChart } from "./components/CumulativeChart";
+
+// ─────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────
+
+function fmtPct(x: number | null, decimals = 1, signed = true): string {
+  if (x == null) return "—";
+  const v = x * 100;
+  return signed ? `${v >= 0 ? "+" : ""}${v.toFixed(decimals)}%` : `${v.toFixed(decimals)}%`;
+}
+
+function fmtNum(x: number | null, decimals = 2): string {
+  if (x == null) return "—";
+  return x.toFixed(decimals);
+}
+
+function fmtCount(x: number | null): string {
+  if (x == null) return "—";
+  return x.toLocaleString();
+}
+
+function pctColor(x: number | null): string {
+  if (x == null) return PALETTE.textMid;
+  return x >= 0 ? PALETTE.green : PALETTE.orange;
+}
+
+/**
+ * Lead-sentence narrative summary derived directly from the snapshot data.
+ * Real model-generated insights land in a follow-up; this version surfaces
+ * the dominant risk driver + selection α + cohort rank highlight.
+ */
+function buildAiSummary(snap: FundSnapshot, navEndpoint: number | null, grossEndpoint: number): string {
+  const m = snap.metrics.returns;
+  const factors = {
+    market: Math.abs(m.market ?? 0),
+    sector: Math.abs(m.sector ?? 0),
+    subsector: Math.abs(m.subsector ?? 0),
+    residual: Math.abs(m.idiosyncratic ?? 0),
+  };
+  const total = factors.market + factors.sector + factors.subsector + factors.residual || 1e-9;
+  const dominant = (Object.entries(factors).sort(([, a], [, b]) => b - a)[0] ?? ["market", 0])[0];
+  const dominantPct = (factors[dominant as keyof typeof factors] / total) * 100;
+
+  const bestRank = snap.cohort_context?.ranks.reduce<{ metric: string; rank: number; size: number | null } | null>(
+    (acc, r) => {
+      if (r.cohort_size == null || r.cohort_size === 0) return acc;
+      const pct = r.rank / r.cohort_size;
+      if (acc == null || pct < acc.rank / (acc.size ?? r.cohort_size)) {
+        return { metric: r.metric, rank: r.rank, size: r.cohort_size };
+      }
+      return acc;
+    },
+    null,
+  );
+
+  const lead = `${dominant.charAt(0).toUpperCase() + dominant.slice(1)} is the dominant return driver (${dominantPct.toFixed(0)}% of attribution); residual α of ${fmtPct(m.idiosyncratic)} reflects stock selection.`;
+  const bits: string[] = [];
+  if (navEndpoint != null) {
+    const gap = navEndpoint - grossEndpoint;
+    bits.push(
+      `Realised NAV ${fmtPct(navEndpoint)} ${gap >= 0 ? "outpaces" : "trails"} the 13F-derived gross by ${fmtPct(Math.abs(gap), 1, false)} — gap captures intra-quarter trading + fees`,
+    );
+  }
+  if (bestRank) {
+    bits.push(`ranks ${bestRank.rank} of ${bestRank.size} in ${snap.equity_style_9box ?? "cohort"} on ${bestRank.metric.replace(/_/g, " ")}`);
+  }
+  return bits.length > 0 ? `${lead} ${bits.join("; ")}.` : lead;
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Identity rail
+// ─────────────────────────────────────────────────────────────────────
+
+function IdentityRail({ snap }: { snap: FundSnapshot }) {
+  const m = snap.metrics;
+  const nFundsInCell = snap.cohort_context?.n_funds_in_cell ?? null;
+
+  const Row = ({ label, value, valueColor }: { label: string; value: string; valueColor?: string }) => (
+    <div style={{ display: "flex", justifyContent: "space-between", padding: "3px 0", fontSize: 10 }}>
+      <span style={{ color: PALETTE.textMid }}>{label}</span>
+      <span style={{ fontWeight: 600, color: valueColor ?? PALETTE.textDark }}>{value}</span>
+    </div>
+  );
+  const SectionHead = ({ children }: { children: string }) => (
+    <div
+      style={{
+        marginTop: SPACING.md,
+        marginBottom: 4,
+        fontSize: 9,
+        fontWeight: 600,
+        color: PALETTE.textLight,
+        letterSpacing: 0.6,
+        borderBottom: `1px solid ${PALETTE.axisLine}`,
+        paddingBottom: 2,
+      }}
+    >
+      {children}
+    </div>
+  );
+
+  return (
+    <div
+      style={{
+        background: PALETTE.bgLight,
+        border: `1px solid ${PALETTE.axisLine}`,
+        borderRadius: 4,
+        padding: SPACING.md,
+        height: "100%",
+        boxSizing: "border-box",
+      }}
+    >
+      <div style={{ fontSize: 14, fontWeight: 700, color: PALETTE.navy, lineHeight: 1.15 }}>
+        {snap.fund_name ?? snap.bw_fund_id}
+      </div>
+      <div style={{ fontSize: 10, color: PALETTE.textMid, marginTop: 3 }}>
+        {snap.ticker ?? snap.bw_fund_id} · {snap.report_date}
+      </div>
+
+      <SectionHead>IDENTITY</SectionHead>
+      <Row label="bw_fund_id" value={snap.bw_fund_id} />
+      <Row label="9-box cell" value={snap.equity_style_9box ?? "—"} />
+      <Row label="Funds in cell" value={fmtCount(nFundsInCell)} />
+      <Row label="Holdings" value={fmtCount(m.diagnostics.n_holdings_active)} />
+      <Row label="Effective N" value={fmtNum(m.diagnostics.effective_n, 1)} />
+
+      <SectionHead>TRAILING RETURN (PORTFOLIO)</SectionHead>
+      <Row label="Gross" value={fmtPct(m.returns.gross)} valueColor={pctColor(m.returns.gross)} />
+      <Row label="Market (L1)" value={fmtPct(m.returns.market)} valueColor={pctColor(m.returns.market)} />
+      <Row label="Sector (L2)" value={fmtPct(m.returns.sector)} valueColor={pctColor(m.returns.sector)} />
+      <Row label="Subsector (L3)" value={fmtPct(m.returns.subsector)} valueColor={pctColor(m.returns.subsector)} />
+      <Row label="Residual α" value={fmtPct(m.returns.idiosyncratic)} valueColor={pctColor(m.returns.idiosyncratic)} />
+
+      <SectionHead>CONCENTRATION</SectionHead>
+      <Row label="Top-10 weight" value={fmtPct(m.diagnostics.top10_weight_sum, 1, false)} />
+      <Row label="Weight sum" value={fmtPct(m.diagnostics.weight_sum, 1, false)} />
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Cohort rank card (II)
+// ─────────────────────────────────────────────────────────────────────
+
+function CohortRankCard({ snap }: { snap: FundSnapshot }) {
+  const ranks = snap.cohort_context?.ranks ?? [];
+  if (ranks.length === 0) {
+    return (
+      <div style={{ fontSize: 10, color: PALETTE.textMid, fontStyle: "italic" }}>
+        No cohort rankings available for this fund.
+      </div>
+    );
+  }
+  // Take a representative subset — first 6 distinct (metric, period_window) entries.
+  const sorted = [...ranks]
+    .filter((r) => r.cohort_size != null && r.cohort_size > 0)
+    .slice(0, 6);
+  const cellName = snap.cohort_context?.equity_style_9box ?? "cohort";
+
+  return (
+    <div>
+      <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 10 }}>
+        <thead>
+          <tr style={{ color: PALETTE.textMid, borderBottom: `1px solid ${PALETTE.axisLine}` }}>
+            <th style={{ textAlign: "left", padding: "3px 6px", fontWeight: 600 }}>Metric</th>
+            <th style={{ textAlign: "left", padding: "3px 6px", fontWeight: 600 }}>Window</th>
+            <th style={{ textAlign: "right", padding: "3px 6px", fontWeight: 600 }}>Rank</th>
+            <th style={{ width: "40%", padding: "3px 6px" }}>Percentile in {cellName}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {sorted.map((r, i) => {
+            const pct = r.cohort_size ? (1 - r.rank / r.cohort_size) * 100 : null;
+            const tone = pct == null ? PALETTE.textMid : pct >= 50 ? PALETTE.green : PALETTE.orange;
+            return (
+              <tr key={`${r.metric}-${r.period_window}-${i}`} style={{ borderBottom: `1px solid ${PALETTE.axisLine}` }}>
+                <td style={{ padding: "3px 6px", color: PALETTE.textDark }}>
+                  {r.metric.replace(/_/g, " ")}
+                </td>
+                <td style={{ padding: "3px 6px", color: PALETTE.textMid }}>{r.period_window}</td>
+                <td style={{ padding: "3px 6px", textAlign: "right", fontWeight: 600 }}>
+                  {r.rank} / {r.cohort_size}
+                </td>
+                <td style={{ padding: "3px 6px" }}>
+                  <div
+                    style={{
+                      position: "relative",
+                      height: 10,
+                      background: PALETTE.axisLine,
+                      borderRadius: 1,
+                    }}
+                  >
+                    {pct != null && (
+                      <div
+                        style={{
+                          position: "absolute",
+                          left: 0,
+                          top: 0,
+                          height: "100%",
+                          width: `${pct}%`,
+                          background: tone,
+                          borderRadius: 1,
+                        }}
+                      />
+                    )}
+                  </div>
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Holdings table (III)
+// ─────────────────────────────────────────────────────────────────────
+
+function HoldingsTable({ snap }: { snap: FundSnapshot }) {
+  const top = snap.holdings?.top ?? [];
+  if (top.length === 0) {
+    return (
+      <div style={{ fontSize: 10, color: PALETTE.textMid, fontStyle: "italic" }}>
+        No holdings available.
+      </div>
+    );
+  }
+  const rows = top.slice(0, 10);
+  return (
+    <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 10 }}>
+      <thead>
+        <tr style={{ color: PALETTE.textMid, borderBottom: `1px solid ${PALETTE.axisLine}` }}>
+          <th style={{ textAlign: "left", padding: "3px 6px", fontWeight: 600 }}>Symbol</th>
+          <th style={{ textAlign: "right", padding: "3px 6px", fontWeight: 600 }}>Adj MV</th>
+          <th style={{ textAlign: "right", padding: "3px 6px", fontWeight: 600 }}>Weight</th>
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((h) => (
+          <tr key={h.bw_sym_id} style={{ borderBottom: `1px solid ${PALETTE.axisLine}` }}>
+            <td style={{ padding: "3px 6px", color: PALETTE.textDark, fontFamily: "monospace" }}>
+              {h.bw_sym_id}
+            </td>
+            <td style={{ padding: "3px 6px", textAlign: "right" }}>
+              {h.adj_mv ? `$${(h.adj_mv / 1_000_000).toFixed(1)}M` : "—"}
+            </td>
+            <td style={{ padding: "3px 6px", textAlign: "right", fontWeight: 600 }}>
+              {h.weight != null ? fmtPct(h.weight, 2, false) : "—"}
+            </td>
+          </tr>
+        ))}
+        {snap.holdings && snap.holdings.n_total_holdings > rows.length && (
+          <tr>
+            <td colSpan={3} style={{ padding: "3px 6px", fontSize: 9, color: PALETTE.textLight, fontStyle: "italic" }}>
+              + {snap.holdings.n_total_holdings - rows.length} smaller positions not shown
+            </td>
+          </tr>
+        )}
+      </tbody>
+    </table>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Section header helper
+// ─────────────────────────────────────────────────────────────────────
+
+function SectionTitle({ index, title, blurb }: { index: string; title: string; blurb?: string }) {
+  return (
+    <div style={{ marginBottom: SPACING.xs }}>
+      <div style={{ display: "flex", alignItems: "baseline", gap: SPACING.sm }}>
+        <span style={{ color: PALETTE.navy, fontSize: 12, fontWeight: 700 }}>{index}.</span>
+        <span style={{ color: PALETTE.navy, fontSize: 12, fontWeight: 600 }}>{title}</span>
+      </div>
+      {blurb && (
+        <div style={{ color: PALETTE.teal, fontSize: 9, fontStyle: "italic", marginTop: 1 }}>
+          {blurb}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Main composition
+// ─────────────────────────────────────────────────────────────────────
+
+export function F1FundTearsheet({ snap }: { snap: FundSnapshot }) {
+  const series = computeCumulativeSeries(
+    snap.portfolio_history.rows,
+    snap.nav_history?.rows ?? [],
+  );
+  const waterfall = buildWaterfall(series);
+  const grossEnd = waterfall.gross;
+  const navEnd = waterfall.nav;
+  const summary = buildAiSummary(snap, navEnd, grossEnd);
+
+  return (
+    <div
+      data-report-ready="true"
+      style={{
+        width: PAGE.width,
+        height: PAGE.height,
+        padding: PAGE.margin,
+        boxSizing: "border-box",
+        background: PALETTE.white,
+        color: PALETTE.textDark,
+        fontFamily:
+          "'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
+        position: "relative",
+        display: "flex",
+        flexDirection: "column",
+      }}
+    >
+      {/* ── Header ──────────────────────────────────────────────── */}
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "flex-start",
+          paddingBottom: SPACING.sm,
+          borderBottom: `2px solid ${PALETTE.navy}`,
+        }}
+      >
+        <div>
+          <div
+            style={{
+              fontSize: 8,
+              letterSpacing: 0.6,
+              color: PALETTE.textLight,
+              textTransform: "uppercase",
+              marginBottom: 2,
+            }}
+          >
+            RiskModels — Fund Tearsheet
+          </div>
+          <h1 style={{ margin: 0, fontSize: 22, fontWeight: 700, color: PALETTE.navy, lineHeight: 1.05 }}>
+            {snap.fund_name ?? snap.bw_fund_id}
+            {snap.ticker && (
+              <span style={{ fontSize: 13, fontWeight: 500, color: PALETTE.teal, marginLeft: 8 }}>
+                ({snap.ticker})
+              </span>
+            )}
+          </h1>
+        </div>
+        <div style={{ textAlign: "right", fontSize: 9, color: PALETTE.textMid, lineHeight: 1.5 }}>
+          <div>F1 · Factor & NAV Profile</div>
+          <div>As of {snap.report_date}</div>
+          {snap.equity_style_9box && <div>{snap.equity_style_9box}</div>}
+        </div>
+      </div>
+
+      {/* ── Two-column body ─────────────────────────────────────── */}
+      <div
+        style={{
+          flex: 1,
+          display: "grid",
+          gridTemplateColumns: "1.55in 1fr",
+          gap: SPACING.md,
+          marginTop: SPACING.md,
+          minHeight: 0,
+        }}
+      >
+        <IdentityRail snap={snap} />
+
+        <div style={{ display: "flex", flexDirection: "column", gap: SPACING.md, minWidth: 0 }}>
+          {/* AI summary */}
+          <div
+            style={{
+              background: PALETTE.bgPanel,
+              padding: SPACING.sm,
+              borderRadius: 4,
+              fontSize: 10,
+              lineHeight: 1.4,
+              color: PALETTE.textDark,
+            }}
+          >
+            <strong style={{ color: PALETTE.navy }}>Summary.</strong> {summary}
+          </div>
+
+          {/* I. Cumulative Returns */}
+          <div>
+            <SectionTitle
+              index="I"
+              title="Cumulative Returns"
+              blurb={`Trailing ${snap.portfolio_history.lookback_months} months — gross-fund and L*-layer paths from the per-fund Slice 8 zarr; realised NAV (yfinance) overlaid in green where available`}
+            />
+            <CumulativeChart series={series} waterfall={waterfall} width={760} height={210} />
+          </div>
+
+          {/* II + III — side-by-side */}
+          <div style={{ display: "grid", gridTemplateColumns: "1.6fr 1fr", gap: SPACING.md, minHeight: 0 }}>
+            <div>
+              <SectionTitle
+                index="II"
+                title="Cohort Rank"
+                blurb={`Rank within ${snap.cohort_context?.equity_style_9box ?? "9-box cell"} across every metric × window the rankings table covers`}
+              />
+              <CohortRankCard snap={snap} />
+            </div>
+            <div>
+              <SectionTitle index="III" title="Top Holdings" />
+              <HoldingsTable snap={snap} />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* ── Footer ──────────────────────────────────────────────── */}
+      <div
+        style={{
+          marginTop: SPACING.sm,
+          paddingTop: SPACING.xs,
+          borderTop: `1px solid ${PALETTE.axisLine}`,
+          display: "flex",
+          justifyContent: "space-between",
+          fontSize: 8,
+          color: PALETTE.textLight,
+        }}
+      >
+        <span>
+          ERM3 V3 · {snap._metadata.model_version ?? "—"} · 13F report {snap.report_date} · filed {snap.filing_date}
+        </span>
+        <span>BW Macro · Confidential · Not investment advice</span>
+      </div>
+
+      {/* legend strip */}
+      <div
+        style={{
+          position: "absolute",
+          right: PAGE.margin.split(" ")[1] ?? "0.5in",
+          bottom: "0.55in",
+          display: "flex",
+          gap: SPACING.md,
+          fontSize: 8,
+          color: PALETTE.textLight,
+        }}
+      >
+        {[
+          { color: LAYER_COLORS.l1_market, label: "L1 Mkt", dashed: true },
+          { color: LAYER_COLORS.l2_sector, label: "L2 Sec", dashed: true },
+          { color: LAYER_COLORS.l3_subsector, label: "L3 Sub", dashed: true },
+          { color: LAYER_COLORS.residual, label: "Residual" },
+          { color: LAYER_COLORS.gross, label: "Gross (13F)" },
+          { color: LAYER_COLORS.nav, label: "NAV" },
+        ].map((l) => (
+          <span key={l.label} style={{ display: "inline-flex", alignItems: "center", gap: 4 }}>
+            <span
+              style={{
+                width: 14,
+                height: 0,
+                borderTop: `${l.dashed ? "1px dashed" : "2px solid"} ${l.color}`,
+                display: "inline-block",
+              }}
+            />
+            {l.label}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/lib/funds/snapshot-templates/_theme.ts
+++ b/lib/funds/snapshot-templates/_theme.ts
@@ -1,0 +1,93 @@
+/**
+ * Consultant-navy design tokens for funds-side snapshot templates.
+ *
+ * Mirrors the Python `_plotly_theme` constants used by the SDK R1 stock
+ * tearsheet (sdk/riskmodels/snapshots/_plotly_theme.py). Both surfaces
+ * share the same brand palette so the F1 fund tearsheet (HTML/Playwright)
+ * and the future Python F1 tearsheet (D.3) feel like siblings.
+ *
+ * Single source of truth for all visual constants — never hardcode colors
+ * or font sizes inside templates / chart components.
+ */
+
+export const PALETTE = {
+  navy: "#002a5e",
+  teal: "#006f8e",
+  slate: "#2a7fbf",
+  green: "#00aa00",
+  orange: "#e07000",
+  red: "#c0392b",
+
+  textDark: "#111827",
+  textMid: "#4b5563",
+  textLight: "#9ca3af",
+
+  bgLight: "#f8f9fb",
+  bgPanel: "#f0f4f8",
+  border: "#dddddd",
+  axisLine: "#e5e7eb",
+  white: "#ffffff",
+} as const;
+
+/** L1 / L2 / L3 / Residual / Gross color assignments for cumulative chart paths. */
+export const LAYER_COLORS = {
+  l1_market: PALETTE.navy,
+  l2_sector: PALETTE.teal,
+  l3_subsector: PALETTE.slate,
+  residual: PALETTE.orange,
+  gross: PALETTE.navy,
+  nav: PALETTE.green,
+} as const;
+
+export const LAYER_LABELS = {
+  l1_market: "L1 Market (SPY)",
+  l2_sector: "L2 Sector",
+  l3_subsector: "L3 Subsector",
+  residual: "L3 Residual (α)",
+  gross: "Gross (13F)",
+  nav: "Realized NAV",
+} as const;
+
+export const FONTS = {
+  family:
+    "'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
+  size: {
+    title: 22,
+    sectionHead: 13,
+    body: 11,
+    smallLabel: 9,
+    chip: 14,
+    footer: 8,
+  },
+  weight: {
+    bold: 700,
+    semibold: 600,
+    regular: 400,
+  },
+} as const;
+
+/**
+ * Letter landscape geometry (11 × 8.5 in). Playwright is configured to print
+ * with `format: "letter"` and `landscape: true` against the template's
+ * `@page { size: letter landscape; }` CSS rule — no manual scaling needed.
+ */
+export const PAGE = {
+  width: "11in",
+  height: "8.5in",
+  margin: "0.4in 0.5in 0.35in 0.5in",
+} as const;
+
+/** Spacing rhythm (px). 4-multiple grid keeps section gaps consistent. */
+export const SPACING = {
+  xs: 4,
+  sm: 8,
+  md: 12,
+  lg: 16,
+  xl: 20,
+  xxl: 28,
+} as const;
+
+export const BORDER_RADIUS = {
+  panel: 4,
+  pill: 999,
+} as const;

--- a/lib/funds/snapshot-templates/components/CumulativeChart.tsx
+++ b/lib/funds/snapshot-templates/components/CumulativeChart.tsx
@@ -1,0 +1,417 @@
+/**
+ * I. Cumulative Returns — 2-panel SVG chart for the F1 fund tearsheet.
+ *
+ * Mirrors the published RM_ORG/content/medium/series/Part_1/section_I
+ * NVDA reference: a left line panel showing each L*-layer cumulative
+ * path (L1 SPY · L2 sector · L3 subsector · L3 residual · gross fund),
+ * tied via a curved connector to a right waterfall panel that decomposes
+ * the gross endpoint into incremental layer contributions summing to gross.
+ *
+ * D.2 addition: a thicker green "Realized NAV" line (yfinance) overlays
+ * the gross-fund line. Where the two diverge is the institutional-grade
+ * insight — captures intra-quarter trading, fees, cash drag invisible
+ * to 13F-derived attribution.
+ *
+ * Pure SVG, no charting library. Playwright renders this server-side via
+ * the /render-snapshot/funds/[bw_fund_id] page route.
+ */
+
+import React from "react";
+
+import { LAYER_COLORS, PALETTE } from "../_theme";
+import type {
+  AttributionWaterfall,
+  CumulativeSeries,
+} from "../cumulative-math";
+
+// ─────────────────────────────────────────────────────────────────────
+// Component contract
+// ─────────────────────────────────────────────────────────────────────
+
+interface CumulativeChartProps {
+  series: CumulativeSeries;
+  waterfall: AttributionWaterfall;
+  /** Total chart width in px (left+right panels + gap). */
+  width?: number;
+  /** Total chart height in px. */
+  height?: number;
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Small SVG primitives
+// ─────────────────────────────────────────────────────────────────────
+
+function fmtPct(x: number, signed = true): string {
+  const v = x * 100;
+  if (Math.abs(v) < 0.05) return "0.0%";
+  return signed ? `${v >= 0 ? "+" : ""}${v.toFixed(1)}%` : `${v.toFixed(1)}%`;
+}
+
+function fmtMonthLabel(teo: string): string {
+  // teo is YYYY-MM-DD → "MMM YY"
+  const d = new Date(`${teo}T12:00:00Z`);
+  const month = d.toLocaleString("en-US", { month: "short", timeZone: "UTC" });
+  const year = String(d.getUTCFullYear()).slice(-2);
+  return `${month} ${year}`;
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Left panel: cumulative line chart
+// ─────────────────────────────────────────────────────────────────────
+
+interface LinePanelProps {
+  series: CumulativeSeries;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  yMin: number;
+  yMax: number;
+}
+
+function LinePanel({ series, x, y, width, height, yMin, yMax }: LinePanelProps) {
+  if (series.teos.length === 0) {
+    return (
+      <text x={x + width / 2} y={y + height / 2} textAnchor="middle" fontSize={12} fill={PALETTE.textMid}>
+        No portfolio history available
+      </text>
+    );
+  }
+
+  const padL = 56;
+  const padR = 60;
+  const padT = 8;
+  const padB = 28;
+  const innerW = width - padL - padR;
+  const innerH = height - padT - padB;
+  const n = series.teos.length;
+
+  const xAt = (i: number) => x + padL + (n === 1 ? innerW / 2 : (i / (n - 1)) * innerW);
+  const yAt = (v: number) => y + padT + (1 - (v - yMin) / (yMax - yMin || 1)) * innerH;
+  const path = (vals: number[]): string =>
+    vals.map((v, i) => `${i === 0 ? "M" : "L"}${xAt(i).toFixed(2)},${yAt(v).toFixed(2)}`).join(" ");
+
+  // Y-axis ticks: 5 evenly-spaced grid lines.
+  const ticks = 5;
+  const yTicks = Array.from({ length: ticks }, (_, i) => yMin + ((yMax - yMin) * i) / (ticks - 1));
+
+  const lines: { key: keyof CumulativeSeries; data: number[]; color: string; width: number; dasharray?: string }[] = [
+    { key: "l1_market", data: series.l1_market, color: LAYER_COLORS.l1_market, width: 1.5, dasharray: "4 3" },
+    { key: "l2_sector", data: series.l2_sector, color: LAYER_COLORS.l2_sector, width: 1.5, dasharray: "4 3" },
+    { key: "l3_subsector", data: series.l3_subsector, color: LAYER_COLORS.l3_subsector, width: 1.5, dasharray: "4 3" },
+    { key: "residual", data: series.residual, color: LAYER_COLORS.residual, width: 1.5 },
+    { key: "gross", data: series.gross, color: LAYER_COLORS.gross, width: 2.4 },
+  ];
+  if (series.nav.length > 0) {
+    lines.push({ key: "nav", data: series.nav, color: LAYER_COLORS.nav, width: 2.4 });
+  }
+
+  // X-axis labels: first, last, and ~3 evenly-spaced inside.
+  const labelIdx = n <= 6 ? series.teos.map((_, i) => i) : [0, Math.floor(n * 0.25), Math.floor(n * 0.5), Math.floor(n * 0.75), n - 1];
+
+  return (
+    <g>
+      {/* Y-grid */}
+      {yTicks.map((v) => (
+        <g key={v}>
+          <line x1={x + padL} x2={x + padL + innerW} y1={yAt(v)} y2={yAt(v)} stroke={PALETTE.axisLine} strokeWidth={0.5} />
+          <text x={x + padL - 6} y={yAt(v) + 3} textAnchor="end" fontSize={9} fill={PALETTE.textMid}>
+            {fmtPct(v, false)}
+          </text>
+        </g>
+      ))}
+      {/* Zero line emphasis */}
+      <line x1={x + padL} x2={x + padL + innerW} y1={yAt(0)} y2={yAt(0)} stroke={PALETTE.textMid} strokeWidth={0.8} />
+
+      {/* Cumulative paths */}
+      {lines.map((l) => (
+        <path
+          key={l.key}
+          d={path(l.data)}
+          fill="none"
+          stroke={l.color}
+          strokeWidth={l.width}
+          strokeDasharray={l.dasharray}
+        />
+      ))}
+
+      {/* X-axis labels */}
+      {labelIdx.map((i) => (
+        <text key={i} x={xAt(i)} y={y + height - 8} textAnchor="middle" fontSize={9} fill={PALETTE.textMid}>
+          {fmtMonthLabel(series.teos[i]!)}
+        </text>
+      ))}
+
+      {/* Endpoint labels for the gross + NAV series */}
+      <g>
+        <text
+          x={xAt(n - 1) + 4}
+          y={yAt(series.gross[n - 1]!) + 3}
+          fontSize={10}
+          fontWeight={600}
+          fill={LAYER_COLORS.gross}
+        >
+          {fmtPct(series.gross[n - 1]!)}
+        </text>
+        {series.nav.length > 0 && (
+          <text
+            x={xAt(n - 1) + 4}
+            y={yAt(series.nav[n - 1]!) + 14}
+            fontSize={10}
+            fontWeight={600}
+            fill={LAYER_COLORS.nav}
+          >
+            NAV {fmtPct(series.nav[n - 1]!)}
+          </text>
+        )}
+      </g>
+
+      {/* Panel title */}
+      <text x={x + padL} y={y - 4} fontSize={10} fontWeight={600} fill={PALETTE.textMid}>
+        Cumulative Return (%)
+      </text>
+    </g>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Right panel: waterfall
+// ─────────────────────────────────────────────────────────────────────
+
+interface WaterfallPanelProps {
+  waterfall: AttributionWaterfall;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  yMin: number;
+  yMax: number;
+}
+
+function WaterfallPanel({ waterfall, x, y, width, height, yMin, yMax }: WaterfallPanelProps) {
+  const padL = 8;
+  const padR = 60;
+  const padT = 8;
+  const padB = 28;
+  const innerW = width - padL - padR;
+  const innerH = height - padT - padB;
+
+  const yAt = (v: number) => y + padT + (1 - (v - yMin) / (yMax - yMin || 1)) * innerH;
+
+  // Build the four contribution bars + a phantom "gross total" bar at the end.
+  const bars = [
+    { label: "L1 Market", value: waterfall.l1_market, color: LAYER_COLORS.l1_market, hatched: false },
+    { label: "L2 Sector", value: waterfall.l2_sector, color: LAYER_COLORS.l2_sector, hatched: false },
+    { label: "L3 Subsector", value: waterfall.l3_subsector, color: LAYER_COLORS.l3_subsector, hatched: false },
+    { label: "Residual α", value: waterfall.residual, color: LAYER_COLORS.residual, hatched: true },
+  ];
+
+  const nBars = bars.length;
+  const slot = innerW / (nBars + 0.5); // small extra for the gross marker on the right
+  const barW = slot * 0.55;
+
+  // Track running cumulative for each bar's bottom.
+  let running = 0;
+  const drawn = bars.map((b, i) => {
+    const startVal = running;
+    const endVal = running + b.value;
+    running = endVal;
+    const cx = x + padL + slot * i + slot / 2;
+    const yTop = yAt(Math.max(startVal, endVal));
+    const yBot = yAt(Math.min(startVal, endVal));
+    return { ...b, cx, yTop, yBot, endVal };
+  });
+
+  return (
+    <g>
+      {/* Zero line */}
+      <line
+        x1={x + padL}
+        x2={x + padL + innerW + 30}
+        y1={yAt(0)}
+        y2={yAt(0)}
+        stroke={PALETTE.textMid}
+        strokeWidth={0.8}
+      />
+
+      {/* Y-axis tick on the right edge */}
+      {[yMin, 0, yMax].map((v, i) => (
+        <text
+          key={i}
+          x={x + width - padR + 4}
+          y={yAt(v) + 3}
+          fontSize={9}
+          fill={PALETTE.textMid}
+        >
+          {fmtPct(v, false)}
+        </text>
+      ))}
+
+      {/* Hatched pattern for residual */}
+      <defs>
+        <pattern id="hatch-residual" patternUnits="userSpaceOnUse" width="6" height="6" patternTransform="rotate(45)">
+          <rect width="6" height="6" fill={LAYER_COLORS.residual} fillOpacity={0.18} />
+          <line x1="0" y1="0" x2="0" y2="6" stroke={LAYER_COLORS.residual} strokeWidth={1.4} />
+        </pattern>
+      </defs>
+
+      {/* Connectors between consecutive bar tops */}
+      {drawn.map((b, i) => {
+        if (i === 0) return null;
+        const prev = drawn[i - 1]!;
+        const yLine = yAt(prev.endVal);
+        return (
+          <line
+            key={`conn-${i}`}
+            x1={prev.cx + barW / 2}
+            x2={b.cx - barW / 2}
+            y1={yLine}
+            y2={yLine}
+            stroke={PALETTE.textLight}
+            strokeWidth={0.8}
+            strokeDasharray="2 2"
+          />
+        );
+      })}
+
+      {/* Bars + value labels */}
+      {drawn.map((b) => {
+        const fill = b.hatched ? "url(#hatch-residual)" : b.color;
+        const labelY = b.value >= 0 ? b.yTop - 4 : b.yBot + 12;
+        return (
+          <g key={b.label}>
+            <rect
+              x={b.cx - barW / 2}
+              y={b.yTop}
+              width={barW}
+              height={Math.max(1, b.yBot - b.yTop)}
+              fill={fill}
+              stroke={b.color}
+              strokeWidth={0.8}
+            />
+            <text
+              x={b.cx}
+              y={labelY}
+              textAnchor="middle"
+              fontSize={10}
+              fontWeight={700}
+              fill={PALETTE.textDark}
+            >
+              {fmtPct(b.value)}
+            </text>
+            <text
+              x={b.cx}
+              y={y + height - 8}
+              textAnchor="middle"
+              fontSize={9}
+              fill={PALETTE.textMid}
+            >
+              {b.label}
+            </text>
+          </g>
+        );
+      })}
+
+      {/* NAV endpoint as a separate marker — does NOT participate in the waterfall sum.
+          Rendered to the right of the four bars to surface the "13F-vs-realised" gap. */}
+      {waterfall.nav != null && (
+        <g>
+          <line
+            x1={x + padL + innerW - 8}
+            x2={x + padL + innerW + 12}
+            y1={yAt(waterfall.nav)}
+            y2={yAt(waterfall.nav)}
+            stroke={LAYER_COLORS.nav}
+            strokeWidth={2.4}
+          />
+          <text
+            x={x + padL + innerW + 16}
+            y={yAt(waterfall.nav) + 3}
+            fontSize={10}
+            fontWeight={700}
+            fill={LAYER_COLORS.nav}
+          >
+            NAV {fmtPct(waterfall.nav)}
+          </text>
+        </g>
+      )}
+
+      {/* Panel title */}
+      <text x={x + padL} y={y - 4} fontSize={10} fontWeight={600} fill={PALETTE.textMid}>
+        Return Contribution (%)
+      </text>
+    </g>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Main component
+// ─────────────────────────────────────────────────────────────────────
+
+export function CumulativeChart({
+  series,
+  waterfall,
+  width = 760,
+  height = 240,
+}: CumulativeChartProps) {
+  // Shared y-axis domain so the tie-line height matches across panels.
+  const lineVals = [
+    ...series.l1_market,
+    ...series.l2_sector,
+    ...series.l3_subsector,
+    ...series.residual,
+    ...series.gross,
+    ...series.nav,
+  ];
+  const wfVals = [0, waterfall.l1_market, waterfall.gross, waterfall.nav].filter(
+    (v): v is number => v != null,
+  );
+  const allVals = lineVals.concat(wfVals);
+  if (allVals.length === 0) {
+    return (
+      <svg width={width} height={height}>
+        <text x={width / 2} y={height / 2} textAnchor="middle" fontSize={12} fill={PALETTE.textMid}>
+          No data available for I. Cumulative Returns
+        </text>
+      </svg>
+    );
+  }
+  const dataMin = Math.min(...allVals, 0);
+  const dataMax = Math.max(...allVals, 0);
+  const span = Math.max(0.05, dataMax - dataMin);
+  const yMin = Math.floor((dataMin - span * 0.08) * 20) / 20; // round to 5%
+  const yMax = Math.ceil((dataMax + span * 0.08) * 20) / 20;
+
+  // 60/40 left-right split with a small horizontal gap.
+  const gap = 24;
+  const leftW = Math.round(width * 0.6) - gap / 2;
+  const rightW = width - leftW - gap;
+
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      style={{ display: "block" }}
+    >
+      <LinePanel
+        series={series}
+        x={0}
+        y={16}
+        width={leftW}
+        height={height - 16}
+        yMin={yMin}
+        yMax={yMax}
+      />
+      <WaterfallPanel
+        waterfall={waterfall}
+        x={leftW + gap}
+        y={16}
+        width={rightW}
+        height={height - 16}
+        yMin={yMin}
+        yMax={yMax}
+      />
+    </svg>
+  );
+}

--- a/lib/funds/snapshot-templates/cumulative-math.ts
+++ b/lib/funds/snapshot-templates/cumulative-math.ts
@@ -1,0 +1,176 @@
+/**
+ * Geometric cumulative-return + waterfall attribution math, ported from the
+ * Python SDK's `stock_deep_dive._make_dd_cum_chart` and
+ * `p1_stock_performance._make_cum_waterfall`.
+ *
+ * The fund tearsheet's I. Cumulative Returns chart consumes both outputs:
+ * the line panel plots each layer's compounded path, the waterfall summarizes
+ * the endpoints into incremental layer contributions that sum to gross.
+ */
+
+import type { FundNavRow, FundPortfolioRow } from "@/lib/dal/funds-zarr-reader";
+
+export interface CumulativeSeries {
+  /** ISO month-end labels matching the source rows, length = rows.length. */
+  teos: string[];
+  /** L1 (market) cumulative path: ∏(1 + r_market[t]) − 1. */
+  l1_market: number[];
+  /** L2 (market + sector) cumulative path: ∏(1 + r_mkt + r_sec) − 1. */
+  l2_sector: number[];
+  /** L3 (market + sector + subsector) cumulative path. */
+  l3_subsector: number[];
+  /** Idiosyncratic-only cumulative path (stand-alone residual line). */
+  residual: number[];
+  /** Gross-fund cumulative path from the actual 13F-derived holdings return. */
+  gross: number[];
+  /** Realized NAV cumulative path from yfinance. Empty when navHistory is null. */
+  nav: number[];
+}
+
+/**
+ * Compute geometric cumulative returns for each layer + the realized NAV path.
+ *
+ * `portfolioHistory` and `navHistory` may have different teo coverage. We
+ * align them by intersecting on teo and dropping rows that don't appear in
+ * both — without alignment the line endpoints would be misleading
+ * ("which series ended where?"). Returns an empty series object when there
+ * are zero overlapping teos.
+ *
+ * Per row:
+ *   r_l1[t] = portfolio_market_return
+ *   r_l2[t] = r_l1 + portfolio_sector_return
+ *   r_l3[t] = r_l2 + portfolio_subsector_return
+ *   r_residual[t] = portfolio_idiosyncratic_return
+ *   r_gross[t] = portfolio_gross_return
+ *   r_nav[t] = nav_return_monthly  (when present)
+ *
+ * Cumulative path: cum[t] = ∏_{i ≤ t}(1 + r[i]) − 1.
+ */
+export function computeCumulativeSeries(
+  portfolioHistory: FundPortfolioRow[],
+  navHistory: FundNavRow[],
+): CumulativeSeries {
+  const empty: CumulativeSeries = {
+    teos: [],
+    l1_market: [],
+    l2_sector: [],
+    l3_subsector: [],
+    residual: [],
+    gross: [],
+    nav: [],
+  };
+  if (portfolioHistory.length === 0) return empty;
+
+  const navByTeo = new Map<string, number>();
+  for (const r of navHistory) {
+    if (r.nav_return_monthly != null) {
+      navByTeo.set(r.teo, r.nav_return_monthly);
+    }
+  }
+
+  const teos: string[] = [];
+  const l1_step: number[] = [];
+  const l2_step: number[] = [];
+  const l3_step: number[] = [];
+  const res_step: number[] = [];
+  const gross_step: number[] = [];
+  const nav_step: number[] = [];
+  const hasNav = navByTeo.size > 0;
+
+  for (const row of portfolioHistory) {
+    if (hasNav && !navByTeo.has(row.teo)) continue;
+
+    const r_mkt = row.portfolio_market_return ?? 0;
+    const r_sec = row.portfolio_sector_return ?? 0;
+    const r_sub = row.portfolio_subsector_return ?? 0;
+    const r_idio = row.portfolio_idiosyncratic_return ?? 0;
+    const r_gross = row.portfolio_gross_return ?? 0;
+
+    teos.push(row.teo);
+    l1_step.push(r_mkt);
+    l2_step.push(r_mkt + r_sec);
+    l3_step.push(r_mkt + r_sec + r_sub);
+    res_step.push(r_idio);
+    gross_step.push(r_gross);
+    if (hasNav) nav_step.push(navByTeo.get(row.teo) ?? 0);
+  }
+
+  if (teos.length === 0) return empty;
+
+  return {
+    teos,
+    l1_market: compoundCumulative(l1_step),
+    l2_sector: compoundCumulative(l2_step),
+    l3_subsector: compoundCumulative(l3_step),
+    residual: compoundCumulative(res_step),
+    gross: compoundCumulative(gross_step),
+    nav: hasNav ? compoundCumulative(nav_step) : [],
+  };
+}
+
+/**
+ * Geometric compounding of monthly steps into cumulative returns:
+ *   cum[t] = ∏_{i ≤ t}(1 + r[i]) − 1.
+ */
+export function compoundCumulative(stepReturns: number[]): number[] {
+  const out = new Array<number>(stepReturns.length);
+  let acc = 1;
+  for (let i = 0; i < stepReturns.length; i++) {
+    acc *= 1 + stepReturns[i]!;
+    out[i] = acc - 1;
+  }
+  return out;
+}
+
+export interface AttributionWaterfall {
+  /** L1 endpoint = SPY-style market cumulative return at the last teo. */
+  l1_market: number;
+  /** L2 incremental contribution = L2_endpoint − L1_endpoint. */
+  l2_sector: number;
+  /** L3 incremental contribution = L3_endpoint − L2_endpoint. */
+  l3_subsector: number;
+  /** Residual contribution = gross_endpoint − L3_endpoint (the alpha sliver). */
+  residual: number;
+  /** Sum of the four layer contributions. */
+  gross: number;
+  /**
+   * Realized-NAV endpoint, when present. Plotted as a separate marker on the
+   * waterfall — does NOT roll into the four-bar attribution. The gap between
+   * `nav` and `gross` is the institutional-grade "13F-vs-realised" insight.
+   */
+  nav: number | null;
+}
+
+/**
+ * Build the right-panel waterfall endpoints from a cumulative series. Each
+ * incremental contribution is the geometric-attribution delta of one layer
+ * over the prior. With the L3 identity:
+ *   gross = L1 + (L2 − L1) + (L3 − L2) + (gross − L3)
+ *         = market + sector_tilt + subsector_tilt + residual.
+ */
+export function buildWaterfall(series: CumulativeSeries): AttributionWaterfall {
+  if (series.teos.length === 0) {
+    return {
+      l1_market: 0,
+      l2_sector: 0,
+      l3_subsector: 0,
+      residual: 0,
+      gross: 0,
+      nav: null,
+    };
+  }
+  const last = series.teos.length - 1;
+  const l1 = series.l1_market[last]!;
+  const l2 = series.l2_sector[last]!;
+  const l3 = series.l3_subsector[last]!;
+  const gross = series.gross[last]!;
+  const nav = series.nav.length > 0 ? series.nav[last]! : null;
+  return {
+    l1_market: l1,
+    l2_sector: l2 - l1,
+    l3_subsector: l3 - l2,
+    residual: gross - l3,
+    gross,
+    nav,
+  };
+}

--- a/tests/funds-cumulative-math.test.ts
+++ b/tests/funds-cumulative-math.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from "vitest";
+
+import type { FundNavRow, FundPortfolioRow } from "@/lib/dal/funds-zarr-reader";
+
+import {
+  buildWaterfall,
+  compoundCumulative,
+  computeCumulativeSeries,
+} from "@/lib/funds/snapshot-templates/cumulative-math";
+
+const PORTFOLIO_ROW = (
+  teo: string,
+  m: number,
+  s: number,
+  sub: number,
+  idio: number,
+  gross: number,
+): FundPortfolioRow => ({
+  teo,
+  portfolio_gross_return: gross,
+  portfolio_market_return: m,
+  portfolio_sector_return: s,
+  portfolio_subsector_return: sub,
+  portfolio_idiosyncratic_return: idio,
+  identity_residual: null,
+  weight_sum: 1,
+  n_holdings_active: 100,
+  effective_n: 50,
+  top10_weight_sum: 0.3,
+});
+
+const NAV_ROW = (teo: string, ret: number): FundNavRow => ({
+  teo,
+  nav_close: 100,
+  nav_return_monthly: ret,
+});
+
+describe("compoundCumulative", () => {
+  it("compounds three +1% steps to (1.01)^3 - 1", () => {
+    const out = compoundCumulative([0.01, 0.01, 0.01]);
+    expect(out).toHaveLength(3);
+    expect(out[0]).toBeCloseTo(0.01, 12);
+    expect(out[1]).toBeCloseTo(0.0201, 12);
+    expect(out[2]).toBeCloseTo(0.030301, 12);
+  });
+
+  it("handles a draw-down step correctly", () => {
+    const out = compoundCumulative([0.10, -0.05]);
+    expect(out[0]).toBeCloseTo(0.10, 12);
+    expect(out[1]).toBeCloseTo(1.10 * 0.95 - 1, 12);
+  });
+
+  it("returns an empty array for empty input", () => {
+    expect(compoundCumulative([])).toEqual([]);
+  });
+});
+
+describe("computeCumulativeSeries", () => {
+  it("derives layer paths matching the L3 identity (L3 = mkt + sec + sub)", () => {
+    const rows = [
+      PORTFOLIO_ROW("2026-01-31", 0.02, 0.005, 0.003, 0.001, 0.029),
+      PORTFOLIO_ROW("2026-02-28", 0.01, -0.002, 0.001, 0.004, 0.013),
+    ];
+    const series = computeCumulativeSeries(rows, []);
+
+    // L1 = market only
+    expect(series.l1_market[0]).toBeCloseTo(0.02, 12);
+    expect(series.l1_market[1]).toBeCloseTo(1.02 * 1.01 - 1, 12);
+
+    // L2 = market + sector (per-month)
+    expect(series.l2_sector[0]).toBeCloseTo(0.025, 12);
+    expect(series.l2_sector[1]).toBeCloseTo(1.025 * 1.008 - 1, 12);
+
+    // L3 = market + sector + subsector
+    expect(series.l3_subsector[0]).toBeCloseTo(0.028, 12);
+  });
+
+  it("aligns NAV to the portfolio history by intersecting on teo", () => {
+    const portfolio = [
+      PORTFOLIO_ROW("2026-01-31", 0.01, 0, 0, 0, 0.01),
+      PORTFOLIO_ROW("2026-02-28", 0.01, 0, 0, 0, 0.01),
+      PORTFOLIO_ROW("2026-03-31", 0.01, 0, 0, 0, 0.01),
+    ];
+    // NAV missing the middle month — align should drop 2026-02-28 from both.
+    const nav = [
+      NAV_ROW("2026-01-31", 0.012),
+      NAV_ROW("2026-03-31", 0.011),
+    ];
+    const series = computeCumulativeSeries(portfolio, nav);
+    expect(series.teos).toEqual(["2026-01-31", "2026-03-31"]);
+    expect(series.nav).toHaveLength(2);
+    expect(series.gross).toHaveLength(2);
+  });
+
+  it("returns empty series object when portfolioHistory is empty", () => {
+    const out = computeCumulativeSeries([], []);
+    expect(out.teos).toEqual([]);
+    expect(out.l1_market).toEqual([]);
+    expect(out.gross).toEqual([]);
+  });
+
+  it("treats null layer returns as 0 (avoids NaN propagation)", () => {
+    const rows = [
+      {
+        ...PORTFOLIO_ROW("2026-01-31", 0.02, 0, 0, 0, 0.02),
+        portfolio_sector_return: null,
+        portfolio_subsector_return: null,
+      } as FundPortfolioRow,
+    ];
+    const series = computeCumulativeSeries(rows, []);
+    expect(series.l2_sector[0]).toBeCloseTo(0.02, 12);
+    expect(series.l3_subsector[0]).toBeCloseTo(0.02, 12);
+  });
+});
+
+describe("buildWaterfall", () => {
+  it("decomposes gross into market + sector_tilt + subsector_tilt + residual", () => {
+    // Deterministic single-month example so endpoints equal step returns.
+    // r_mkt=4%, r_sec=2%, r_sub=1%, r_idio=−1%, r_gross=6%
+    const series = computeCumulativeSeries(
+      [PORTFOLIO_ROW("2026-01-31", 0.04, 0.02, 0.01, -0.01, 0.06)],
+      [],
+    );
+    const wf = buildWaterfall(series);
+    expect(wf.l1_market).toBeCloseTo(0.04, 12);
+    expect(wf.l2_sector).toBeCloseTo(0.02, 12);
+    expect(wf.l3_subsector).toBeCloseTo(0.01, 12);
+    expect(wf.residual).toBeCloseTo(0.06 - (0.04 + 0.02 + 0.01), 12);
+    expect(wf.gross).toBeCloseTo(0.06, 12);
+
+    // Identity: the four contributions sum to gross.
+    expect(wf.l1_market + wf.l2_sector + wf.l3_subsector + wf.residual)
+      .toBeCloseTo(wf.gross, 12);
+  });
+
+  it("returns nav: null when there's no NAV history", () => {
+    const series = computeCumulativeSeries(
+      [PORTFOLIO_ROW("2026-01-31", 0.01, 0, 0, 0, 0.01)],
+      [],
+    );
+    expect(buildWaterfall(series).nav).toBeNull();
+  });
+
+  it("attaches realized-NAV endpoint when NAV history is present", () => {
+    const series = computeCumulativeSeries(
+      [PORTFOLIO_ROW("2026-01-31", 0.05, 0, 0, 0, 0.05)],
+      [NAV_ROW("2026-01-31", 0.04)],
+    );
+    const wf = buildWaterfall(series);
+    expect(wf.nav).toBeCloseTo(0.04, 12);
+    expect(wf.gross).toBeCloseTo(0.05, 12);
+  });
+
+  it("returns zeros for empty input", () => {
+    const wf = buildWaterfall(computeCumulativeSeries([], []));
+    expect(wf).toEqual({
+      l1_market: 0,
+      l2_sector: 0,
+      l3_subsector: 0,
+      residual: 0,
+      gross: 0,
+      nav: null,
+    });
+  });
+});

--- a/tests/funds-f1-tearsheet.test.ts
+++ b/tests/funds-f1-tearsheet.test.ts
@@ -1,0 +1,152 @@
+/**
+ * F1 fund tearsheet — render-to-string structural tests.
+ *
+ * Real-fixture-driven: the FundSnapshot is composed from the same JSON
+ * fixtures that drive the snapshot composer / route tests, then the
+ * F1FundTearsheet is rendered to static HTML via react-dom/server. We
+ * assert structure (sentinel, section titles, SVG presence, NAV legend
+ * gating) — not pixel layout, which is Playwright's job in D.2.b.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import type {
+  FundLatestRow,
+  FundRow,
+  StylePortfolioRow,
+  StyleRankingRow,
+} from "@/lib/dal/funds-engine";
+import type {
+  FundNavRow,
+  FundPortfolioRow,
+} from "@/lib/dal/funds-zarr-reader";
+import { composeFundSnapshot } from "@/lib/funds/snapshot-composer";
+import { F1FundTearsheet } from "@/lib/funds/snapshot-templates/F1FundTearsheet";
+
+function fixture<T>(name: string): T {
+  const p = join(__dirname, "fixtures", "funds", name);
+  return JSON.parse(readFileSync(p, "utf8")) as T;
+}
+
+const FUND = fixture<FundRow>("fund.json");
+const LATEST = fixture<FundLatestRow>("funds_latest.json");
+const FUND_COHORT_RANKS = fixture<StyleRankingRow[]>("fund_cohort_ranks.json");
+const COHORT_METRICS = fixture<StylePortfolioRow[]>("cohort_metrics.json");
+
+/** 12-month synthetic portfolio history. The real ds_portfolio.zarr is not
+ * dumped to JSON fixtures — this scaffolding satisfies the row shape required
+ * by the chart component without committing zarr binaries. */
+function makePortfolio(months = 12): FundPortfolioRow[] {
+  const rows: FundPortfolioRow[] = [];
+  for (let i = 1; i <= months; i++) {
+    const d = new Date(Date.UTC(2025, i - 1, 1));
+    d.setUTCMonth(d.getUTCMonth() + 1);
+    d.setUTCDate(0);
+    rows.push({
+      teo: d.toISOString().slice(0, 10),
+      portfolio_gross_return: 0.012 + (i % 4) * 0.001,
+      portfolio_market_return: 0.008 + (i % 3) * 0.001,
+      portfolio_sector_return: 0.002,
+      portfolio_subsector_return: 0.001,
+      portfolio_idiosyncratic_return: 0.001,
+      identity_residual: 0,
+      weight_sum: 0.99,
+      n_holdings_active: 100,
+      effective_n: 50,
+      top10_weight_sum: 0.34,
+    });
+  }
+  return rows;
+}
+
+function makeNav(months = 12): FundNavRow[] {
+  return makePortfolio(months).map((r) => ({
+    teo: r.teo,
+    nav_close: 100,
+    nav_return_monthly: (r.portfolio_gross_return ?? 0) - 0.001,
+  }));
+}
+
+function renderHtml(snap: ReturnType<typeof composeFundSnapshot>): string {
+  return renderToStaticMarkup(
+    React.createElement(F1FundTearsheet, { snap }),
+  );
+}
+
+describe("F1FundTearsheet — server render (composed snapshot, real fixtures)", () => {
+  const snap = composeFundSnapshot({
+    fund: FUND,
+    latest: LATEST,
+    holdings: null,
+    hedge: null,
+    portfolioHistory: makePortfolio(),
+    navHistory: makeNav(),
+    cohortRanks: FUND_COHORT_RANKS,
+    cohortMetrics: COHORT_METRICS,
+  });
+
+  it("emits the data-report-ready sentinel for Playwright", () => {
+    const html = renderHtml(snap);
+    expect(html).toContain('data-report-ready="true"');
+  });
+
+  it("renders the fund identity in the header", () => {
+    const html = renderHtml(snap);
+    expect(html).toContain(FUND.fund_name!);
+    if (FUND.ticker) {
+      expect(html).toContain(FUND.ticker);
+    }
+  });
+
+  it("renders the I / II / III section titles", () => {
+    const html = renderHtml(snap);
+    expect(html).toContain("Cumulative Returns");
+    expect(html).toContain("Cohort Rank");
+    expect(html).toContain("Top Holdings");
+  });
+
+  it("emits an SVG cumulative chart with at least one path", () => {
+    const html = renderHtml(snap);
+    expect(html).toMatch(/<svg[^>]+>[\s\S]*<path[^>]+>/);
+  });
+
+  it("includes the NAV legend chip + endpoint text when nav_history is present", () => {
+    const html = renderHtml(snap);
+    // Legend chip + endpoint markers both render the literal "NAV"
+    expect(html).toContain("NAV");
+    // The geometric attribution waterfall shows "Residual α" as a category label
+    expect(html).toContain("Residual");
+  });
+
+  it("falls back gracefully when nav_history is null (no NAV overlay rendered)", () => {
+    const noNavSnap = composeFundSnapshot({
+      fund: FUND,
+      latest: LATEST,
+      holdings: null,
+      hedge: null,
+      portfolioHistory: makePortfolio(),
+      navHistory: [],
+      cohortRanks: FUND_COHORT_RANKS,
+      cohortMetrics: COHORT_METRICS,
+    });
+    expect(noNavSnap.nav_history).toBeNull();
+    const html = renderHtml(noNavSnap);
+    expect(html).toContain('data-report-ready="true"');
+    expect(html).toContain("Cumulative Returns");
+  });
+
+  it("places at least one cohort rank row when fund_cohort_ranks fixture is non-empty", () => {
+    const html = renderHtml(snap);
+    // First metric label should appear in the table; metrics are like
+    // 'portfolio_gross_return' rendered with underscores → spaces in the UI.
+    if (FUND_COHORT_RANKS.length > 0) {
+      const firstMetricSpaced = FUND_COHORT_RANKS[0]!.metric.replace(/_/g, " ");
+      expect(html).toContain(firstMetricSpaced);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

The first half of Stage D.2 — a single-page institutional fund tearsheet, mounted at `/render-snapshot/funds/[bw_fund_id]` for Playwright to print to PDF in D.2.b.

**Visual reference:** Mirrors `RM_ORG/content/medium/series/Part_1/section_I_cumulative_returns.png` — a 2-panel layout where left = cumulative L1/L2/L3/Residual/Gross paths, right = 4-bar waterfall summing the gross endpoint. The fund version overlays a green realised-NAV line on the left panel and adds a separate green endpoint marker on the right; that gap is the institutional-grade insight (intra-quarter trading, fees, cash drag invisible to 13F-derived attribution).

## What's in this slice

- `lib/funds/snapshot-templates/_theme.ts` — design tokens ported from SDK R1 `_plotly_theme`. Single source of truth shared with D.3 SDK.
- `lib/funds/snapshot-templates/cumulative-math.ts` — geometric-attribution math: `computeCumulativeSeries()` aligns portfolio + NAV histories on teo, `buildWaterfall()` decomposes gross into L1 + (L2-L1) + (L3-L2) + (gross-L3).
- `lib/funds/snapshot-templates/components/CumulativeChart.tsx` — pure SVG 2-panel chart (no charting lib).
- `lib/funds/snapshot-templates/F1FundTearsheet.tsx` — full composition: header, 24% identity rail, AI summary, I. Cumulative Returns, II. Cohort Rank Card (percentile bars), III. Top Holdings, footer + legend strip.
- `app/(print)/render-snapshot/funds/[bw_fund_id]/page.tsx` — thin client page that reads `window.__FUND_SNAPSHOT__` and waits on a `fund-snapshot-ready` event. Same handshake pattern as the existing portfolio render-snapshot route.

## Layout

```
┌──────────────────────────────────────────────────────────────┐
│  Header (fund name + ticker chip + as-of)                    │
├──────────────┬───────────────────────────────────────────────┤
│ Identity     │ AI summary lead                                │
│  rail        ├───────────────────────────────────────────────┤
│  (24%)       │ I. Cumulative Returns (line + waterfall)      │
│              ├───────────────────────────────────────────────┤
│              │ II. Cohort Rank      │ III. Top Holdings      │
├──────────────┴──────────────────────┴───────────────────────  │
│ Footer (lineage + confidentiality + legend strip)            │
└──────────────────────────────────────────────────────────────┘
```

## Test plan

- [x] 11 cumulative-math tests (compounding identity, NAV alignment, waterfall sum-to-gross, empty-input handling) — `tests/funds-cumulative-math.test.ts`
- [x] 7 server-render structural tests on F1FundTearsheet (`react-dom/server` + real FundSnapshot fixture) — `tests/funds-f1-tearsheet.test.ts`
- [x] 18/18 passing; type-check clean
- [ ] Visual verification in headless Chromium — happens organically in D.2.b when the PDF route is wired

## Out of scope

- The SDK Python F1 (D.3) — separate slice, mirrors R1 1-to-1 with Plotly
- Symbol resolution for the holdings table (currently shows `bw_sym_id`; ticker resolution = follow-up)
- AI summary is template-derived for now; richer model-generated narrative = follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)