### PR TITLE
ci: license-guard for licensed-identifier exposure (CUSIP/ISIN/FactSet)

### DIFF
--- a/.github/workflows/license-guard.yml
+++ b/.github/workflows/license-guard.yml
@@ -1,0 +1,56 @@
+name: License-Guard — licensed-identifier exposure
+
+# Two-pronged check for accidental exposure of LICENSED third-party
+# identifiers (CUSIP, ISIN, fsym_id, factset_*_id):
+#
+#   1. Code scan      — scripts/check-licensed-identifiers.sh
+#                       Walks API-exposed paths (app/api, lib, sdk,
+#                       OpenAPI specs, MCP spec) for whole-word matches.
+#
+#   2. Commit scan    — scripts/check-licensed-identifiers-git.sh
+#                       Walks the PR commit range for the same tokens
+#                       in commit messages. GitHub log is public + indexed,
+#                       so a leak there has the same compliance impact as
+#                       a leak in code.
+#
+# Allowlist markers (case-insensitive, in either code or commit message):
+#   licensed-id-ok: <reason>          — line-level skip
+#   licensed-id-ok-file: <reason>     — file-level skip when in first 40 lines
+#   AUDIT-PENDING                     — surfaced as warning, doesn't fail
+#
+# See scripts/check-licensed-identifiers.sh header for full rationale.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  code-scan:
+    name: Licensed-identifier code scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run code scan
+        run: bash scripts/check-licensed-identifiers.sh
+
+  commit-message-scan:
+    name: Licensed-identifier commit-message scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Need PR base ref + full HEAD history for the range scan.
+          fetch-depth: 0
+
+      - name: Run commit-message scan
+        env:
+          # GITHUB_BASE_REF is set on pull_request events. On push to main
+          # it's empty and the script falls back to HEAD~20..HEAD.
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+        run: bash scripts/check-licensed-identifiers-git.sh

--- a/app/api/data/security-master/resolve/route.ts
+++ b/app/api/data/security-master/resolve/route.ts
@@ -1,3 +1,7 @@
+// licensed-id-ok-file: client-supplied CUSIP/ISIN translator endpoint.
+// Inputs are user's own licensed identifiers; outputs are our internal
+// ticker / bw_sym_id / FIGI. The CUSIP/ISIN values in the response are
+// echoes of the user-supplied input (not redistributed by us).
 import { NextResponse, type NextRequest } from "next/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { verifyGatewayAuth } from "@/lib/gateway-auth";

--- a/app/api/data/symbols/[ticker]/route.ts
+++ b/app/api/data/symbols/[ticker]/route.ts
@@ -1,3 +1,8 @@
+// licensed-id-ok-file: AUDIT-PENDING — public per-ticker symbol endpoint
+// selects and returns `isin` from the symbols table. Pre-existing exposure
+// flagged for license-team review; clear by either removing `isin` from
+// the response shape (Path 1) or confirming ANNA license covers
+// redistribution (Path 2).
 import { NextResponse, type NextRequest } from "next/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { verifyGatewayAuth } from "@/lib/gateway-auth";

--- a/app/api/data/symbols/batch/route.ts
+++ b/app/api/data/symbols/batch/route.ts
@@ -1,3 +1,8 @@
+// licensed-id-ok-file: AUDIT-PENDING — public batch symbol endpoint
+// selects and returns `isin` from the symbols table. Pre-existing exposure
+// flagged for license-team review; clear by either removing `isin` from
+// the response shape (Path 1) or confirming ANNA license covers
+// redistribution (Path 2).
 import { NextResponse, type NextRequest } from "next/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { verifyGatewayAuth } from "@/lib/gateway-auth";

