### PR TITLE
fix(ci): unblock main — soft-auth test contract + scrub /Users/ paths

### DIFF
--- a/sdk/scripts/run_bulk_dd_render.sh
+++ b/sdk/scripts/run_bulk_dd_render.sh
@@ -10,8 +10,14 @@
 #       --out-dir /Volumes/ext_2t/Stock_Snapshots \
 #       --limit 1000 --upload-mode batch --resume --force --workers 8
 #
-# One-liner using BWMACRO .venv (replace BW_Code paths if yours differ):
-#   export ERM3_ZARR_ROOT=/Volumes/ext_2t/factset/processed && cd /Users/conradgann/BW_Code/RiskModels_API && mkdir -p /Volumes/ext_2t/Stock_Snapshots && PYTHONPATH=sdk /Users/conradgann/BW_Code/BWMACRO/.venv/bin/python sdk/scripts/bulk_dd_render.py --out-dir /Volumes/ext_2t/Stock_Snapshots --limit 1000 --upload-mode batch --resume --force --workers 8 2>&1 | tee "$HOME/_bulk_stdout.log"
+# One-liner using BWMACRO .venv (run from RiskModels_API repo root; assumes
+# sibling BWMACRO clone per docs/SUBMODULES.md):
+#   export ERM3_ZARR_ROOT=/Volumes/ext_2t/factset/processed && \
+#     mkdir -p /Volumes/ext_2t/Stock_Snapshots && \
+#     PYTHONPATH=sdk ../BWMACRO/.venv/bin/python sdk/scripts/bulk_dd_render.py \
+#       --out-dir /Volumes/ext_2t/Stock_Snapshots --limit 1000 \
+#       --upload-mode batch --resume --force --workers 8 \
+#     2>&1 | tee "$HOME/_bulk_stdout.log"
 
 set -euo pipefail
 

--- a/tests/funds-data-routes.test.ts
+++ b/tests/funds-data-routes.test.ts
@@ -116,16 +116,21 @@ describe("GET /api/data/funds/[bw_fund_id]", () => {
     expect(res.headers.get("X-Data-Filing-Date")).toBeNull();
   });
 
-  it("rejects an invalid Bearer token (soft auth still validates when service key set)", async () => {
+  it("treats an invalid Bearer token as anonymous public read (soft auth)", async () => {
+    // Soft-auth contract per lib/gateway-auth.ts: only the matching service key
+    // grants elevated role; user API keys, JWTs, or any other Bearer fall back
+    // to public read (same as omitting Authorization). An invalid Bearer must
+    // NOT 401 — that's the requireGatewayAuth path, not used here.
     process.env.RISKMODELS_API_SERVICE_KEY = "secret";
+    vi.mocked(resolveFundById).mockResolvedValue({ fund: FUND, latest: LATEST });
     const res = await getFund(
       req("http://localhost/api/data/funds/BW-FUND-X", {
         headers: { authorization: "Bearer wrong" },
       }),
       { params: Promise.resolve({ bw_fund_id: "BW-FUND-X" }) },
     );
-    expect(res.status).toBe(401);
-    expect(vi.mocked(resolveFundById)).not.toHaveBeenCalled();
+    expect(res.status).toBe(200);
+    expect(vi.mocked(resolveFundById)).toHaveBeenCalledWith("BW-FUND-X");
   });
 });
 


### PR DESCRIPTION
## Summary

Two interlocking pre-existing CI failures on `main`, fixed together so neither blocks the other:

1. **`tests/funds-data-routes.test.ts`** — soft-auth test was written under an older strict-auth assumption (expected 401 from an invalid Bearer when service key set). Route uses `verifyGatewayAuth` (lib/gateway-auth.ts) — explicit soft auth since `73c62c6` (agent-ready surface): only the matching service key grants elevated role; other Bearers fall back to public read. Renamed test and asserted the documented contract (200 + DAL invoked).
2. **`sdk/scripts/run_bulk_dd_render.sh`** — Public safety audit trips on `grep -rIq "/Users/"`. Hardcoded `/Users/conradgann/...` paths in the example one-liner comment replaced with sibling-relative form (`../BWMACRO/.venv/bin/python`) matching the script's monorepo convention per `docs/SUBMODULES.md`. Comment was illustrative only — no executable code path changed.

Splits PR #42 chicken-and-egg: each pre-existing failure blocked the other's fix, so they're combined here.

## Test plan

- [x] `npx vitest run tests/funds-data-routes.test.ts` → 18/18 pass
- [x] `grep -rIq "/Users/" .` (excluding node_modules/.git/.github/.next) → no matches
- [ ] CI fully green on this PR
- [ ] After merge, rebase PR #42 (H.20) — should also go green

## Closes

- Closes #43 (split test fix; superseded here)
- Closes #44 (split path strip; superseded here)
- Unblocks #42 (H.20 telemetry dedupe)

## Heads-up for `feat/d8-13f-api`

`services/render-svc/RUNBOOK.md` (added in `a763d45`) line 67 has the same `/Users/conradgann` pattern. Will fail the same audit when that branch merges to main. 1-line tidy on that branch before its eventual PR — not in scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)