### PR TITLE
fix(billing): H.20 — telemetry no longer duplicates deductBalance cost

### DIFF
--- a/lib/agent/telemetry.ts
+++ b/lib/agent/telemetry.ts
@@ -77,21 +77,27 @@ export interface HealthStatus {
 }
 
 /**
- * Log a telemetry event
- * Non-blocking - failures are silently ignored
+ * Log a telemetry event (request_id, capability_id, latency, success).
+ *
+ * Telemetry rows always insert with cost_usd=0. The authoritative billing
+ * row is written by `deductBalance` (lib/agent/billing.ts) with type='debit'
+ * and the actual cost. H.20 (2026-05-10): prior code also wrote event.cost_usd
+ * here, doubling revenue tracking on every billable request.
+ *
+ * Non-blocking - failures are silently ignored.
  */
 export async function logTelemetry(event: TelemetryEvent): Promise<void> {
   try {
-    // Insert into billing_events table for now
-    // In production, this might go to a separate telemetry table
-    // or a time-series database like TimescaleDB
+    // Insert into billing_events table for now; long-term this should move to
+    // a separate request_telemetry table (or TimescaleDB). Discriminate from
+    // debit rows via `latency_ms IS NOT NULL` (debit rows leave it null).
     const { error } = await createAdminClient()
       .from("billing_events")
       .insert({
         user_id: event.user_id,
         request_id: event.request_id,
         capability_id: event.capability_id,
-        cost_usd: event.cost_usd || 0,
+        cost_usd: 0, // H.20: never duplicate the deductBalance row's cost
         latency_ms: event.latency_ms,
         success: event.success,
         metadata: {


### PR DESCRIPTION
## Summary

- Surgical fix: `logTelemetry` no longer inserts `cost_usd > 0` into `billing_events`. `deductBalance` (lib/agent/billing.ts) is now the single source of truth for charges.
- Root cause (H.20, surfaced 2026-05-08 during G.8 trusted-gateway verification): every billable request was producing two `billing_events` rows ~107ms apart with identical `request_id` / `user_id` / `capability_id` / `cost_usd`, doubling revenue tracking. Test snapshot `req_moxotw4o_s4m1lk` charged the gateway UUID \$0.50 instead of \$0.25.
- Caller signature unchanged (`TelemetryEvent.cost_usd` retained but ignored), so existing call sites compile without edits.

## Why this fix shape

The duplicate writes happen in two `billing-middleware.ts` paths (lines ~646 + 678 and ~950 + 966): `deductBalance` writes the authoritative debit row (`type='debit'`, `cost_usd`, `balance_after_usd`); `logTelemetry` was a "for now" placeholder per the in-file comment, also writing `cost_usd` from the same context. Hardcoding `cost_usd: 0` in telemetry stops the dupe with a one-call-site change.

The deeper architectural fix (move telemetry to a `request_telemetry` table) is tracked separately as a follow-up.

## Test plan

- [ ] Deploy to staging
- [ ] Run a billable capability (e.g., `POST /api/snapshot` against gateway billing user)
- [ ] Verify exactly **one** row in `billing_events` for the returned `request_id`
- [ ] Run audit query against staging:
  ```sql
  SELECT request_id, count(*) FROM billing_events
  WHERE created_at > '<deploy ts>'
  GROUP BY request_id HAVING count(*) > 1;
  -- expected: 0 rows
  ```
- [ ] Quantify historic exposure on prod (read-only, no schema change):
  ```sql
  SELECT request_id, count(*), sum(cost_usd) FROM billing_events
  GROUP BY request_id HAVING count(*) > 1;
  ```
- [ ] Promote to prod after staging verification

## Out of scope (follow-up backlog item)

`getTelemetryMetrics` in `lib/agent/telemetry.ts:295` aggregates over all rows, so today's `revenue_usd` is 2× actual and `success_rate` is depressed by debit rows defaulting to `success=false`. Doesn't gate Phase 2A trial launch but worth a separate fix once the dual-purpose table is split.

## Backlog refs

- Closes **H.20** (BWMACRO `docs/ceo/MASTER_BACKLOG.md`)
- Gates **Phase 2A OAuth Claude trial loop** ([plan](https://github.com/BlueWaterCorp/BWMACRO/blob/main/docs/cursor_plans/net_phase2_oauth_claude_trial.md)) M1

🤖 Generated with [Claude Code](https://claude.com/claude-code)