### PR TITLE
feat(chat): AGENT_BACKEND flag — flip the default chat model to Claude

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -9,7 +9,20 @@ import { addMetadataHeaders, buildMetadataBody } from "@/lib/dal/response-header
 
 export const dynamic = "force-dynamic";
 
-const DEFAULT_MODEL = "gpt-4o-mini";
+/**
+ * Default model when the request omits `model`. Flips with the AGENT_BACKEND
+ * env flag (Doppler): `claude` → `claude-sonnet-4-6`; anything else (incl.
+ * unset) → `gpt-4o-mini`, today's behavior. A request-supplied `model:`
+ * always wins over this default (see `const model = modelOpt?.trim() || ...`).
+ *
+ * Phase 2A note: the trial surface on `.net` /activation passes
+ * `model: "claude-sonnet-4-6"` explicitly, so it doesn't depend on this flag.
+ * Flip AGENT_BACKEND only when you want *all* default chat traffic on Claude.
+ */
+const DEFAULT_MODEL =
+  process.env.AGENT_BACKEND?.toLowerCase() === "claude"
+    ? "claude-sonnet-4-6"
+    : "gpt-4o-mini";
 const MAX_TOOL_ROUNDS = 5;
 
 function appendCostLineIfMissing(content: string, toolTotalUsd: number, toolCallCount: number): string {
@@ -46,11 +59,15 @@ export const POST = withBilling(
   async (request: NextRequest, context: BillingContext) => {
     const origin = request.headers.get("origin");
 
-    if (!process.env.OPENAI_API_KEY) {
+    // At least one backend must be configured. The runner picks per-request
+    // based on the resolved model (claude-* → Anthropic, else OpenAI), so we
+    // only hard-fail here if neither key is present.
+    if (!process.env.OPENAI_API_KEY && !process.env.ANTHROPIC_API_KEY) {
       return NextResponse.json(
         {
           error: "Service unavailable",
-          message: "AI chat is not configured (missing OPENAI_API_KEY)",
+          message:
+            "AI chat is not configured (need OPENAI_API_KEY or ANTHROPIC_API_KEY)",
         },
         { status: 503, headers: getCorsHeaders(origin) },
       );


### PR DESCRIPTION
## Summary

`DEFAULT_MODEL` in `app/api/chat/route.ts` now reads the `AGENT_BACKEND` env var (Doppler):
- `claude` → `claude-sonnet-4-6`
- anything else / unset → `gpt-4o-mini` (**today's behavior — this PR is a no-op until the flag is set**)

A request-supplied `model:` always wins over the default — so the Phase 2A trial surface on `.net` `/activation`, which passes `model: "claude-sonnet-4-6"` explicitly, doesn't depend on this flag. Flip `AGENT_BACKEND` only when you want *all* default chat traffic on Claude.

Also **relaxes the startup guard**: route previously 503'd if `OPENAI_API_KEY` was missing, full stop. Now it 503s only if *neither* `OPENAI_API_KEY` nor `ANTHROPIC_API_KEY` is present — the runner picks the backend per-request, so a Claude-only deployment is now valid.

## To activate

```
# Doppler erm3
doppler secrets set AGENT_BACKEND=claude --project erm3 --config prd
# add AGENT_BACKEND to scripts/doppler-vercel-allowlist.txt, then:
DOPPLER_PROJECT=erm3 DOPPLER_CONFIG=prd VERCEL_ENVS=production ./scripts/doppler-sync-to-vercel.sh
# redeploy riskmodels-api
```

Not added to the allowlist in this PR — the flag is a no-op until set, and pre-adding it would imply a decision that hasn't been made.

## Test plan

- [x] `npx tsc --noEmit` → clean
- [x] `npx vitest run` → 221/221 passing (no regressions)
- [ ] After setting `AGENT_BACKEND=claude` + redeploy: a `/api/chat` request with no `model` field gets a Claude response; one with `model: "gpt-4o-mini"` still gets OpenAI

🤖 Generated with [Claude Code](https://claude.com/claude-code)