### PR TITLE
feat: safelist symbols.metadata before public response

### DIFF
--- a/app/api/data/symbols/[ticker]/route.ts
+++ b/app/api/data/symbols/[ticker]/route.ts
@@ -7,6 +7,7 @@ import { NextResponse, type NextRequest } from "next/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { verifyGatewayAuth } from "@/lib/gateway-auth";
 import { resolveTickerAlias } from "@/lib/ticker-aliases";
+import { filterSafeMetadata } from "@/lib/dal/symbol-metadata";
 
 export const dynamic = "force-dynamic";
 
@@ -61,7 +62,7 @@ export async function GET(
     subsector_etf: data.subsector_etf,
     is_adr: data.is_adr,
     isin: data.isin,
-    metadata: data.metadata,
+    metadata: filterSafeMetadata(data.metadata),
     latest_metrics: data.latest_metrics,
     latest_vol: data.latest_vol,
     latest_teo: data.latest_teo,

--- a/app/api/data/symbols/batch/route.ts
+++ b/app/api/data/symbols/batch/route.ts
@@ -7,6 +7,7 @@ import { NextResponse, type NextRequest } from "next/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { verifyGatewayAuth } from "@/lib/gateway-auth";
 import { resolveTickerAliases } from "@/lib/ticker-aliases";
+import { filterSafeMetadata } from "@/lib/dal/symbol-metadata";
 
 export const dynamic = "force-dynamic";
 
@@ -74,7 +75,7 @@ export async function POST(request: NextRequest) {
       subsector_etf: row.subsector_etf,
       is_adr: row.is_adr,
       isin: row.isin,
-      metadata: row.metadata,
+      metadata: filterSafeMetadata(row.metadata),
       latest_metrics: row.latest_metrics,
       latest_vol: row.latest_vol,
       latest_teo: row.latest_teo,

--- a/lib/dal/symbol-metadata.ts
+++ b/lib/dal/symbol-metadata.ts
@@ -1,0 +1,55 @@
+/**
+ * Safelist filter for the `symbols.metadata` JSONB column.
+ *
+ * The `metadata` JSONB stored in Supabase contains fields populated upstream
+ * by `ERM3/scripts/python/sync_erm3_to_supabase.py` from the security_master
+ * table — including licensed third-party identifiers (`isin`, `cusip`) and // licensed-id-ok: descriptive docstring naming the fields this helper strips; no values exposed
+ * licensed industry codes (`industry_code` = FactSet `fs_industry_code`).
+ *
+ * Public API surfaces must NOT redistribute those fields. This helper
+ * restricts whole-metadata passthrough to a small allowlist of fields that
+ * are either internally derived (FIGI, BW ETF mappings) or non-sensitive
+ * (sector name, company name, delisted flag).
+ *
+ * Why a helper rather than per-route filtering: keeps the safelist in one
+ * place so adding a new route doesn't risk reintroducing the leak.
+ */
+
+const SAFE_METADATA_KEYS = [
+  "figi",          // Open identifier (Bloomberg OpenFIGI)
+  "sector",        // GICS sector NAME (e.g. "Technology") — non-sensitive label
+  "company_name",  // Public company name
+  "market_etf",    // BW-derived ETF mapping
+  "sector_etf",    // BW-derived ETF mapping
+  "subsector_etfs",// BW-derived ETF mapping array
+  "is_delisted",   // Boolean flag
+  "unique_ticker", // BW-derived disambiguated ticker
+] as const;
+
+const SAFE_KEYS_SET = new Set<string>(SAFE_METADATA_KEYS);
+
+export type SafeSymbolMetadata = Partial<{
+  figi: string | null;
+  sector: string | null;
+  company_name: string | null;
+  market_etf: string | null;
+  sector_etf: string | null;
+  subsector_etfs: string[] | null;
+  is_delisted: boolean | null;
+  unique_ticker: string | null;
+}>;
+
+export function filterSafeMetadata(
+  metadata: unknown,
+): SafeSymbolMetadata | null {
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
+    return null;
+  }
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(metadata as Record<string, unknown>)) {
+    if (SAFE_KEYS_SET.has(key)) {
+      out[key] = value;
+    }
+  }
+  return out as SafeSymbolMetadata;
+}

