### PR TITLE
chore(deploy): allowlist ANTHROPIC_API_KEY for Doppler → Vercel sync

### DIFF
--- a/scripts/doppler-vercel-allowlist.txt
+++ b/scripts/doppler-vercel-allowlist.txt
@@ -29,3 +29,7 @@ UPSTASH_REDIS_REST_TOKEN
 
 # Plaintext rm_agent_* / rm_user_* key surfaced in https://riskmodels.app/llms.txt (MAG7 agent examples)
 LLMS_TXT_PUBLIC_AGENT_KEY
+
+# Anthropic Messages API key for the Phase 2A Claude tool loop (lib/chat/anthropic-agent.ts).
+# Server-only; never reaches the browser. Read by /api/chat when `model: "claude-*"`.
+ANTHROPIC_API_KEY


### PR DESCRIPTION
## Summary

- 4-line addition to `scripts/doppler-vercel-allowlist.txt` so the existing `doppler-sync-to-vercel.sh` picks up `ANTHROPIC_API_KEY` when run.
- Without this, the key sits in Doppler but never lands in Vercel's environment, and [PR #46](https://github.com/BlueWaterCorp/RiskModels_API/pull/46) (Anthropic tool loop) fails in deployed envs with `"ANTHROPIC_API_KEY is not configured"` — even though local dev works because dev reads Doppler directly.

## After merge, run the sync

```bash
DOPPLER_PROJECT=erm3 DOPPLER_CONFIG=prd VERCEL_ENVS=production \
  ./scripts/doppler-sync-to-vercel.sh
DOPPLER_PROJECT=erm3 DOPPLER_CONFIG=stg VERCEL_ENVS=preview \
  ./scripts/doppler-sync-to-vercel.sh
```

Then redeploy on Vercel for the new value to take effect (Vercel doesn't hot-reload env changes into existing deployments).

## Test plan

- [x] Allowlist text-only change; no code paths affected on this PR
- [ ] After merge, sync output should include a `🔐 ANTHROPIC_API_KEY → production (sensitive)` line and a matching one for `preview`
- [ ] Trigger a Vercel redeploy
- [ ] Hit `/api/chat` with `model: "claude-sonnet-4-6"` and confirm no `"ANTHROPIC_API_KEY is not configured"` error (gated on PR #46 being merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)