### PR TITLE
fix(tests): align funds-data-routes soft-auth assertion with route contract

### DIFF
--- a/tests/funds-data-routes.test.ts
+++ b/tests/funds-data-routes.test.ts
@@ -116,16 +116,21 @@ describe("GET /api/data/funds/[bw_fund_id]", () => {
     expect(res.headers.get("X-Data-Filing-Date")).toBeNull();
   });
 
-  it("rejects an invalid Bearer token (soft auth still validates when service key set)", async () => {
+  it("treats an invalid Bearer token as anonymous public read (soft auth)", async () => {
+    // Soft-auth contract per lib/gateway-auth.ts: only the matching service key
+    // grants elevated role; user API keys, JWTs, or any other Bearer fall back
+    // to public read (same as omitting Authorization). An invalid Bearer must
+    // NOT 401 — that's the requireGatewayAuth path, not used here.
     process.env.RISKMODELS_API_SERVICE_KEY = "secret";
+    vi.mocked(resolveFundById).mockResolvedValue({ fund: FUND, latest: LATEST });
     const res = await getFund(
       req("http://localhost/api/data/funds/BW-FUND-X", {
         headers: { authorization: "Bearer wrong" },
       }),
       { params: Promise.resolve({ bw_fund_id: "BW-FUND-X" }) },
     );
-    expect(res.status).toBe(401);
-    expect(vi.mocked(resolveFundById)).not.toHaveBeenCalled();
+    expect(res.status).toBe(200);
+    expect(vi.mocked(resolveFundById)).toHaveBeenCalledWith("BW-FUND-X");
   });
 });
 


### PR DESCRIPTION
## Summary

- Test `tests/funds-data-routes.test.ts:119` expected 401 from an invalid Bearer; route uses **soft auth** (`verifyGatewayAuth`) where any non-service-key Bearer falls back to public read. Test was written under an older strict-auth assumption.
- Renamed and rewrote the test to match the documented contract: invalid Bearer → 200 + DAL invoked (anonymous public read).
- Inline comment cites the source of truth so the strict expectation isn't re-introduced.

## Why this is the test, not the code

`lib/gateway-auth.ts` documents two distinct modes:

- `verifyGatewayAuth` (used here): *"User API keys (rm_agent_* / rm_user_*) and other Bearer tokens **must NOT be rejected** — only the service key grants elevated gateway role; everything else is treated as public read (same as omitting Authorization)."*
- `requireGatewayAuth`: strict 401 path, reserved for write/admin endpoints (Phase 2+).

The route was deliberately moved to soft auth in `73c62c6` (agent-ready surface). The test predates that refactor (`f58f84a`).

## Test plan

- [x] `npx vitest run tests/funds-data-routes.test.ts` — 18/18 pass locally
- [ ] CI green on this PR
- [ ] Rebase / re-run CI on PR #42 (H.20) once this lands — PR #42 inherits this pre-existing failure

## Backlog

Unblocks **H.20** (PR #42) and any other PR that runs the funds-data-routes test suite. No backlog entry created — this is a one-shot test alignment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)