--- a/tests/symbol-metadata.test.ts
+++ b/tests/symbol-metadata.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { filterSafeMetadata } from "@/lib/dal/symbol-metadata";
+
+describe("filterSafeMetadata", () => {
+  it("strips licensed third-party identifiers from metadata", () => {
+    const input = {
+      isin: "US0378331005",
+      cusip: "037833100",
+      industry_code: "12345",
+      figi: "BBG000B9XRY4",
+      sector: "Technology",
+      company_name: "Apple Inc.",
+      market_etf: "SPY",
+      sector_etf: "XLK",
+      subsector_etfs: ["SOXX"],
+      is_delisted: false,
+      unique_ticker: "AAPL",
+    };
+    const out = filterSafeMetadata(input);
+    expect(out).toEqual({
+      figi: "BBG000B9XRY4",
+      sector: "Technology",
+      company_name: "Apple Inc.",
+      market_etf: "SPY",
+      sector_etf: "XLK",
+      subsector_etfs: ["SOXX"],
+      is_delisted: false,
+      unique_ticker: "AAPL",
+    });
+    expect(out).not.toHaveProperty("isin");
+    expect(out).not.toHaveProperty("cusip");
+    expect(out).not.toHaveProperty("industry_code");
+  });
+
+  it("returns null for null/undefined input", () => {
+    expect(filterSafeMetadata(null)).toBeNull();
+    expect(filterSafeMetadata(undefined)).toBeNull();
+  });
+
+  it("returns null for non-object input", () => {
+    expect(filterSafeMetadata("string")).toBeNull();
+    expect(filterSafeMetadata(123)).toBeNull();
+    expect(filterSafeMetadata([1, 2, 3])).toBeNull();
+  });
+
+  it("returns empty object when input has no safe keys", () => {
+    const input = { isin: "US123", cusip: "123", industry_code: "A1" };
+    expect(filterSafeMetadata(input)).toEqual({});
+  });
+
+  it("ignores unknown keys not on safelist", () => {
+    const input = {
+      sector: "Tech",
+      some_unknown_field: "leaks_through",
+      another_random_key: 42,
+    };
+    expect(filterSafeMetadata(input)).toEqual({ sector: "Tech" });
+  });
+});


### PR DESCRIPTION
## Summary

- Closes a metadata-passthrough leak that PR #36 (Path 4) didn't catch: the symbols routes returned `metadata: data.metadata` whole, exposing licensed third-party identifier fields embedded in the JSONB.
- Adds `lib/dal/symbol-metadata.ts` with a single-source safelist filter `filterSafeMetadata()`, and applies it to `/api/data/symbols/[ticker]` and `/api/data/symbols/batch`.

licensed-id-ok-pr: PR description names the audited fields by category; no values exposed

## The leak

The `symbols.metadata` JSONB is populated upstream by `ERM3/scripts/python/sync_erm3_to_supabase.py` from `security_master`. Each row's metadata contains:

| Key | Source | Disposition |
|---|---|---|
| `figi` | OpenFIGI | ✓ Keep — open identifier |
| `sector` | GICS sector name | ✓ Keep — non-sensitive label |
| `company_name` | Public company name | ✓ Keep — public |
| `market_etf` / `sector_etf` / `subsector_etfs` | BW-derived | ✓ Keep — internal mappings |
| `is_delisted` | Boolean | ✓ Keep — non-sensitive |
| `unique_ticker` | BW-derived | ✓ Keep |
| `isin` | ANNA / CGS (US) | ✗ Strip — licensed |
| `cusip` | CGS | ✗ Strip — licensed |
| `industry_code` | FactSet `fs_industry_code` | ✗ Strip — FactSet-licensed |

Pre-PR, the licensed three were leaking through the whole-passthrough `metadata: data.metadata` line. PR #36 removes the top-level `isin` field but doesn't reach into the JSONB. This PR plugs that gap.

## Other audit findings (no fix needed)

- `app/api/tickers/route.ts` already manually extracts specific safe fields rather than passing metadata whole. Safe.
- `lib/agent/billing.ts:571` reads `metadata` from the `billing_transactions` table — different source, not `symbols.metadata`. Safe.
- No direct reads of `metadata.{isin,cusip,industry_code}` found elsewhere in `app/api` or `lib`.

## Layer-on-top with PR #36

These two PRs touch different lines and should not conflict:
- **PR #36 (Path 4):** removes top-level `isin: data.isin` from response; removes AUDIT-PENDING file markers
- **This PR:** adds `filterSafeMetadata()` and replaces `metadata: data.metadata` with `metadata: filterSafeMetadata(data.metadata)`

Once both merge, the symbols routes will have neither (a) top-level `isin` field nor (b) `metadata.isin` / `metadata.cusip` / `metadata.industry_code` leaks.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint` clean
- [x] `vitest tests/symbol-metadata.test.ts`: 5/5 pass (new tests for the safelist)
- [x] `vitest tests/canonical-snapshot.test.ts`: 2/2 pass (no regression)
- [x] `bash scripts/check-licensed-identifiers.sh`: clean (existing AUDIT-PENDING warnings on the route files will clear when PR #36 merges)
- [ ] CI green
- [ ] Spot-check `/api/data/symbols/AAPL` response after deploy — `response.metadata` no longer contains `isin`, `cusip`, or `industry_code`

🤖 Generated with [Claude Code](https://claude.com/claude-code)