### PR TITLE
fix(scripts): drop machine-specific /Users/ paths from bulk_dd_render comment

### DIFF
--- a/sdk/scripts/run_bulk_dd_render.sh
+++ b/sdk/scripts/run_bulk_dd_render.sh
@@ -10,8 +10,14 @@
 #       --out-dir /Volumes/ext_2t/Stock_Snapshots \
 #       --limit 1000 --upload-mode batch --resume --force --workers 8
 #
-# One-liner using BWMACRO .venv (replace BW_Code paths if yours differ):
-#   export ERM3_ZARR_ROOT=/Volumes/ext_2t/factset/processed && cd /Users/conradgann/BW_Code/RiskModels_API && mkdir -p /Volumes/ext_2t/Stock_Snapshots && PYTHONPATH=sdk /Users/conradgann/BW_Code/BWMACRO/.venv/bin/python sdk/scripts/bulk_dd_render.py --out-dir /Volumes/ext_2t/Stock_Snapshots --limit 1000 --upload-mode batch --resume --force --workers 8 2>&1 | tee "$HOME/_bulk_stdout.log"
+# One-liner using BWMACRO .venv (run from RiskModels_API repo root; assumes
+# sibling BWMACRO clone per docs/SUBMODULES.md):
+#   export ERM3_ZARR_ROOT=/Volumes/ext_2t/factset/processed && \
+#     mkdir -p /Volumes/ext_2t/Stock_Snapshots && \
+#     PYTHONPATH=sdk ../BWMACRO/.venv/bin/python sdk/scripts/bulk_dd_render.py \
+#       --out-dir /Volumes/ext_2t/Stock_Snapshots --limit 1000 \
+#       --upload-mode batch --resume --force --workers 8 \
+#     2>&1 | tee "$HOME/_bulk_stdout.log"
 
 set -euo pipefail
 


### PR DESCRIPTION
## Summary

- CI **Public safety audit** trips on `grep -rIq "/Users/"` and was failing every PR because of hardcoded `/Users/conradgann/...` paths in the example one-liner comment of `sdk/scripts/run_bulk_dd_render.sh`.
- Replaced with sibling-relative form (`../BWMACRO/.venv/bin/python`) matching the script's monorepo convention per `docs/SUBMODULES.md`.
- Comment was illustrative only — no executable code path changed.

## Test plan

- [x] Local: `grep -rIq "/Users/" .` (excluding node_modules/.git/.github/.next) returns no matches
- [ ] CI Public safety audit passes on this PR
- [ ] After merge, rebase PR #42 (H.20) and PR #43 (soft-auth test) — both should go fully green

## Heads-up for 13F branch

`services/render-svc/RUNBOOK.md` (added on `feat/d8-13f-api` in `a763d45`) line 67 has `cd /Users/conradgann/BW_Code/RiskModels_API`. Will fail the same audit when `feat/d8-13f-api` merges to `main`. Worth a 1-line tidy on that branch before the PR lands. Not in scope here.

## Backlog

No backlog entry — minor CI hygiene. Unblocks PR #42 and PR #43.

🤖 Generated with [Claude Code](https://claude.com/claude-code)