### PR TITLE
feat(snapshots): canonical stock snapshot contract + reference renderer (PR 1/3)

### DIFF
--- a/sdk/riskmodels/snapshots/__init__.py
+++ b/sdk/riskmodels/snapshots/__init__.py
@@ -93,6 +93,30 @@ from .r1_risk_profile import (
 from .s1_forensic import S1Data, get_data_for_s1, render_s1_to_pdf
 from .s2_waterfall import S2Data, get_data_for_s2, render_s2_to_pdf
 
+# Canonical contract — the single semantic object backing all stock snapshots.
+# Premium institutional renderers live in BWMACRO; this repo exposes the
+# contract + a public reference renderer.
+from .canonical import (
+    CANONICAL_SCHEMA_VERSION,
+    CanonicalStockSnapshot,
+    Identity,
+    CoreMetrics,
+    AttributionPoint,
+    PerformanceAttribution,
+    DecompositionPoint,
+    RiskDecomposition,
+    PeerRow,
+    PeerContext,
+    HedgeBasis,
+    MacroBasis,
+    from_dd_data,
+)
+from .reference_renderer import (
+    render_canonical_to_pdf,
+    render_canonical_to_png,
+    render_canonical_to_png_bytes,
+)
+
 __all__ = [
     # Design system — Matplotlib (legacy S1/S2)
     "THEME", "Theme", "Palette", "Typography", "Layout", "Strokes",
@@ -145,4 +169,21 @@ __all__ = [
     "S2Data",
     "get_data_for_s2",
     "render_s2_to_pdf",
+    # Canonical contract + reference renderer
+    "CANONICAL_SCHEMA_VERSION",
+    "CanonicalStockSnapshot",
+    "Identity",
+    "CoreMetrics",
+    "AttributionPoint",
+    "PerformanceAttribution",
+    "DecompositionPoint",
+    "RiskDecomposition",
+    "PeerRow",
+    "PeerContext",
+    "HedgeBasis",
+    "MacroBasis",
+    "from_dd_data",
+    "render_canonical_to_pdf",
+    "render_canonical_to_png",
+    "render_canonical_to_png_bytes",
 ]

--- a/sdk/riskmodels/snapshots/canonical.py
+++ b/sdk/riskmodels/snapshots/canonical.py
@@ -1,0 +1,568 @@
+"""Canonical Stock Snapshot — the single semantic object every renderer reads.
+
+This module defines the **public contract** that splits the snapshot system
+into a public math/primitives layer (this repo) and a private institutional
+composition layer (BWMACRO). Every downstream surface — PDF, PNG, web,
+agent summary, social preview — derives from a ``CanonicalStockSnapshot``.
+
+The structure mirrors the canonical conceptual distinction:
+
+    RETURN ATTRIBUTION   — what drove realized returns
+    RISK DECOMPOSITION   — what drives variance / risk
+
+These are **not** the same thing. The schema keeps them strictly separate.
+
+What is here
+------------
+    CanonicalStockSnapshot   — top-level frozen dataclass; version-stamped
+    Identity                 — ticker, name, as-of, sector/subsector ETFs
+    CoreMetrics              — left-rail spine (beta, vol, residual ER, …)
+    PerformanceAttribution   — Section I
+    RiskDecomposition        — Section II
+    PeerContext              — Section III
+    HedgeBasis               — Section IV
+    MacroBasis               — Section V
+    CANONICAL_SCHEMA_VERSION — bump on shape change
+    from_dd_data()           — adapter from DDData (existing pipeline)
+
+What is NOT here
+----------------
+    - Editorial vocabulary or qualifier strings (those live in
+      ``bwmacro/risk_interpretation/`` and reach the snapshot via the
+      ``Judgment`` field, populated by the BWMACRO engine).
+    - Premium institutional layouts (those live in
+      ``bwmacro/snapshots/stock/``).
+    - Any rendering logic. This file is data only.
+
+The reference public renderer is :mod:`riskmodels.snapshots.reference_renderer`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, asdict
+from pathlib import Path
+from typing import Any, TYPE_CHECKING
+
+from ..interpretation import Judgment
+
+if TYPE_CHECKING:
+    from .stock_deep_dive import DDData
+
+
+CANONICAL_SCHEMA_VERSION = "canonical-stock/1.0"
+
+
+# ---------------------------------------------------------------------------
+# Identity + left rail
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class Identity:
+    """Stable identity band — top of every rendering."""
+
+    ticker: str
+    company_name: str
+    as_of: str                       # ISO date, e.g. "2026-04-08"
+    sector_etf: str | None
+    subsector_etf: str | None
+    market_cap_usd: float | None
+    universe: str = "uni_mc_3000"
+
+
+@dataclass(frozen=True)
+class CoreMetrics:
+    """Fixed left-rail spine — present on every snapshot variant.
+
+    Decomposition shares are percent-of-variance (sum to ~1.0 when present).
+    Hedge ratios are factor betas (signed, dimensionless).
+    """
+
+    # Headline stats
+    beta: float | None = None                 # market beta (1y daily)
+    vol_23d: float | None = None              # 23-day vol (annualized)
+    max_drawdown_pct: float | None = None     # worst peak-to-trough (signed)
+    sharpe_252d: float | None = None          # 252d Sharpe
+
+    # Residual / idiosyncratic
+    residual_er: float | None = None          # residual explained return (pct)
+    residual_vol: float | None = None         # residual vol (annualized)
+
+    # Variance-share decomposition (Σ ≈ 1.0 when populated)
+    market_share: float | None = None
+    sector_share: float | None = None
+    subsector_share: float | None = None
+    residual_share: float | None = None
+
+
+# ---------------------------------------------------------------------------
+# Section I — Performance Attribution ("what drove returns?")
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class AttributionPoint:
+    """One step in a sequential / telescoping return-attribution waterfall."""
+
+    label: str                  # e.g. "Market", "Sector", "Subsector", "Residual", "Gross"
+    value_pct: float            # cumulative or step contribution, in pct
+    sequence: int               # ordering index for waterfall semantics
+
+
+@dataclass(frozen=True)
+class PerformanceAttribution:
+    """Section I — return attribution over a window.
+
+    `series` holds the geometric/sequential decomposition (Market → Sector →
+    Subsector → Residual → Gross). Time-series fields are optional and used
+    by chart-heavy renderers; tabular-only renderers can ignore them.
+    """
+
+    window_label: str                                            # "1Y", "3M", …
+    window_start: str                                            # ISO date
+    window_end: str                                              # ISO date
+    series: list[AttributionPoint] = field(default_factory=list)
+
+    # Optional: trailing-window scalar returns by entity
+    trailing_returns: dict[str, float | None] = field(default_factory=dict)
+    # Optional: cumulative curves keyed by entity (target / SPY / sector ETF / …)
+    cumulative_curves: dict[str, list[tuple[str, float]]] = field(default_factory=dict)
+    # Optional: drawdown series keyed by entity
+    drawdown_curves: dict[str, list[tuple[str, float]]] = field(default_factory=dict)
+    # True iff cumulative_curves uses combined factor returns (CFR), not gross ETF
+    uses_combined_factor_returns: bool = False
+
+
+# ---------------------------------------------------------------------------
+# Section II — Risk Decomposition ("what drives variance?")
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class DecompositionPoint:
+    """One row of variance-share decomposition."""
+
+    label: str                  # "Market", "Sector", "Subsector", "Residual"
+    share: float                # 0.0 – 1.0, fraction of total variance
+    sequence: int               # display ordering
+
+
+@dataclass(frozen=True)
+class RiskDecomposition:
+    """Section II — variance decomposition.
+
+    Distinct from :class:`PerformanceAttribution`: variance shares answer
+    "what drives risk?", not "what drove returns?". The two views often
+    disagree (e.g. a stock can be variance-dominated by market while being
+    return-driven by residual) — this is the central RiskModels insight
+    the schema encodes.
+    """
+
+    total_variance: float | None = None
+    components: list[DecompositionPoint] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Section III — Peer Context ("how unusual relative to peers?")
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class PeerRow:
+    """One row of the peer cohort table."""
+
+    ticker: str
+    weight: float | None = None                 # cap weight in the cohort, 0–1
+    market_cap_usd: float | None = None
+
+    # Hedge ratios (factor betas)
+    market_hr: float | None = None
+    sector_hr: float | None = None
+    subsector_hr: float | None = None
+
+    # Residual quality
+    residual_er: float | None = None            # pct
+    residual_quality_pct: float | None = None   # cohort percentile, 0–100 (100 = best)
+    gross_rank_pct: float | None = None         # cohort percentile, 0–100 (100 = best)
+
+
+@dataclass(frozen=True)
+class PeerContext:
+    """Section III — target vs. cohort.
+
+    `target` is the snapshot's stock; `peers` are its cap-weighted cohort.
+    `selection_spread` is target.residual_er − cap-weighted-mean(peer.residual_er).
+    """
+
+    cohort_label: str                               # e.g. "IDGT subsector peers"
+    cohort_size: int
+    target: PeerRow
+    peers: list[PeerRow] = field(default_factory=list)
+    selection_spread: float | None = None
+    target_vol: float | None = None
+    peer_avg_vol: float | None = None
+
+
+# ---------------------------------------------------------------------------
+# Section IV — Hedge Basis ("how to isolate exposures?")
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class HedgeBasis:
+    """Section IV — factor isolation via hedge ratios.
+
+    Overlaps :class:`RiskDecomposition` semantically (both are dual views of
+    the factor model) but kept distinct so renderers can show "how to
+    construct the hedge" separately from "what variance to attribute".
+    """
+
+    market_hr: float | None = None              # L1 — broad market beta
+    sector_hr: float | None = None              # L2 — sector beta
+    subsector_hr: float | None = None           # L3 — subsector beta
+    residual_quality_pct: float | None = None   # cohort percentile of residual ER
+
+
+# ---------------------------------------------------------------------------
+# Section V — Macro Basis ("what regimes influence residual?")
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class MacroBasis:
+    """Section V — macro-factor correlations of the residual stream."""
+
+    correlations: dict[str, float] = field(default_factory=dict)
+    window_label: str = "252d"
+
+
+# ---------------------------------------------------------------------------
+# Top-level snapshot
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class CanonicalStockSnapshot:
+    """Single semantic object backing every stock-snapshot surface.
+
+    Renderers (PDF / PNG / web / agent / social) read this object — they
+    do not call the API or recompute anything. The fetch layer produces
+    one of these per (ticker, as-of); presentation is downstream.
+
+    `judgment` carries the editorial layer when populated by the BWMACRO
+    interpretation engine; the public reference renderer gracefully falls
+    back to numeric headlines when it is None.
+    """
+
+    schema_version: str
+    generated_utc: str
+
+    identity: Identity
+    core_metrics: CoreMetrics
+
+    performance: PerformanceAttribution
+    risk: RiskDecomposition
+
+    peer: PeerContext | None = None
+    hedge: HedgeBasis | None = None
+    macro: MacroBasis | None = None
+
+    judgment: Judgment | None = None
+
+    # ---- JSON I/O ----------------------------------------------------------
+
+    def to_json(self, path: str | Path) -> Path:
+        import json
+        p = Path(path)
+        p.write_text(json.dumps(_to_jsonable(self), indent=2, default=str))
+        return p
+
+    @classmethod
+    def from_json(cls, path: str | Path) -> "CanonicalStockSnapshot":
+        import json
+        raw = json.loads(Path(path).read_text())
+        return _from_jsonable(raw)
+
+
+# ---------------------------------------------------------------------------
+# JSON serialization helpers
+# ---------------------------------------------------------------------------
+
+def _to_jsonable(snap: CanonicalStockSnapshot) -> dict[str, Any]:
+    """Convert a snapshot to a plain-dict tree suitable for json.dumps."""
+    return asdict(snap)
+
+
+def _from_jsonable(raw: dict[str, Any]) -> CanonicalStockSnapshot:
+    """Inverse of :func:`_to_jsonable`. Tolerant of missing optional sections."""
+
+    def _opt(key: str, builder):
+        v = raw.get(key)
+        return builder(v) if v is not None else None
+
+    identity = Identity(**raw["identity"])
+    core = CoreMetrics(**raw["core_metrics"])
+
+    perf_raw = raw["performance"]
+    series = [AttributionPoint(**p) for p in perf_raw.get("series", [])]
+    performance = PerformanceAttribution(
+        window_label=perf_raw["window_label"],
+        window_start=perf_raw["window_start"],
+        window_end=perf_raw["window_end"],
+        series=series,
+        trailing_returns=perf_raw.get("trailing_returns", {}),
+        cumulative_curves={
+            k: [(str(d), float(v)) for d, v in lst]
+            for k, lst in perf_raw.get("cumulative_curves", {}).items()
+        },
+        drawdown_curves={
+            k: [(str(d), float(v)) for d, v in lst]
+            for k, lst in perf_raw.get("drawdown_curves", {}).items()
+        },
+        uses_combined_factor_returns=bool(perf_raw.get("uses_combined_factor_returns", False)),
+    )
+
+    risk_raw = raw["risk"]
+    risk = RiskDecomposition(
+        total_variance=risk_raw.get("total_variance"),
+        components=[DecompositionPoint(**c) for c in risk_raw.get("components", [])],
+    )
+
+    peer = _opt(
+        "peer",
+        lambda p: PeerContext(
+            cohort_label=p["cohort_label"],
+            cohort_size=int(p["cohort_size"]),
+            target=PeerRow(**p["target"]),
+            peers=[PeerRow(**r) for r in p.get("peers", [])],
+            selection_spread=p.get("selection_spread"),
+            target_vol=p.get("target_vol"),
+            peer_avg_vol=p.get("peer_avg_vol"),
+        ),
+    )
+    hedge = _opt("hedge", lambda h: HedgeBasis(**h))
+    macro = _opt("macro", lambda m: MacroBasis(**m))
+    judgment = _opt("judgment", lambda j: Judgment(**j))
+
+    return CanonicalStockSnapshot(
+        schema_version=raw["schema_version"],
+        generated_utc=raw["generated_utc"],
+        identity=identity,
+        core_metrics=core,
+        performance=performance,
+        risk=risk,
+        peer=peer,
+        hedge=hedge,
+        macro=macro,
+        judgment=judgment,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Adapter: DDData → CanonicalStockSnapshot
+# ---------------------------------------------------------------------------
+
+def _g(d: dict, *keys: str) -> Any:
+    """First non-None value among `keys`. Tolerates abbreviated/full schemas
+    (``l3_market_hr`` vs ``l3_mkt_hr``). Mirrors :func:`interpretation._g`."""
+    for k in keys:
+        v = d.get(k)
+        if v is not None:
+            return v
+    return None
+
+
+def _to_float(v: Any) -> float | None:
+    if v is None:
+        return None
+    try:
+        f = float(v)
+    except (TypeError, ValueError):
+        return None
+    import math
+    return f if math.isfinite(f) else None
+
+
+def from_dd_data(
+    dd: "DDData",
+    *,
+    judgment: Judgment | None = None,
+    generated_utc: str | None = None,
+) -> CanonicalStockSnapshot:
+    """Convert a :class:`DDData` (existing pipeline) into the canonical schema.
+
+    This is the migration bridge: every cached DD JSON in the repo can be
+    replayed through the canonical pipeline without re-fetching. Use it to
+    validate the contract against real shipped data before downstream
+    renderers move off DDData.
+    """
+    from datetime import datetime, timezone
+
+    p1 = dd.p1
+    m = dict(p1.metrics or {})
+
+    identity = Identity(
+        ticker=p1.ticker,
+        company_name=p1.company_name,
+        as_of=p1.teo,
+        sector_etf=p1.sector_etf,
+        subsector_etf=p1.subsector_etf,
+        market_cap_usd=_to_float(_g(m, "market_cap", "mc")),
+        universe=p1.universe,
+    )
+
+    # ── Variance-share decomposition (l3_*_er normalized) ──────────────
+    mkt_er = _to_float(_g(m, "l3_market_er", "l3_mkt_er")) or 0.0
+    sec_er = _to_float(_g(m, "l3_sector_er", "l3_sec_er")) or 0.0
+    sub_er = _to_float(_g(m, "l3_subsector_er", "l3_sub_er")) or 0.0
+    res_er = _to_float(_g(m, "l3_residual_er", "l3_res_er")) or 0.0
+    total_er = mkt_er + sec_er + sub_er + res_er
+
+    def _share(x: float) -> float | None:
+        return (x / total_er) if total_er > 0 else None
+
+    core = CoreMetrics(
+        beta=_to_float(_g(m, "l1_mkt_beta", "beta_252d", "beta")),
+        vol_23d=_to_float(p1.vol_23d if p1.vol_23d is not None else _g(m, "vol_23d")),
+        max_drawdown_pct=_to_float(p1.max_drawdown),
+        sharpe_252d=_to_float(p1.sharpe_1y),
+        residual_er=_to_float(res_er) if total_er > 0 else None,
+        residual_vol=_to_float(_g(m, "residual_vol", "res_vol")),
+        market_share=_share(mkt_er),
+        sector_share=_share(sec_er),
+        subsector_share=_share(sub_er),
+        residual_share=_share(res_er),
+    )
+
+    # ── Section II: variance decomposition ─────────────────────────────
+    components: list[DecompositionPoint] = []
+    if total_er > 0:
+        components = [
+            DecompositionPoint("Market", mkt_er / total_er, 0),
+            DecompositionPoint("Sector", sec_er / total_er, 1),
+            DecompositionPoint("Subsector", sub_er / total_er, 2),
+            DecompositionPoint("Residual", res_er / total_er, 3),
+        ]
+    risk = RiskDecomposition(
+        total_variance=_to_float(_g(m, "stock_var", "variance")),
+        components=components,
+    )
+
+    # ── Section I: performance attribution (window summary + curves) ───
+    cum_stock = list(p1.cum_stock or [])
+    window_start = cum_stock[0][0] if cum_stock else p1.teo
+    window_end = cum_stock[-1][0] if cum_stock else p1.teo
+
+    perf_series: list[AttributionPoint] = []  # geometric attribution lives in BWMACRO
+
+    cumulative_curves: dict[str, list[tuple[str, float]]] = {}
+    if cum_stock:
+        cumulative_curves[p1.ticker] = cum_stock
+    if p1.cum_spy:
+        cumulative_curves["SPY"] = list(p1.cum_spy)
+    if p1.cum_sector and p1.sector_etf:
+        cumulative_curves[p1.sector_etf] = list(p1.cum_sector)
+    if p1.cum_subsector and p1.subsector_etf:
+        cumulative_curves[p1.subsector_etf] = list(p1.cum_subsector)
+
+    drawdown_curves: dict[str, list[tuple[str, float]]] = {}
+    if p1.dd_stock:
+        drawdown_curves[p1.ticker] = list(p1.dd_stock)
+    if p1.dd_spy:
+        drawdown_curves["SPY"] = list(p1.dd_spy)
+
+    trailing = {
+        p1.ticker: _to_float(p1.tr_stock.get("1Y")) if p1.tr_stock else None,
+        "SPY": _to_float(p1.tr_spy.get("1Y")) if p1.tr_spy else None,
+    }
+    if p1.sector_etf and p1.tr_sector:
+        trailing[p1.sector_etf] = _to_float(p1.tr_sector.get("1Y"))
+    if p1.subsector_etf and p1.tr_subsector:
+        trailing[p1.subsector_etf] = _to_float(p1.tr_subsector.get("1Y"))
+
+    performance = PerformanceAttribution(
+        window_label="1Y",
+        window_start=window_start,
+        window_end=window_end,
+        series=perf_series,
+        trailing_returns=trailing,
+        cumulative_curves=cumulative_curves,
+        drawdown_curves=drawdown_curves,
+        uses_combined_factor_returns=p1.cumulative_bench_lines_use_cfr,
+    )
+
+    # ── Section III: peer context ──────────────────────────────────────
+    peer: PeerContext | None = None
+    if dd.peer_comparison is not None:
+        pc = dd.peer_comparison
+        target_metrics = pc.target_metrics or {}
+        target_row = PeerRow(
+            ticker=pc.target_ticker,
+            market_hr=_to_float(_g(target_metrics, "l3_market_hr", "l3_mkt_hr")),
+            sector_hr=_to_float(_g(target_metrics, "l3_sector_hr", "l3_sec_hr")),
+            subsector_hr=_to_float(_g(target_metrics, "l3_subsector_hr", "l3_sub_hr")),
+            residual_er=_to_float(_g(target_metrics, "l3_residual_er", "l3_res_er")),
+            residual_quality_pct=_to_float(
+                (dd.peer_rankings.get(pc.target_ticker) or (None, None))[1]
+            ),
+            gross_rank_pct=_to_float(
+                (dd.peer_rankings.get(pc.target_ticker) or (None, None))[0]
+            ),
+        )
+
+        peer_rows: list[PeerRow] = []
+        peer_detail = pc.peer_detail
+        if peer_detail is not None and not peer_detail.empty:
+            for tk, row in peer_detail.iterrows():
+                rk = dd.peer_rankings.get(str(tk), (None, None))
+                peer_rows.append(
+                    PeerRow(
+                        ticker=str(tk),
+                        weight=_to_float(row.get("weight")),
+                        market_cap_usd=_to_float(row.get("market_cap")),
+                        market_hr=_to_float(row.get("l3_market_hr") or row.get("l3_mkt_hr")),
+                        sector_hr=_to_float(row.get("l3_sector_hr") or row.get("l3_sec_hr")),
+                        subsector_hr=_to_float(
+                            row.get("l3_subsector_hr") or row.get("l3_sub_hr")
+                        ),
+                        residual_er=_to_float(
+                            row.get("l3_residual_er") or row.get("l3_res_er")
+                        ),
+                        residual_quality_pct=_to_float(rk[1]),
+                        gross_rank_pct=_to_float(rk[0]),
+                    )
+                )
+
+        peer = PeerContext(
+            cohort_label=pc.peer_group_label,
+            cohort_size=len(peer_rows),
+            target=target_row,
+            peers=peer_rows,
+            selection_spread=_to_float(pc.selection_spread),
+            target_vol=_to_float(pc.target_vol),
+            peer_avg_vol=_to_float(pc.peer_avg_vol),
+        )
+
+    # ── Section IV: hedge basis ────────────────────────────────────────
+    hedge = HedgeBasis(
+        market_hr=_to_float(_g(m, "l3_market_hr", "l3_mkt_hr")),
+        sector_hr=_to_float(_g(m, "l3_sector_hr", "l3_sec_hr")),
+        subsector_hr=_to_float(_g(m, "l3_subsector_hr", "l3_sub_hr")),
+        residual_quality_pct=_to_float(
+            (dd.peer_rankings.get(p1.ticker) or (None, None))[1]
+        ),
+    )
+
+    # ── Section V: macro basis ─────────────────────────────────────────
+    macro: MacroBasis | None = None
+    if p1.macro_correlations:
+        macro = MacroBasis(
+            correlations={k: float(v) for k, v in p1.macro_correlations.items() if v is not None},
+            window_label=p1.macro_window or "252d",
+        )
+
+    return CanonicalStockSnapshot(
+        schema_version=CANONICAL_SCHEMA_VERSION,
+        generated_utc=generated_utc or datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        identity=identity,
+        core_metrics=core,
+        performance=performance,
+        risk=risk,
+        peer=peer,
+        hedge=hedge,
+        macro=macro,
+        judgment=judgment,
+    )

--- a/sdk/riskmodels/snapshots/reference_renderer.py
+++ b/sdk/riskmodels/snapshots/reference_renderer.py
@@ -1,0 +1,345 @@
+"""Public reference renderer for :class:`CanonicalStockSnapshot`.
+
+Produces a clean, institutional, single-page PDF / PNG. Intentionally
+less opinionated than the BWMACRO renderers — no narrative, no curated
+peer benchmarking layout, no hedge-construction artwork — but trustworthy
+as a working reference. Open-source consumers and the SDK community
+render through this; the premium institutional layouts live privately
+in BWMACRO.
+
+Sections rendered (in order):
+
+    Header                          identity band (ticker, company, as-of)
+    Chips                           beta, vol, max DD, Sharpe
+    Section I — Performance         cumulative-return curves (1Y)
+    Section II — Risk decomposition variance shares (Market/Sector/Sub/Residual)
+    Section III — Peer context      top peers by weight (compact table)
+
+Hedge / macro sections in :class:`CanonicalStockSnapshot` are not rendered
+here — they exist for downstream BWMACRO consumers.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import matplotlib.ticker as mticker
+import numpy as np
+
+from ._charts import chart_hbar, chart_table
+from ._page import SnapshotPage
+from ._theme import THEME
+from .canonical import CanonicalStockSnapshot
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _fmt_pct(v: float | None, *, decimals: int = 1, sign: bool = False) -> str:
+    if v is None:
+        return "—"
+    fmt = f"{{:+.{decimals}f}}%" if sign else f"{{:.{decimals}f}}%"
+    return fmt.format(v * 100.0)
+
+
+def _fmt_num(v: float | None, *, decimals: int = 2) -> str:
+    if v is None:
+        return "—"
+    return f"{v:.{decimals}f}"
+
+
+def _build_chips(snap: CanonicalStockSnapshot) -> list[tuple[str, str]]:
+    cm = snap.core_metrics
+    return [
+        ("Beta",     _fmt_num(cm.beta)),
+        ("Vol 23d",  _fmt_pct(cm.vol_23d)),
+        ("Max DD",   _fmt_pct(cm.max_drawdown_pct, sign=True)),
+        ("Sharpe",   _fmt_num(cm.sharpe_252d)),
+        ("Resid ER", _fmt_pct(cm.residual_er, sign=True)),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Section renderers
+# ---------------------------------------------------------------------------
+
+def _render_section_i_performance(page: SnapshotPage, snap: CanonicalStockSnapshot) -> None:
+    """Cumulative-return curves over the snapshot window."""
+    perf = snap.performance
+    if not perf.cumulative_curves:
+        ax = page.panel(row_slice=slice(2, 6), col_slice=slice(3, 12))
+        ax.text(
+            0.5, 0.5, "Performance series unavailable",
+            ha="center", va="center",
+            color=THEME.palette.text_light,
+            fontsize=THEME.type.body,
+            transform=ax.transAxes,
+        )
+        ax.set_title("I. Performance Attribution", loc="left",
+                     fontsize=THEME.type.panel_title,
+                     fontweight=THEME.type.weight_bold,
+                     color=THEME.palette.navy)
+        ax.set_xticks([]); ax.set_yticks([])
+        return
+
+    ax = page.panel(row_slice=slice(2, 6), col_slice=slice(3, 12))
+
+    # Pull stable label order: target → SPY → sector → subsector → others
+    target = snap.identity.ticker
+    ordered_labels: list[str] = []
+    for k in [target, "SPY", snap.identity.sector_etf, snap.identity.subsector_etf]:
+        if k and k in perf.cumulative_curves and k not in ordered_labels:
+            ordered_labels.append(k)
+    for k in perf.cumulative_curves:
+        if k not in ordered_labels:
+            ordered_labels.append(k)
+
+    pal = THEME.palette
+    strk = THEME.strokes
+    typ = THEME.type
+
+    palette = [pal.navy, pal.teal, pal.slate, pal.green, pal.orange]
+
+    drawn = 0
+    for i, label in enumerate(ordered_labels):
+        pts = perf.cumulative_curves.get(label) or []
+        if not pts:
+            continue
+        dates = [p[0] for p in pts]
+        values = [p[1] for p in pts]
+        color = palette[i % len(palette)]
+        lw = strk.series_lw if drawn < 3 else strk.thin_lw
+        ax.plot(dates, values, label=label, color=color, linewidth=lw, zorder=3 + i)
+        drawn += 1
+
+    if drawn == 0:
+        ax.text(0.5, 0.5, "No data", ha="center", va="center",
+                color=pal.text_light, transform=ax.transAxes)
+        ax.set_xticks([]); ax.set_yticks([])
+        return
+
+    ax.set_title(
+        f"I. Performance Attribution · {perf.window_label}",
+        loc="left",
+        fontsize=typ.panel_title,
+        fontweight=typ.weight_bold,
+        color=pal.navy,
+        pad=8,
+    )
+    ax.yaxis.set_major_formatter(mticker.FuncFormatter(lambda y, _: f"{y:+.0%}"))
+    ax.axhline(0, color=pal.border, linewidth=strk.thin_lw, zorder=2)
+    ax.legend(fontsize=typ.axis_tick, loc="best", ncol=min(drawn, 4))
+    ax.spines["top"].set_visible(False)
+    ax.spines["right"].set_visible(False)
+    # Sparser x-tick labels — show ~6 labels max
+    n_pts = len(perf.cumulative_curves[ordered_labels[0]])
+    if n_pts > 0:
+        step = max(1, n_pts // 6)
+        ax.xaxis.set_major_locator(mticker.MultipleLocator(step))
+        for tick in ax.get_xticklabels():
+            tick.set_rotation(0)
+            tick.set_fontsize(typ.axis_tick)
+
+
+def _render_section_ii_risk(page: SnapshotPage, snap: CanonicalStockSnapshot) -> None:
+    """Variance-share decomposition."""
+    ax = page.panel(row_slice=slice(8, 12), col_slice=slice(3, 7))
+
+    comps = snap.risk.components
+    if not comps:
+        ax.set_title("II. Risk Decomposition (variance share)",
+                     loc="left",
+                     fontsize=THEME.type.panel_title,
+                     fontweight=THEME.type.weight_bold,
+                     color=THEME.palette.navy)
+        ax.text(0.5, 0.5, "Decomposition unavailable",
+                ha="center", va="center",
+                color=THEME.palette.text_light,
+                transform=ax.transAxes)
+        ax.set_xticks([]); ax.set_yticks([])
+        return
+
+    labels = [c.label for c in comps]
+    values = [c.share * 100.0 for c in comps]
+
+    chart_hbar(
+        ax,
+        labels=labels,
+        values=values,
+        colors=THEME.palette.factor_colors[:len(labels)],
+        title="II. Risk Decomposition (variance share)",
+        value_fmt="{:.1f}%",
+        sort=False,
+    )
+
+
+def _render_section_iii_peer(page: SnapshotPage, snap: CanonicalStockSnapshot) -> None:
+    """Compact peer-cohort table."""
+    ax = page.panel(row_slice=slice(8, 12), col_slice=slice(8, 12))
+    ax.set_title("III. Peer Context",
+                 loc="left",
+                 fontsize=THEME.type.panel_title,
+                 fontweight=THEME.type.weight_bold,
+                 color=THEME.palette.navy,
+                 pad=6)
+    ax.set_xticks([]); ax.set_yticks([])
+    for spine in ax.spines.values():
+        spine.set_visible(False)
+
+    if snap.peer is None or not snap.peer.peers:
+        ax.text(0.5, 0.5, "Peer context unavailable",
+                ha="center", va="center",
+                color=THEME.palette.text_light,
+                transform=ax.transAxes)
+        return
+
+    # Top 6 peers by weight (descending)
+    rows_sorted = sorted(
+        snap.peer.peers,
+        key=lambda r: (r.weight if r.weight is not None else 0.0),
+        reverse=True,
+    )[:6]
+
+    table_rows: list[list[str]] = []
+    for r in rows_sorted:
+        table_rows.append([
+            r.ticker,
+            _fmt_pct(r.weight) if r.weight is not None else "—",
+            _fmt_pct(r.residual_er, sign=True),
+        ])
+
+    chart_table(
+        ax,
+        rows=table_rows,
+        headers=["Ticker", "Wt", "Resid ER"],
+    )
+
+    # Cohort label as caption — small text under the table
+    page.fig.text(
+        0.83, 0.115,
+        f"Cohort: {snap.peer.cohort_label}  ·  N={snap.peer.cohort_size}",
+        fontsize=THEME.type.footer,
+        color=THEME.palette.text_light,
+        ha="center", va="top",
+    )
+
+
+def _render_left_rail(page: SnapshotPage, snap: CanonicalStockSnapshot) -> None:
+    """Stable identity spine — text-only summary in the left columns."""
+    ax = page.panel(row_slice=slice(2, 12), col_slice=slice(0, 3))
+    ax.set_xticks([]); ax.set_yticks([])
+    for spine in ax.spines.values():
+        spine.set_visible(False)
+    ax.set_facecolor(THEME.palette.panel_bg)
+
+    pal = THEME.palette
+    typ = THEME.type
+    cm = snap.core_metrics
+    idy = snap.identity
+
+    lines: list[tuple[str, str]] = [
+        ("IDENTITY", ""),
+        ("Ticker",        idy.ticker),
+        ("Sector ETF",    idy.sector_etf or "—"),
+        ("Subsector ETF", idy.subsector_etf or "—"),
+        ("Market Cap",    f"${idy.market_cap_usd/1e9:,.1f}B" if idy.market_cap_usd else "—"),
+        ("",              ""),
+        ("DECOMPOSITION", ""),
+        ("Market",        _fmt_pct(cm.market_share)),
+        ("Sector",        _fmt_pct(cm.sector_share)),
+        ("Subsector",     _fmt_pct(cm.subsector_share)),
+        ("Residual",      _fmt_pct(cm.residual_share)),
+    ]
+
+    if snap.macro and snap.macro.correlations:
+        lines.append(("", ""))
+        lines.append(("MACRO ρ", ""))
+        for name, rho in list(snap.macro.correlations.items())[:5]:
+            lines.append((name, f"{rho:+.2f}"))
+
+    n = len(lines)
+    # Distribute lines vertically inside the axes (0.0 at bottom, 1.0 at top)
+    for i, (label, value) in enumerate(lines):
+        y = 1.0 - (i + 0.5) / n
+        is_section = label.isupper() and value == "" and label != ""
+        if is_section:
+            ax.text(
+                0.0, y, label,
+                fontsize=typ.chip_label,
+                fontweight=typ.weight_bold,
+                color=pal.navy,
+                transform=ax.transAxes,
+                va="center", ha="left",
+            )
+        else:
+            if label:
+                ax.text(
+                    0.02, y, label,
+                    fontsize=typ.body,
+                    color=pal.text_mid,
+                    transform=ax.transAxes,
+                    va="center", ha="left",
+                )
+            if value:
+                ax.text(
+                    0.98, y, value,
+                    fontsize=typ.body,
+                    fontweight=typ.weight_bold,
+                    color=pal.text_dark,
+                    transform=ax.transAxes,
+                    va="center", ha="right",
+                )
+
+
+# ---------------------------------------------------------------------------
+# Public entry points
+# ---------------------------------------------------------------------------
+
+def render_canonical_to_pdf(
+    snap: CanonicalStockSnapshot,
+    output_path: str | Path,
+) -> Path:
+    """Render `snap` to a single-page PDF and return the output path."""
+    page = _build_page(snap)
+    return page.save(output_path)
+
+
+def render_canonical_to_png(
+    snap: CanonicalStockSnapshot,
+    output_path: str | Path,
+) -> Path:
+    """Render `snap` to a single-page PNG and return the output path."""
+    page = _build_page(snap)
+    return page.save(output_path)
+
+
+def render_canonical_to_png_bytes(snap: CanonicalStockSnapshot) -> bytes:
+    """Render `snap` to PNG bytes (no file I/O)."""
+    page = _build_page(snap)
+    return page.to_png_bytes()
+
+
+# ---------------------------------------------------------------------------
+# Internal: page assembly
+# ---------------------------------------------------------------------------
+
+def _build_page(snap: CanonicalStockSnapshot) -> SnapshotPage:
+    title = f"{snap.identity.ticker} — {snap.identity.company_name}"
+    subtitle = f"Stock Snapshot · As of {snap.identity.as_of}"
+
+    page = SnapshotPage(
+        title=title,
+        subtitle=subtitle,
+        ticker=snap.identity.ticker,
+        teo=snap.identity.as_of,
+        chips=_build_chips(snap),
+    )
+
+    _render_left_rail(page, snap)
+    _render_section_i_performance(page, snap)
+    _render_section_ii_risk(page, snap)
+    _render_section_iii_peer(page, snap)
+
+    return page

--- a/sdk/tests/test_canonical_snapshot.py
+++ b/sdk/tests/test_canonical_snapshot.py
@@ -1,0 +1,204 @@
+"""Smoke tests for the canonical stock-snapshot contract.
+
+Two layers:
+
+  1. Schema round-trip (unconditional). Builds a minimal valid
+     ``CanonicalStockSnapshot``, dumps to JSON, reloads, asserts the
+     reload equals the original. Tests the contract itself, not data.
+
+  2. Adapter + reference renderer (conditional on local DD cache,
+     which is gitignored). Loads ``AAPL_dd_cache.json`` if present,
+     converts via :func:`from_dd_data`, renders to PDF + PNG bytes,
+     and asserts non-empty output. Skipped on CI / fresh checkouts.
+
+Per the project rule against synthetic test data: the round-trip test
+constructs a clearly-marked ``__TEST__`` snapshot to exercise
+serialization only — it does not pretend to be real ticker data. The
+end-to-end render path is covered by the real-fixture conditional test.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from riskmodels.snapshots.canonical import (
+    AttributionPoint,
+    CANONICAL_SCHEMA_VERSION,
+    CanonicalStockSnapshot,
+    CoreMetrics,
+    DecompositionPoint,
+    HedgeBasis,
+    Identity,
+    MacroBasis,
+    PeerContext,
+    PeerRow,
+    PerformanceAttribution,
+    RiskDecomposition,
+    from_dd_data,
+)
+
+
+# ---------------------------------------------------------------------------
+# 1. Schema round-trip
+# ---------------------------------------------------------------------------
+
+def _build_test_snapshot() -> CanonicalStockSnapshot:
+    """Construct a schema-valid snapshot with obviously-test identity."""
+    return CanonicalStockSnapshot(
+        schema_version=CANONICAL_SCHEMA_VERSION,
+        generated_utc="2026-05-08T00:00:00+00:00",
+        identity=Identity(
+            ticker="__TEST__",
+            company_name="Test Fixture, Inc.",
+            as_of="2026-05-08",
+            sector_etf="XLK",
+            subsector_etf="SMH",
+            market_cap_usd=1.0e12,
+            universe="uni_mc_3000",
+        ),
+        core_metrics=CoreMetrics(
+            beta=1.10,
+            vol_23d=0.28,
+            max_drawdown_pct=-0.18,
+            sharpe_252d=1.45,
+            residual_er=0.012,
+            residual_vol=0.085,
+            market_share=0.55,
+            sector_share=0.20,
+            subsector_share=0.10,
+            residual_share=0.15,
+        ),
+        performance=PerformanceAttribution(
+            window_label="1Y",
+            window_start="2025-05-08",
+            window_end="2026-05-08",
+            series=[
+                AttributionPoint("Market", 0.18, 0),
+                AttributionPoint("Sector", 0.05, 1),
+                AttributionPoint("Subsector", 0.03, 2),
+                AttributionPoint("Residual", 0.02, 3),
+                AttributionPoint("Gross", 0.28, 4),
+            ],
+            trailing_returns={"__TEST__": 0.28, "SPY": 0.12},
+            cumulative_curves={
+                "__TEST__": [("2025-05-08", 0.0), ("2026-05-08", 0.28)],
+                "SPY":      [("2025-05-08", 0.0), ("2026-05-08", 0.12)],
+            },
+            drawdown_curves={
+                "__TEST__": [("2025-05-08", 0.0), ("2026-05-08", -0.05)],
+            },
+            uses_combined_factor_returns=False,
+        ),
+        risk=RiskDecomposition(
+            total_variance=0.0784,
+            components=[
+                DecompositionPoint("Market", 0.55, 0),
+                DecompositionPoint("Sector", 0.20, 1),
+                DecompositionPoint("Subsector", 0.10, 2),
+                DecompositionPoint("Residual", 0.15, 3),
+            ],
+        ),
+        peer=PeerContext(
+            cohort_label="SMH peers",
+            cohort_size=2,
+            target=PeerRow(ticker="__TEST__", weight=0.30, residual_er=0.012),
+            peers=[
+                PeerRow(ticker="PEER1", weight=0.40, residual_er=0.005),
+                PeerRow(ticker="PEER2", weight=0.30, residual_er=-0.002),
+            ],
+            selection_spread=0.010,
+        ),
+        hedge=HedgeBasis(market_hr=0.95, sector_hr=0.45, subsector_hr=0.85),
+        macro=MacroBasis(
+            correlations={"VIX": -0.42, "Oil": 0.10},
+            window_label="252d",
+        ),
+    )
+
+
+def test_schema_round_trip() -> None:
+    """JSON dump + reload yields an equal snapshot."""
+    snap = _build_test_snapshot()
+
+    with tempfile.TemporaryDirectory() as td:
+        out = Path(td) / "test_snap.json"
+        snap.to_json(out)
+
+        # File parses as valid JSON
+        raw = json.loads(out.read_text())
+        assert raw["schema_version"] == CANONICAL_SCHEMA_VERSION
+        assert raw["identity"]["ticker"] == "__TEST__"
+
+        # Round-trip equality (frozen dataclasses → __eq__ is structural)
+        reloaded = CanonicalStockSnapshot.from_json(out)
+        assert reloaded == snap
+
+
+def test_optional_sections_can_be_absent() -> None:
+    """peer / hedge / macro are optional and survive a round-trip as None."""
+    snap = CanonicalStockSnapshot(
+        schema_version=CANONICAL_SCHEMA_VERSION,
+        generated_utc="2026-05-08T00:00:00+00:00",
+        identity=Identity(
+            ticker="__TEST__", company_name="Test", as_of="2026-05-08",
+            sector_etf=None, subsector_etf=None, market_cap_usd=None,
+        ),
+        core_metrics=CoreMetrics(),
+        performance=PerformanceAttribution(
+            window_label="1Y", window_start="2025-05-08", window_end="2026-05-08",
+        ),
+        risk=RiskDecomposition(),
+    )
+
+    with tempfile.TemporaryDirectory() as td:
+        out = Path(td) / "minimal.json"
+        snap.to_json(out)
+        reloaded = CanonicalStockSnapshot.from_json(out)
+
+    assert reloaded.peer is None
+    assert reloaded.hedge is None
+    assert reloaded.macro is None
+    assert reloaded.judgment is None
+    assert reloaded == snap
+
+
+# ---------------------------------------------------------------------------
+# 2. Adapter + reference render — conditional on real cache
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DD_CACHE = REPO_ROOT / "sdk" / "riskmodels" / "snapshots" / "output" / "AAPL_dd_cache.json"
+
+
+@pytest.mark.skipif(not DD_CACHE.exists(), reason="AAPL_dd_cache.json not present (gitignored)")
+def test_from_dd_data_renders() -> None:
+    """Real DD cache → canonical → reference renderer produces non-empty PNG bytes."""
+    from riskmodels.snapshots.stock_deep_dive import DDData
+    from riskmodels.snapshots.reference_renderer import render_canonical_to_png_bytes
+
+    dd = DDData.from_json(DD_CACHE)
+    snap = from_dd_data(dd)
+
+    # Identity flows through
+    assert snap.identity.ticker == dd.p1.ticker
+    assert snap.identity.as_of == dd.p1.teo
+
+    # Variance shares are populated and roughly normalized
+    shares = [
+        snap.core_metrics.market_share,
+        snap.core_metrics.sector_share,
+        snap.core_metrics.subsector_share,
+        snap.core_metrics.residual_share,
+    ]
+    if all(s is not None for s in shares):
+        total = sum(shares)
+        assert 0.99 <= total <= 1.01, f"variance shares should sum to ~1.0; got {total}"
+
+    # Reference renderer produces non-empty PNG bytes
+    png_bytes = render_canonical_to_png_bytes(snap)
+    assert len(png_bytes) > 1000, "PNG output suspiciously small"
+    assert png_bytes[:8] == b"\x89PNG\r\n\x1a\n", "not a valid PNG header"


### PR DESCRIPTION
## Summary

PR 1 of 3 in the migration that moves premium R1/P1/DD composition into BWMACRO while keeping math, primitives, and a working reference renderer in this repo. No existing renderers are removed yet — purely additive.

The schema mirrors the immutable RiskModels distinction:
- **RETURN ATTRIBUTION** — what drove realized returns
- **RISK DECOMPOSITION** — what drives variance / risk

These are strictly separate fields in the schema so renderers cannot accidentally blur them.

## What landed

- `sdk/riskmodels/snapshots/canonical.py` — `CanonicalStockSnapshot` frozen dataclass with sub-objects: `Identity`, `CoreMetrics`, `PerformanceAttribution`, `RiskDecomposition`, `PeerContext`, `HedgeBasis`, `MacroBasis`. Versioned via `CANONICAL_SCHEMA_VERSION = "canonical-stock/1.0"`. JSON round-trip via `to_json` / `from_json`.
- `from_dd_data(dd: DDData)` adapter so every cached DD JSON in the repo replays through the canonical pipeline without re-fetching — validates the contract against real shipped data.
- `sdk/riskmodels/snapshots/reference_renderer.py` — public reference PDF/PNG renderer. Clean, institutional, less opinionated than the BWMACRO renderers. Uses only public `_theme` + `_charts` primitives. Renders Identity / Core metrics / Section I (cumulative returns) / Section II (variance shares) / Section III (peer table). Skips hedge + macro sections (those exist in the contract for BWMACRO consumers).
- `sdk/tests/test_canonical_snapshot.py` — schema round-trip (unconditional) + adapter/render against real AAPL DD cache (skipped when cache absent, since `output/` is gitignored).

## Test plan

- [x] `pytest sdk/tests/test_canonical_snapshot.py` — 3 passed locally (round-trip, optional sections, real-fixture render).
- [x] Adjacent snapshot tests still green (`test_phase_a`, `test_csv_exports`, `test_interpretation`) — 27 passed.
- [x] Manually rendered AAPL canonical PNG and verified beta/vol/decomposition shares are accurate.
- [ ] CI: type-check + sdk test suite green on push.

## Followups (separate PRs)

- **PR 2** — copy `r1_risk_profile.py` / `p1_stock_performance.py` / `stock_deep_dive.py` / curated `visuals/` into `bwmacro/snapshots/stock/`, rewire imports, leave deprecated shims in this repo so nothing breaks while consumers migrate.
- **PR 3** — delete the public shims; color-ontology cutover (subsector slate → violet) with cache invalidation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)