### PR TITLE
feat(chat): Phase 2A M2 — Anthropic Messages API tool loop alongside OpenAI

### DIFF
--- a/lib/chat/agent-runner.ts
+++ b/lib/chat/agent-runner.ts
@@ -54,12 +54,25 @@ export function modelSupportsParallelToolCalls(model: string): boolean {
 }
 
 /**
- * Run the tool-calling agent loop against OpenAI. Shared by
- * POST /api/chat (billed) and POST /api/landing/chat (keyless MAG7 demo).
+ * Run the tool-calling agent loop. Shared by POST /api/chat (billed) and
+ * POST /api/landing/chat (keyless MAG7 demo).
+ *
+ * Dispatches by `model` prefix:
+ *   - `claude-*`  → Anthropic Messages API runner (lib/chat/anthropic-agent.ts)
+ *   - otherwise    → OpenAI tool loop (this function below)
+ *
+ * Both runners implement the same RunChatAgentOptions / RunChatAgentResult
+ * contract and share `executeToolCalls()` for billing + idempotency, so dispatch
+ * is transparent to callers (route, landing demo, internal tools).
  */
 export async function runChatAgent(
   opts: RunChatAgentOptions,
 ): Promise<RunChatAgentResult> {
+  if (opts.model.startsWith("claude-")) {
+    const { runAnthropicChatAgent } = await import("@/lib/chat/anthropic-agent");
+    return runAnthropicChatAgent(opts);
+  }
+
   const {
     userMessages,
     model,

--- a/lib/chat/anthropic-agent.ts
+++ b/lib/chat/anthropic-agent.ts
@@ -1,0 +1,219 @@
+import Anthropic from "@anthropic-ai/sdk";
+import type {
+  ChatCompletionMessageToolCall,
+  ChatCompletionTool,
+} from "openai/resources/chat/completions";
+import { CHAT_TOOLS } from "@/lib/chat/tools";
+import { buildSystemPrompt } from "@/lib/chat/system-prompt";
+import { executeToolCalls } from "@/lib/chat/tool-executor";
+import {
+  AgentUpstreamError,
+  type RunChatAgentOptions,
+  type RunChatAgentResult,
+} from "@/lib/chat/agent-runner";
+
+const DEFAULT_MAX_TOKENS = 4096;
+
+/**
+ * Translate an OpenAI function-calling tool to the Anthropic tool_use shape.
+ * Both use JSON Schema for parameters — only the wrapper differs.
+ */
+function toAnthropicTool(t: ChatCompletionTool): Anthropic.Tool {
+  if (t.type !== "function") {
+    throw new AgentUpstreamError(`Unsupported tool type for Claude: ${t.type}`);
+  }
+  return {
+    name: t.function.name,
+    description: t.function.description ?? "",
+    input_schema: t.function.parameters as Anthropic.Tool.InputSchema,
+  };
+}
+
+/**
+ * Wrap an Anthropic `tool_use` block in the OpenAI ChatCompletionMessageToolCall
+ * shape so the existing `executeToolCalls()` path (billing, idempotency,
+ * preflight guard) runs unchanged.
+ *
+ * Anthropic delivers `input` as a parsed object; the OpenAI executor expects
+ * `arguments` as a JSON string. We re-serialize once here.
+ */
+function toolUseToFakeOpenAICall(
+  block: Anthropic.ToolUseBlock,
+): ChatCompletionMessageToolCall {
+  return {
+    id: block.id,
+    type: "function",
+    function: {
+      name: block.name,
+      arguments: JSON.stringify(block.input ?? {}),
+    },
+  };
+}
+
+/**
+ * Run the tool-calling agent loop against Anthropic (Claude). Implements the
+ * same RunChatAgentOptions / RunChatAgentResult contract as the OpenAI runner
+ * in lib/chat/agent-runner.ts so dispatch is transparent to callers.
+ *
+ * Prompt caching: `cache_control: {type: "ephemeral"}` on the system prompt
+ * caches the (frozen) tools + system together per the prefix-match rule
+ * (tools render before system; breakpoint on last system block covers both).
+ *
+ * Thinking: defaults to disabled for chat workloads — single-tool-call
+ * portfolio analysis doesn't benefit enough from adaptive thinking to justify
+ * the token cost in trial mode. Effort `medium` is the cost/quality sweet spot.
+ *
+ * Models: dispatch is based on `model.startsWith("claude-")`; callers pass any
+ * canonical alias from shared/models.md (e.g. claude-sonnet-4-6).
+ */
+export async function runAnthropicChatAgent(
+  opts: RunChatAgentOptions,
+): Promise<RunChatAgentResult> {
+  const {
+    userMessages,
+    model,
+    userId,
+    requestId,
+    maxToolRounds = 5,
+    maxCompletionTokens,
+    allowedToolNames,
+    execParallel = true,
+    skipBilling = false,
+    preFlightGuard,
+  } = opts;
+
+  if (!process.env.ANTHROPIC_API_KEY) {
+    throw new AgentUpstreamError("ANTHROPIC_API_KEY is not configured");
+  }
+  const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+
+  const selectedTools: ChatCompletionTool[] = allowedToolNames
+    ? CHAT_TOOLS.filter(
+        (t) =>
+          t.type === "function" && allowedToolNames.includes(t.function.name),
+      )
+    : CHAT_TOOLS;
+  const anthropicTools = selectedTools.map(toAnthropicTool);
+
+  const messages: Anthropic.MessageParam[] = userMessages.map((m) => ({
+    role: m.role,
+    content: m.content,
+  }));
+
+  const totalUsage = {
+    prompt_tokens: 0,
+    completion_tokens: 0,
+    total_tokens: 0,
+  };
+  const toolCallResults: RunChatAgentResult["toolCallResults"] = [];
+  let finalContent = "";
+  let finalModel = model;
+
+  for (let round = 0; round < maxToolRounds; round++) {
+    let response: Anthropic.Message;
+    try {
+      response = await client.messages.create({
+        model,
+        max_tokens: maxCompletionTokens ?? DEFAULT_MAX_TOKENS,
+        system: [
+          {
+            type: "text",
+            text: buildSystemPrompt(),
+            cache_control: { type: "ephemeral" },
+          },
+        ],
+        tools: anthropicTools,
+        messages,
+      });
+    } catch (e) {
+      if (e instanceof Anthropic.APIError) {
+        throw new AgentUpstreamError(
+          `Anthropic API error (${e.status}): ${e.message}`,
+        );
+      }
+      const msg = e instanceof Error ? e.message : "Anthropic request failed";
+      throw new AgentUpstreamError(msg);
+    }
+
+    finalModel = response.model;
+    totalUsage.prompt_tokens +=
+      response.usage.input_tokens +
+      (response.usage.cache_read_input_tokens ?? 0) +
+      (response.usage.cache_creation_input_tokens ?? 0);
+    totalUsage.completion_tokens += response.usage.output_tokens;
+    totalUsage.total_tokens =
+      totalUsage.prompt_tokens + totalUsage.completion_tokens;
+
+    if (response.stop_reason === "end_turn" || response.stop_reason === "stop_sequence") {
+      finalContent = response.content
+        .filter((b): b is Anthropic.TextBlock => b.type === "text")
+        .map((b) => b.text)
+        .join("\n");
+      break;
+    }
+
+    if (
+      response.stop_reason !== "tool_use" &&
+      response.stop_reason !== "pause_turn"
+    ) {
+      finalContent = response.content
+        .filter((b): b is Anthropic.TextBlock => b.type === "text")
+        .map((b) => b.text)
+        .join("\n");
+      break;
+    }
+
+    messages.push({ role: "assistant", content: response.content });
+
+    if (response.stop_reason === "pause_turn") {
+      continue;
+    }
+
+    const toolUseBlocks = response.content.filter(
+      (b): b is Anthropic.ToolUseBlock => b.type === "tool_use",
+    );
+    if (toolUseBlocks.length === 0) {
+      finalContent = response.content
+        .filter((b): b is Anthropic.TextBlock => b.type === "text")
+        .map((b) => b.text)
+        .join("\n");
+      break;
+    }
+
+    const fakeCalls = toolUseBlocks.map(toolUseToFakeOpenAICall);
+    const results = await executeToolCalls(fakeCalls, {
+      parallel: execParallel,
+      userId,
+      requestId,
+      skipBilling,
+      preFlightGuard,
+    });
+    for (const r of results) {
+      toolCallResults.push(r);
+    }
+
+    const toolResultBlocks: Anthropic.ToolResultBlockParam[] = toolUseBlocks.map(
+      (block, i) => {
+        const r = results[i];
+        const content =
+          typeof r?.result === "string"
+            ? r.result
+            : JSON.stringify(r?.result ?? { error: "No result" });
+        return {
+          type: "tool_result",
+          tool_use_id: block.id,
+          content,
+          is_error: r?.error != null,
+        };
+      },
+    );
+    messages.push({ role: "user", content: toolResultBlocks });
+  }
+
+  return {
+    finalContent,
+    model: finalModel,
+    usage: totalUsage,
+    toolCallResults,
+  };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "packages/*"
       ],
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.95.1",
         "@google-cloud/storage": "^7.19.0",
         "@mdx-js/loader": "^3.1.0",
         "@mdx-js/react": "^3.1.0",
@@ -90,6 +91,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.95.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.95.1.tgz",
+      "integrity": "sha512-OO9AF7hmAoU492c/mD7Q2cPqI2WNAj7rAPHlawgBeUgpwiboLRiDs+grsErGWeHHP9ZRWfzq2OVrODTt8aITVg==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2512,6 +2534,12 @@
       "engines": {
         "node": ">= 8.0.0"
       }
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
     },
     "node_modules/@supabase/auth-js": {
       "version": "2.99.2",
@@ -6540,6 +6568,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
+    },
     "node_modules/fast-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
@@ -8578,6 +8612,19 @@
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -12559,6 +12606,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -13309,6 +13366,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
     },
     "node_modules/ts-api-utils": {
       "version": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,9 @@
   "name": "riskmodels-api-portal",
   "version": "1.1.0",
   "private": true,
-  "workspaces": ["packages/*"],
+  "workspaces": [
+    "packages/*"
+  ],
   "description": "RiskModels API Developer Portal",
   "scripts": {
     "dev": "next dev",
@@ -35,15 +37,16 @@
     "postinstall": "npm run build:sdk && npm run build:web-sdk"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.95.1",
     "@google-cloud/storage": "^7.19.0",
     "@mdx-js/loader": "^3.1.0",
     "@mdx-js/react": "^3.1.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "@riskmodels/sdk": "workspace:*",
-    "@riskmodels/web": "workspace:*",
     "@next/mdx": "^15.1.0",
     "@react-email/components": "^1.0.12",
     "@react-email/render": "^1.0.4",
+    "@riskmodels/sdk": "workspace:*",
+    "@riskmodels/web": "workspace:*",
     "@supabase/ssr": "^0.9.0",
     "@supabase/supabase-js": "^2.99.2",
     "@tailwindcss/typography": "^0.5.19",


### PR DESCRIPTION
**Status:** Draft for early architecture review. No route changes; Claude is opt-in by passing `model: "claude-sonnet-4-6"` (the locked Phase 2A default).

## What this is

Phase 2A M2 of the [OAuth-gated Claude trial loop plan](https://github.com/BlueWaterCorp/BWMACRO/blob/main/docs/cursor_plans/net_phase2_oauth_claude_trial.md) — Anthropic Messages API tool loop built alongside the existing OpenAI runner, dispatched on model prefix.

```
runChatAgent(opts)
  └── if opts.model.startsWith("claude-") → runAnthropicChatAgent
      else                                  → existing OpenAI loop
```

Both runners implement the same `RunChatAgentOptions` / `RunChatAgentResult` contract and **share `lib/chat/tool-executor.ts` for billing + idempotency**. Tool execution stays a single source of truth across backends.

## Files

| File | Lines | Purpose |
|---|---|---|
| `lib/chat/anthropic-agent.ts` | +180 (new) | Anthropic tool-loop runner, mirrors `agent-runner.ts` shape |
| `lib/chat/agent-runner.ts` | +14 / -4 | Dispatch shim at the top of `runChatAgent()` |
| `package.json` / lock | dep | `@anthropic-ai/sdk@^0.95.1` |

## Key design choices

- **Tool translation:** OpenAI function-calling → Anthropic `tool_use`. Both use JSON Schema for parameters; only the wrapper differs. Anthropic `tool_use` blocks are wrapped in fake `ChatCompletionMessageToolCall` shape so the existing executor runs unchanged.
- **Prompt caching:** `cache_control: {type: "ephemeral"}` on the system prompt. Tools render before system; one breakpoint on the last system block caches tools + system together per the prefix-match rule.
- **Stop reasons:** `end_turn` / `stop_sequence` (terminate), `tool_use` (execute + continue), `pause_turn` (resume by re-sending — SDK contract), other (terminate with current text).
- **Usage mapping:** Anthropic's `{input_tokens, output_tokens, cache_*}` flattens to existing `{prompt_tokens, completion_tokens, total_tokens}`. Cache tokens fold into `prompt_tokens` for billing-middleware compatibility.
- **Errors:** Typed `Anthropic.APIError` caught and rewrapped as `AgentUpstreamError` so the route's existing 502 handling fires.
- **Thinking + effort:** Not set on this request. Chat workloads with a single tool call don't benefit enough from adaptive thinking to justify the token cost in trial mode. Effort follow-up once trial volume is meaningful.
- **Streaming:** V1 is non-streaming to match the OpenAI runner. Streaming via `client.messages.stream()` + `finalMessage()` is a drop-in follow-up.

## Out of scope (follow-ups)

- **Per-token Claude capability IDs** in `lib/agent/capabilities.ts`. Today the OpenAI rate curve is used for cost accounting on the Claude path. For Phase 2A trial this is acceptable — billing flows through the gateway-billing UUID, not a customer; trial caps are enforced separately at the `.net` edge.
- **`AGENT_BACKEND` Doppler flag** to swap the route's default. Today users opt in per-request via `model:`.
- **Unit tests** for the dispatcher + tool-translation. `lib/chat/` has no existing test fixtures to extend; adding alongside the next M3 work.

## Verification

- [x] `npx tsc --noEmit` → clean
- [x] `npx vitest run` → 221/221 passing (no regressions on OpenAI path)
- [ ] Manual smoke test against `claude-sonnet-4-6` — gated on `ANTHROPIC_API_KEY` live on Vercel preview (M0 deploy pending)

## Gates downstream

- M3 (`agent_context_projection` builder on `.net`)
- M4 (mount `chat-agent.tsx` in `/activation`)
- M6 (`POST /snapshot` as a Claude tool — partially covered: existing snapshot tool in `CHAT_TOOLS` is reachable from Claude the moment this lands; M6 polishes the schema for Anthropic-specific semantics)

## Backlog refs

- Phase 2A plan: [`BWMACRO/docs/cursor_plans/net_phase2_oauth_claude_trial.md`](https://github.com/BlueWaterCorp/BWMACRO/blob/main/docs/cursor_plans/net_phase2_oauth_claude_trial.md)
- Master backlog: `G.10` Phase 2A path (Option A — Messages API, sidesteps G.9 economics gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)