### PR TITLE
feat: drop ISIN from public symbols data plane (Path 4)

### DIFF
--- a/app/api/data/symbols/[ticker]/route.ts
+++ b/app/api/data/symbols/[ticker]/route.ts
@@ -1,8 +1,3 @@
-// licensed-id-ok-file: AUDIT-PENDING — public per-ticker symbol endpoint
-// selects and returns `isin` from the symbols table. Pre-existing exposure
-// flagged for license-team review; clear by either removing `isin` from
-// the response shape (Path 1) or confirming ANNA license covers
-// redistribution (Path 2).
 import { NextResponse, type NextRequest } from "next/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { verifyGatewayAuth } from "@/lib/gateway-auth";
@@ -36,7 +31,7 @@ export async function GET(
   const { data, error } = await supabase
     .from("symbols")
     .select(
-      "symbol, ticker, name, asset_type, sector_etf, subsector_etf, is_adr, isin, metadata, latest_metrics, latest_vol, latest_teo",
+      "symbol, ticker, name, asset_type, sector_etf, subsector_etf, is_adr, metadata, latest_metrics, latest_vol, latest_teo",
     )
     .eq("ticker", canonicalTicker)
     .maybeSingle();
@@ -61,7 +56,6 @@ export async function GET(
       data.sector_etf ?? (metadata.sector_etf as string | null) ?? null,
     subsector_etf: data.subsector_etf,
     is_adr: data.is_adr,
-    isin: data.isin,
     metadata: filterSafeMetadata(data.metadata),
     latest_metrics: data.latest_metrics,
     latest_vol: data.latest_vol,

--- a/app/api/data/symbols/batch/route.ts
+++ b/app/api/data/symbols/batch/route.ts
@@ -1,8 +1,3 @@
-// licensed-id-ok-file: AUDIT-PENDING — public batch symbol endpoint
-// selects and returns `isin` from the symbols table. Pre-existing exposure
-// flagged for license-team review; clear by either removing `isin` from
-// the response shape (Path 1) or confirming ANNA license covers
-// redistribution (Path 2).
 import { NextResponse, type NextRequest } from "next/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { verifyGatewayAuth } from "@/lib/gateway-auth";
@@ -52,7 +47,7 @@ export async function POST(request: NextRequest) {
   const { data, error } = await supabase
     .from("symbols")
     .select(
-      "symbol, ticker, name, asset_type, sector_etf, subsector_etf, is_adr, isin, metadata, latest_metrics, latest_vol, latest_teo",
+      "symbol, ticker, name, asset_type, sector_etf, subsector_etf, is_adr, metadata, latest_metrics, latest_vol, latest_teo",
     )
     .in("ticker", canonicalTickers);
 
@@ -74,7 +69,6 @@ export async function POST(request: NextRequest) {
         row.sector_etf ?? (metadata.sector_etf as string | null) ?? null,
       subsector_etf: row.subsector_etf,
       is_adr: row.is_adr,
-      isin: row.isin,
       metadata: filterSafeMetadata(row.metadata),
       latest_metrics: row.latest_metrics,
       latest_vol: row.latest_vol,

--- a/app/api/data/symbols/search/route.ts
+++ b/app/api/data/symbols/search/route.ts
@@ -1,8 +1,3 @@
-// licensed-id-ok-file: AUDIT-PENDING — public symbols search endpoint
-// selects and returns `isin` from the symbols table. Pre-existing exposure
-// flagged for license-team review; clear by either removing `isin` from
-// the response shape (Path 1) or confirming ANNA license covers
-// redistribution (Path 2).
 import { NextResponse, type NextRequest } from "next/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { verifyGatewayAuth } from "@/lib/gateway-auth";
@@ -33,7 +28,7 @@ export async function GET(request: NextRequest) {
   let query = supabase
     .from("symbols")
     .select(
-      "symbol, ticker, name, asset_type, sector_etf, subsector_etf, is_adr, isin, metadata, latest_metrics, latest_vol, latest_teo",
+      "symbol, ticker, name, asset_type, sector_etf, subsector_etf, is_adr, metadata, latest_metrics, latest_vol, latest_teo",
     );
 
   if (q) {

--- a/lib/dal/risk-engine-v3.ts
+++ b/lib/dal/risk-engine-v3.ts
@@ -1,9 +1,3 @@
-// licensed-id-ok-file: AUDIT-PENDING — DAL still selects/returns `isin`
-// from the symbols table; downstream consumers (api/data/symbols/*) echo
-// it in responses. Pre-existing exposure flagged for license-team review.
-// To clear: either remove `isin` from public response shapes (Path 1) or
-// confirm ANNA license covers redistribution scope (Path 2), then change
-// this marker to a definitive reason.
 /**
  * ERM3 V3 Risk Engine DAL — pure-Zarr history, Supabase relational + `_latest`
  *
@@ -104,7 +98,6 @@ export interface SymbolRegistryRow {
   sector_etf: string | null;
   subsector_etf: string | null;
   is_adr: boolean | null;
-  isin: string | null;
 }
 
 // Fetch options
@@ -209,7 +202,6 @@ function normalizeSymbolRow(row: Record<string, unknown> | null): SymbolRegistry
     sector_etf: (row.sector_etf as string | null) ?? (metadata.sector_etf as string | null) ?? null,
     subsector_etf: row.subsector_etf as string | null,
     is_adr: row.is_adr as boolean | null,
-    isin: row.isin as string | null,
   };
 }
 
@@ -227,7 +219,7 @@ export async function resolveSymbolByTicker(
       const admin = createAdminClient();
       const { data, error } = await admin
         .from("symbols")
-        .select("symbol, ticker, name, asset_type, sector_etf, subsector_etf, is_adr, isin, metadata")
+        .select("symbol, ticker, name, asset_type, sector_etf, subsector_etf, is_adr, metadata")
         .eq("ticker", t)
         .maybeSingle();
       if (error) {
@@ -267,7 +259,7 @@ export async function resolveSymbolsByTickers(
     const admin = createAdminClient();
     const { data, error } = await admin
       .from("symbols")
-      .select("symbol, ticker, name, asset_type, sector_etf, subsector_etf, is_adr, isin, metadata")
+      .select("symbol, ticker, name, asset_type, sector_etf, subsector_etf, is_adr, metadata")
       .in("ticker", upperTickers);
 
     if (error) {
@@ -303,7 +295,7 @@ export async function resolveSymbolsByTickers(
 
     const { data: aliasData } = await admin
       .from("symbols")
-      .select("symbol, ticker, name, asset_type, sector_etf, subsector_etf, is_adr, isin, metadata")
+      .select("symbol, ticker, name, asset_type, sector_etf, subsector_etf, is_adr, metadata")
       .in("ticker", Array.from(allAliases));
 
     for (const row of aliasData ?? []) {

--- a/tests/canonical-snapshot.test.ts
+++ b/tests/canonical-snapshot.test.ts
@@ -91,7 +91,6 @@ describe("buildCanonicalPortfolioSnapshot", () => {
       sector_etf: "XLK",
       subsector_etf: "SOXX",
       is_adr: false,
-      isin: null,
     };
     vi.mocked(resolveSymbolsByTickers).mockResolvedValue(
       new Map<string, SymbolRegistryRow>([["MSFT", msftRow]]),


### PR DESCRIPTION
## Summary

- Removes `isin` field from public API responses on `/api/data/symbols/*` endpoints (search, [ticker], batch).
- Resolves the AUDIT-PENDING markers added in #35 by eliminating the underlying exposure rather than allowlisting it.
- Keeps the input-only translator endpoint at `/api/data/security-master/resolve` for customers who need ISIN→symbol lookup.

## Why

ISIN is licensed by ANNA / national numbering agencies. US ISINs embed CUSIPs licensed by CGS. Our EODHD agreement (Exhibit B(b)) prohibits commercial redistribution of the API \"or any part thereof... in raw or bulk form,\" and §7(b) is broader still (\"data cannot be resold\"). EODHD's contract is silent on third-party identifier pass-through, so they can't grant us redistribution rights they don't own. Massive's standard terms are even tighter (§5(c) Derived Works clause).

Default posture for a B2B API without an explicit redistribution license: assume no rights to redistribute licensed identifiers. Path 4 ships the safe answer pre-emptively while the EODHD contract conversation continues.

## Path 4 strategy

The original Path 1/2 framing was binary (drop entirely vs. confirm license). Path 4 splits the difference:

| Surface | Action | Posture |
|---|---|---|
| `/api/data/symbols/*` (data plane) | Drop ISIN from response shapes | Removes redistribution risk |
| `/api/data/security-master/resolve` (translator) | Keep unchanged | Input-only — defensible because response `value` is a literal echo of caller input, never a DB-sourced licensed value |

Customers who need to look up a symbol by ISIN use the translator, which is the actual workflow they care about. We don't return ISINs *we own*, only ISINs the *caller submitted to us*.

## Files changed

- `lib/dal/risk-engine-v3.ts`: drop `isin` from `SymbolRegistryRow` type, 3 SELECT clauses, `normalizeSymbolRow` constructor; drop AUDIT-PENDING file marker.
- `app/api/data/symbols/{[ticker],batch,search}/route.ts`: drop `isin` from SELECT clauses + response builders; drop file markers.
- `tests/canonical-snapshot.test.ts`: drop `isin: null` from `SymbolRegistryRow` fixture.

5 files changed, 6 insertions(+), 32 deletions(-).

## Migration notes

- **SDK consumers reading `response.isin`** will get `undefined`. If they were using it to round-trip back to `bw_sym_id`, route them to `POST /api/data/security-master/resolve` instead — that's the supported workflow.
- **OpenAPI specs did not document `isin`** as a response field. No schema changes needed — this was an undocumented exposure.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint` clean
- [x] `vitest canonical-snapshot.test.ts` passes
- [x] `bash scripts/check-licensed-identifiers.sh` clean (no AUDIT-PENDING warnings remaining)
- [ ] CI green
- [ ] Spot-check `/api/data/symbols/AAPL` response shape after deploy — `isin` field gone

## Related

- Builds on #35 (license-guard CI) — this PR resolves the AUDIT-PENDING markers that #35 introduced.
- The remaining `licensed-id-ok-file` marker on `/api/data/security-master/resolve/route.ts` stays — that's a definitive (non-AUDIT-PENDING) marker for the legitimate translator endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)