--- a/app/api/data/symbols/search/route.ts
+++ b/app/api/data/symbols/search/route.ts
@@ -1,3 +1,8 @@
+// licensed-id-ok-file: AUDIT-PENDING — public symbols search endpoint
+// selects and returns `isin` from the symbols table. Pre-existing exposure
+// flagged for license-team review; clear by either removing `isin` from
+// the response shape (Path 1) or confirming ANNA license covers
+// redistribution (Path 2).
 import { NextResponse, type NextRequest } from "next/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { verifyGatewayAuth } from "@/lib/gateway-auth";

--- a/lib/dal/funds-zarr-reader.ts
+++ b/lib/dal/funds-zarr-reader.ts
@@ -289,7 +289,7 @@ export async function readFundPortfolioSeries(
 // Layout: coords (teo,); data_vars nav_close (teo,) and nav_return_monthly
 // (teo,). Produced by Funds_DAG's fund_nav_zarr v3 asset, which pulls daily
 // NAV by ticker_primary and resamples to month-end. Replaces the legacy
-// step_1b factset_fund_id-keyed multi-fund yf_nav_returns zarr at the API
+// step_1b factset_fund_id-keyed multi-fund yf_nav_returns zarr at the API // licensed-id-ok: comment names a legacy upstream key that this layer replaces; no FactSet ID exposed
 // surface — the API only ever sees bw_fund_id-keyed per-fund layouts.
 // ---------------------------------------------------------------------------
 

--- a/lib/dal/risk-engine-v3.ts
+++ b/lib/dal/risk-engine-v3.ts
@@ -1,3 +1,9 @@
+// licensed-id-ok-file: AUDIT-PENDING — DAL still selects/returns `isin`
+// from the symbols table; downstream consumers (api/data/symbols/*) echo
+// it in responses. Pre-existing exposure flagged for license-team review.
+// To clear: either remove `isin` from public response shapes (Path 1) or
+// confirm ANNA license covers redistribution scope (Path 2), then change
+// this marker to a definitive reason.
 /**
  * ERM3 V3 Risk Engine DAL — pure-Zarr history, Supabase relational + `_latest`
  *

--- a/lib/dal/zarr-reader.ts
+++ b/lib/dal/zarr-reader.ts
@@ -449,7 +449,7 @@ export async function readHistorySlice(
   const returnsSymMap = returnsGrp ? await readSymbolIndexMap(returnsGrp) : null;
   const levelMaps = returnsGrp ? await readLevelIndexMap(returnsGrp) : null;
 
-  // ETF store. Disjoint from ds_daily — ~100 ETFs with their own CUSIP-based
+  // ETF store. Disjoint from ds_daily — ~100 ETFs with their own CUSIP-based // licensed-id-ok: comment explains internal bw_sym_id derivation; no CUSIP value exposed
   // bw_sym_ids (e.g. SPY = BW-US78462F1030). Always opened because the
   // caller's symbol list can contain a mix of stocks and ETFs and we can't
   // tell which is which upfront without a Supabase round-trip. The store is

--- a/scripts/check-licensed-identifiers-git.sh
+++ b/scripts/check-licensed-identifiers-git.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# scripts/check-licensed-identifiers-git.sh
+#
+# Companion to check-licensed-identifiers.sh: scrubs git COMMIT MESSAGES
+# (subject + body) for licensed third-party identifiers. Catches the case
+# where a CUSIP or ISIN value is leaked through a commit message even
+# though the code itself is clean — commit messages are public on GitHub
+# and indexed forever, so a leak there is just as bad as a leak in code.
+#
+# Range:
+#   - On a PR (GITHUB_BASE_REF set):  origin/$GITHUB_BASE_REF..HEAD
+#   - Locally / push to default:      HEAD~20..HEAD
+#
+# Override the range via GIT_LOG_RANGE env var if needed.
+#
+# Allowlist marker (case-insensitive):
+#   `licensed-id-ok: <reason>`  — placed inside the commit message itself
+#                                  on a line near the offending token.
+# Use AUDIT-PENDING in the reason to surface the commit as a warning
+# (does not fail the check).
+
+set -uo pipefail
+
+PATTERN='cusip|fsym_id|factset_fund_id|factset_entity_id|isin'
+
+# Resolve the git log range.
+if [[ -n "${GIT_LOG_RANGE:-}" ]]; then
+    range="$GIT_LOG_RANGE"
+elif [[ -n "${GITHUB_BASE_REF:-}" ]]; then
+    # PR context. Make sure the base ref is fetched.
+    git fetch --quiet origin "$GITHUB_BASE_REF" 2>/dev/null || true
+    range="origin/${GITHUB_BASE_REF}..HEAD"
+else
+    range="HEAD~20..HEAD"
+fi
+
+# Collect commit hashes in range.
+if ! commits=$(git log --format=%H "$range" 2>/dev/null); then
+    echo "::warning::Could not enumerate commits in range '$range' — skipping git history scan"
+    exit 0
+fi
+
+if [[ -z "$commits" ]]; then
+    echo "✓ No commits in range '$range' — nothing to scan"
+    exit 0
+fi
+
+violations=""
+audit_pending=""
+
+while IFS= read -r sha; do
+    [[ -z "$sha" ]] && continue
+    # Full message: subject + body. %B includes both with a blank line.
+    msg=$(git show --no-patch --format=%B "$sha" 2>/dev/null || true)
+    [[ -z "$msg" ]] && continue
+
+    # Find tokens that match the pattern, line by line, case-insensitive,
+    # whole-word.
+    matches=$(echo "$msg" | grep -inwE "$PATTERN" 2>/dev/null || true)
+    [[ -z "$matches" ]] && continue
+
+    # Filter pandas .isin( false positives (rare in commit messages but
+    # technically possible if the message quotes code).
+    matches=$(echo "$matches" | sed -E 's/\.isin[[:space:]]*\(/.METHOD(/g' | grep -inwE "$PATTERN" || true)
+    [[ -z "$matches" ]] && continue
+
+    # If the message body contains the allowlist marker, treat all matches
+    # in this commit as allowlisted. (Per-line markers don't make sense
+    # in commit messages — a message is the unit of authorship.)
+    if echo "$msg" | grep -iqE 'licensed-id-ok'; then
+        if echo "$msg" | grep -iqE 'AUDIT-PENDING'; then
+            audit_pending+="commit ${sha:0:12} — $(git log -1 --format=%s "$sha")"$'\n'
+        fi
+        continue
+    fi
+
+    short=${sha:0:12}
+    subject=$(git log -1 --format=%s "$sha")
+    violations+="commit $short — $subject"$'\n'
+    while IFS= read -r m; do
+        [[ -z "$m" ]] && continue
+        violations+="    $m"$'\n'
+    done <<<"$matches"
+    violations+=$'\n'
+done <<<"$commits"
+
+if [[ -n "$violations" ]]; then
+    echo "::error::Licensed-identifier leak in commit message(s) — range: $range"
+    echo ""
+    echo "$violations"
+    echo "Resolution:"
+    echo "  - Rewrite the offending commit message(s) (interactive rebase or amend)"
+    echo "  - OR add 'licensed-id-ok: <reason>' INSIDE the commit message body"
+    echo "    (re-commit with --amend or rebase to add the marker)"
+    echo ""
+    echo "Commit messages are public on GitHub and indexed by search engines"
+    echo "indefinitely — leaking a CUSIP/ISIN/FactSet ID value here has the"
+    echo "same compliance impact as leaking it in code."
+    exit 1
+fi
+
+if [[ -n "$audit_pending" ]]; then
+    echo "::warning::Commit messages with AUDIT-PENDING licensed-id markers:"
+    echo ""
+    echo "$audit_pending"
+fi
+
+echo "✓ No licensed-identifier leaks in commit messages — range: $range"
+exit 0

--- a/scripts/check-licensed-identifiers.sh
+++ b/scripts/check-licensed-identifiers.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# scripts/check-licensed-identifiers.sh
+#
+# Guards against accidental exposure of LICENSED third-party identifiers
+# in public API surfaces. Specifically:
+#
+#   - CUSIP             (licensed by CUSIP Global Services / S&P; redistribution prohibited)
+#   - ISIN              (licensed by ANNA / national numbering agencies)
+#   - fsym_id           (FactSet proprietary security identifier)
+#   - factset_fund_id   (FactSet proprietary fund identifier)
+#   - factset_entity_id (FactSet proprietary entity identifier)
+#
+# Internal compute layers (Funds_DAG, ERM3) reference these freely — they're
+# inputs we license. The contract this check enforces:
+# **none of these identifiers leaves through a public API response.**
+#
+# Scope: API route handlers, the public DAL, the OpenAPI spec, the MCP
+# spec mirror, and the public-facing SDKs/packages. Migrations, tests,
+# fixtures, and internal admin paths are NOT scanned (those legitimately
+# carry the columns; the contract is downstream of them).
+#
+# Two allowlist markers (case-insensitive):
+#
+#   `licensed-id-ok: <reason>`         — line-level skip
+#   `licensed-id-ok-file: <reason>`    — file-level skip when in first 40 lines
+#
+# Use file-level for translator endpoints that accept CUSIP/ISIN as INPUT
+# and return our internal identifier (ticker / bw_sym_id / FIGI) — that's
+# not redistribution of the licensed value, the user already had it.
+# Use line-level for one-off exposures (comments, single field references).
+# Always include a short reason — `AUDIT-PENDING` flags items for license
+# review and is grep-able later.
+
+set -uo pipefail
+
+# Tokens to flag (case-insensitive whole-word match).
+# `_id` variants and a bare `cusip` / `isin` are sufficient — partial
+# matches inside camelCase or snake_case won't fire because of `-w`.
+PATTERN='cusip|fsym_id|factset_fund_id|factset_entity_id|isin'
+
+# Paths the public API surfaces or that downstream consumers can read.
+SCAN_PATHS=(
+    app/api
+    lib
+    sdk/riskmodels
+    packages
+    OPENAPI_SPEC.yaml
+    mcp/data/openapi.json
+)
+
+# Exclusions (path globs + directories). Tests carry mock data legitimately.
+EXCLUDES=(
+    --exclude-dir=node_modules
+    --exclude-dir=__pycache__
+    --exclude-dir=.venv
+    --exclude-dir=.next
+    --exclude-dir=dist
+    --exclude-dir=build
+    --exclude-dir=tests
+    --exclude='*.test.ts'
+    --exclude='*.test.tsx'
+    --exclude='*.test.py'
+    --exclude='*.spec.ts'
+    --exclude='*.spec.tsx'
+    --exclude-dir=__tests__
+)
+
+# Filter only existing paths (so the grep doesn't fail when one's absent).
+existing_paths=()
+for p in "${SCAN_PATHS[@]}"; do
+    if [[ -e "$p" ]]; then existing_paths+=("$p"); fi
+done
+if [[ ${#existing_paths[@]} -eq 0 ]]; then
+    echo "✓ No paths to scan (license-guard.sh)"
+    exit 0
+fi
+
+# Pre-pass: collect files with a file-level allowlist marker in their
+# first 40 lines. Bash-3 compatible: a single-string sentinel lookup.
+# Files whose marker mentions AUDIT-PENDING are also surfaced as warnings
+# at the end so they're not silently buried.
+FILE_ALLOWLIST_LIST=""
+FILE_AUDIT_PENDING_LIST=""
+collect_file_allowlist() {
+    local f="$1"
+    if [[ -f "$f" ]]; then
+        local head_text
+        head_text=$(head -40 "$f" 2>/dev/null)
+        if echo "$head_text" | grep -iqE 'licensed-id-ok-file:'; then
+            FILE_ALLOWLIST_LIST+="|$f|"
+            if echo "$head_text" | grep -iqE 'AUDIT-PENDING'; then
+                FILE_AUDIT_PENDING_LIST+="$f"$'\n'
+            fi
+        fi
+    fi
+}
+
+for path in "${existing_paths[@]}"; do
+    if [[ -f "$path" ]]; then
+        collect_file_allowlist "$path"
+    elif [[ -d "$path" ]]; then
+        while IFS= read -r f; do
+            collect_file_allowlist "$f"
+        done < <(find "$path" -type f \( -name '*.ts' -o -name '*.tsx' -o -name '*.py' -o -name '*.yaml' -o -name '*.yml' -o -name '*.json' \) 2>/dev/null)
+    fi
+done
+
+raw_matches=$(grep -rinwE "$PATTERN" "${EXCLUDES[@]}" "${existing_paths[@]}" 2>/dev/null || true)
+
+# Filter out:
+#  1. Lines with the allowlist marker `licensed-id-ok` (case-insensitive)
+#  2. False positives where `isin` is the pandas DataFrame.isin() method,
+#     not the security identifier — pattern: `.isin(`
+violations=""
+audit_pending=""
+while IFS= read -r line; do
+    if [[ -z "$line" ]]; then continue; fi
+    # Extract file path (everything before the first colon)
+    file_part="${line%%:*}"
+    if [[ "$FILE_ALLOWLIST_LIST" == *"|$file_part|"* ]]; then
+        continue
+    fi
+    if echo "$line" | grep -iqE 'licensed-id-ok'; then
+        # Surface AUDIT-PENDING markers in summary so they don't get forgotten
+        if echo "$line" | grep -iqE 'AUDIT-PENDING'; then
+            audit_pending+="$line"$'\n'
+        fi
+        continue
+    fi
+    # Drop pandas `.isin(` method calls (NOT the security ISIN identifier).
+    # Strip `.isin(` occurrences before re-checking the remaining hits.
+    stripped=$(echo "$line" | sed -E 's/\.isin[[:space:]]*\(/.METHOD(/g')
+    if ! echo "$stripped" | grep -inwE "$PATTERN" > /dev/null; then
+        continue
+    fi
+    violations+="$line"$'\n'
+done <<<"$raw_matches"
+
+if [[ -n "$violations" ]]; then
+    echo "::error::Licensed-identifier exposure check FAILED"
+    echo ""
+    echo "The following lines reference LICENSED third-party identifiers"
+    echo "(CUSIP / FactSet ID / ISIN) in API-exposed paths:"
+    echo ""
+    echo "$violations"
+    echo ""
+    echo "Resolution: either"
+    echo "  - Remove the identifier from the public surface, OR"
+    echo "  - Add 'licensed-id-ok: <reason>' on the line if it's a legitimate"
+    echo "    internal reference (e.g., admin-only endpoint not in OpenAPI,"
+    echo "    or a comment that names the identifier without exposing values)"
+    echo ""
+    echo "License context:"
+    echo "  CUSIP            — licensed by CUSIP Global Services; redistribution prohibited"
+    echo "  ISIN             — licensed by ANNA / national numbering agencies"
+    echo "  fsym_id / factset_*_id — FactSet proprietary; redistribution requires license"
+    exit 1
+fi
+
+if [[ -n "$audit_pending" ]]; then
+    echo "::warning::Licensed-identifier exposures with AUDIT-PENDING markers:"
+    echo ""
+    echo "$audit_pending"
+    echo "These are tolerated for now but should be reviewed by the license"
+    echo "team. To clear: either remove the exposure or change the marker"
+    echo "comment to a definitive reason."
+    echo ""
+fi
+
+if [[ -n "$FILE_AUDIT_PENDING_LIST" ]]; then
+    echo "::warning::Files with file-level licensed-id-ok-file: AUDIT-PENDING markers:"
+    echo ""
+    echo "$FILE_AUDIT_PENDING_LIST"
+    echo "Each of these files contains licensed-identifier references that"
+    echo "are silently allowlisted at the file level pending license review."
+    echo "To clear: resolve the exposure or rewrite the file marker without"
+    echo "AUDIT-PENDING."
+    echo ""
+fi
+
+echo "✓ No licensed-identifier leaks in API-exposed paths"
+exit 0


### PR DESCRIPTION
## Summary

- Adds two scripts + workflow guarding against accidental redistribution of LICENSED third-party identifiers (CUSIP / ISIN / fsym_id / factset_*_id) through the public API surface.
- **Code scan** (`scripts/check-licensed-identifiers.sh`): walks `app/api`, `lib`, `sdk`, `OPENAPI_SPEC.yaml`, `mcp/data/openapi.json` for whole-word matches. Filters pandas `.isin()` false positives. Bash 3.2 compatible.
- **Commit-message scan** (`scripts/check-licensed-identifiers-git.sh`): walks `origin/${GITHUB_BASE_REF}..HEAD` on PRs (`HEAD~20..HEAD` locally). Public GitHub log + indexed = same compliance impact as code leaks.
- **Workflow** (`.github/workflows/license-guard.yml`): both scripts on `push: main` + `pull_request: main`, `fetch-depth: 0` for the range scan.

## Allowlist mechanism

- `licensed-id-ok: <reason>` — line-level skip
- `licensed-id-ok-file: <reason>` — file-level skip (first 40 lines only)
- `AUDIT-PENDING` in either marker → surfaced as warning, doesn't fail the check

## Path A applied (allowlist existing exposures, ship check active)

| File | Marker | Posture |
|---|---|---|
| `app/api/data/security-master/resolve/route.ts` | file-level | **Clean by design** — INPUT-only translator. Echoes caller-supplied CUSIP/ISIN, never returns DB-sourced licensed values. Verified at line 112-117 (response uses `id.value`, not DB row's `cusip`/`isin`). |
| `app/api/data/symbols/{search,[ticker],batch}/route.ts` | file-level **AUDIT-PENDING** | Public symbols data plane returns `isin` from `security_master`. To clear: drop ISIN from response shape (Path 1) or confirm ANNA license covers redistribution (Path 2). |
| `lib/dal/risk-engine-v3.ts` | file-level **AUDIT-PENDING** | DAL still selects/returns `isin`; downstream consumers echo it. Pre-existing exposure flagged for license-team review. |
| `lib/dal/{zarr-reader,funds-zarr-reader}.ts` | line-level | Architectural comments naming legacy upstream keys (CUSIP-derived bw_sym_id; legacy `factset_fund_id` upstream key). No values exposed. |

## Translator endpoint legal posture

`POST /api/data/security-master/resolve` accepts CUSIP/ISIN as input → returns `{ ticker, bw_sym_id }`. Defensible because:
- We receive licensed input + return unlicensed output (FIGI/bw_sym_id).
- Response `value` field is a literal echo of caller input, never a DB-sourced licensed value.
- Mirrors OpenFIGI legal posture: caller represents they have rights to inputs they submit.

**Non-code follow-ups** (tracked in memory, not in this PR):
- API docs / TOS line on the resolve endpoint: caller represents they're licensed to use submitted CUSIP/ISIN.
- Logging policy: scrub caller-supplied identifiers before observability sinks.

## Test plan

- [x] `bash scripts/check-licensed-identifiers.sh` returns 0 with AUDIT-PENDING warnings
- [x] `bash scripts/check-licensed-identifiers-git.sh` returns 0 on `HEAD~20..HEAD`
- [x] Self-scan of this commit message: passes (markers are valid allowlist tokens; AUDIT-PENDING mentions surface as warnings)
- [ ] CI: license-guard workflow runs green on this PR
- [ ] CI: existing checks (CI, secret-scan, drift-detection, etc.) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)