### PR TITLE
feat(sdk): contract_check rejects recommendation language in a Judgment (The Analyst M2b)

### DIFF
--- a/sdk/riskmodels/interpretation.py
+++ b/sdk/riskmodels/interpretation.py
@@ -201,6 +201,64 @@ def compute_features(data: Any) -> dict[str, Any]:
 
 
 # ---------------------------------------------------------------------------
+# Narrative boundary — no recommendation language in a Judgment
+#
+# The Analyst illuminates risk structure and reports model outputs (including
+# hedge ratios *as math*); it never recommends a specific trade / hedge /
+# rebalance, never assesses suitability, never reasons about the user's personal
+# circumstances. See THE_ANALYST.md §2 (BWMACRO). Same class of guard as the
+# no-mock-data rule: a Judgment whose deterministic narrative text trips this
+# fails CI (`contract_check`). The BWMACRO editorial engine imports the same
+# check so it can't ship recommendation-laden text either.
+# ---------------------------------------------------------------------------
+
+# Unambiguous recommendation framings. Low false-positive on purpose — we flag
+# *advice framing* ("you should …", "we recommend …", "consider buying …"), not
+# the bare words "buy"/"sell"/"hedge", which appear in legitimate descriptions
+# ("the L3 market hedge ratio is 0.62", "buyers and sellers").
+_RECOMMENDATION_MARKERS: tuple[str, ...] = (
+    "you should", "you shouldn't", "you ought to", "you need to", "you must ",
+    "you'll want to", "you will want to", "you might want to", "you may want to",
+    "you could trim", "you could buy", "you could sell", "you could hedge",
+    "you could rebalance", "you could add", "you could reduce",
+    "we recommend", "we'd recommend", "we would recommend", "i recommend",
+    "i'd recommend", "we suggest you", "we suggest that you", "i suggest you",
+    "we'd suggest", "i'd suggest", "we advise", "i advise",
+    "our recommendation", "our advice", "is recommended", "is advised",
+    "consider buying", "consider selling", "consider trimming",
+    "consider hedging", "consider rebalancing", "consider adding",
+    "consider reducing", "consider rotating",
+)
+
+
+def recommendation_language_violations(text: str | None) -> list[str]:
+    """Return the recommendation-framing markers found in ``text`` (case-insensitive).
+
+    Empty list ⇒ clean. See the section comment above for the boundary.
+    """
+    if not text:
+        return []
+    low = text.lower()
+    return [m for m in _RECOMMENDATION_MARKERS if m in low]
+
+
+def judgment_narrative_violations(judgment: Judgment) -> list[str]:
+    """Scan a Judgment's deterministic narrative text fields for recommendation
+    language. Returns ``["text.<field>: '<marker>'", ...]`` — empty when clean.
+
+    Only the free-text ``text`` dict is scanned; ``states``/``flags`` are
+    machine labels, not prose.
+    """
+    out: list[str] = []
+    for field_name, value in (judgment.text or {}).items():
+        if not isinstance(value, str):
+            continue
+        for marker in recommendation_language_violations(value):
+            out.append(f"text.{field_name}: {marker!r}")
+    return out
+
+
+# ---------------------------------------------------------------------------
 # Bland public stub — raw numerics, no editorial vocabulary
 # ---------------------------------------------------------------------------
 
@@ -298,4 +356,6 @@ __all__ = [
     "Judgment",
     "compute_features",
     "derive_default_judgment",
+    "recommendation_language_violations",
+    "judgment_narrative_violations",
 ]

--- a/sdk/riskmodels/snapshots/contract_check.py
+++ b/sdk/riskmodels/snapshots/contract_check.py
@@ -38,6 +38,7 @@ from . import (
 )
 from .canonical import CANONICAL_ONTOLOGY_VERSION, CANONICAL_SCHEMA_VERSION
 from .canonical_fund import CANONICAL_FUND_SCHEMA_VERSION, CanonicalFundSnapshot
+from ..interpretation import judgment_narrative_violations
 
 
 # AOM_SPEC v1 string vocabulary.
@@ -197,6 +198,13 @@ def check_one(p1_cache: Path, *, generated_utc: str) -> tuple[bool, list[str]]:
         elif reloaded.aom != snap_a.aom:
             failures.append("aom provenance drifted across JSON round-trip")
 
+    # 9. Editorial narrative — no recommendation language (THE_ANALYST §2).
+    #    Only fires when an editorial Judgment is attached; the pre-render batch
+    #    runs without one today, but a violating Judgment must never ship.
+    if snap_a.judgment is not None:
+        for v in judgment_narrative_violations(snap_a.judgment):
+            failures.append(f"judgment recommendation language: {v}")
+
     return len(failures) == 0, failures
 
 
@@ -327,6 +335,11 @@ def check_one_fund(f1_cache: Path, *, generated_utc: str) -> tuple[bool, list[st
         failures.append(
             f"len(holdings)={len(port.holdings)} > total_holdings_count={port.total_holdings_count}"
         )
+
+    # Editorial narrative — no recommendation language (THE_ANALYST §2).
+    if snap_a.judgment is not None:
+        for v in judgment_narrative_violations(snap_a.judgment):
+            failures.append(f"judgment recommendation language: {v}")
 
     return len(failures) == 0, failures
 

--- a/sdk/tests/test_interpretation.py
+++ b/sdk/tests/test_interpretation.py
@@ -23,6 +23,8 @@ from riskmodels.interpretation import (
     Judgment,
     compute_features,
     derive_default_judgment,
+    judgment_narrative_violations,
+    recommendation_language_violations,
 )
 from riskmodels.snapshots._stock_data import P1Data
 
@@ -303,3 +305,48 @@ def test_default_judgment_text_contains_numerics():
     j = derive_default_judgment(data)
     # Expect a percent figure somewhere in headline
     assert re.search(r"[+\-]?\d", j.text["headline"]), j.text["headline"]
+
+
+# ---------------------------------------------------------------------------
+# Narrative boundary — no recommendation language (THE_ANALYST §2)
+# ---------------------------------------------------------------------------
+
+def test_recommendation_language_violations_detects_advice_framing():
+    assert recommendation_language_violations("You should trim NVDA here.") == ["you should"]
+    assert "we recommend" in recommendation_language_violations(
+        "We recommend hedging the market leg."
+    )
+    assert "consider buying" in recommendation_language_violations(
+        "You could consider buying more semis."
+    )
+
+
+def test_recommendation_language_violations_clean_on_descriptions():
+    # Bare "buy"/"sell"/"hedge" in factual descriptions must NOT trip the guard.
+    assert recommendation_language_violations("The L3 market hedge ratio is 0.62.") == []
+    assert recommendation_language_violations(
+        "$0.62 of SPY per $1 of portfolio neutralizes the market leg."
+    ) == []
+    assert recommendation_language_violations("Heavy presence of momentum buyers.") == []
+    assert recommendation_language_violations("") == []
+    assert recommendation_language_violations(None) == []
+
+
+def test_judgment_narrative_violations_flags_recommendation_laden_judgment():
+    bad = Judgment(
+        ticker="NVDA",
+        as_of="2026-05-01",
+        text={
+            "headline": "NVDA — systematic 70%, residual +2.1%.",
+            "summary": "You should trim your NVDA position and rebalance toward defensives.",
+        },
+    )
+    viol = judgment_narrative_violations(bad)
+    assert viol, "expected the recommendation-laden summary to be flagged"
+    assert any("text.summary" in v for v in viol)
+
+
+def test_judgment_narrative_violations_clean_on_default_judgment():
+    data = _make_ddata(ticker="NVDA", res_er=0.4, rank_resid=72)
+    j = derive_default_judgment(data)
+    assert judgment_narrative_violations(j) == []


### PR DESCRIPTION
## Summary

The Analyst **P1 / M2 part b** — the NarrativeEvaluator core (plan: BWMACRO `docs/cursor_plans/the_analyst_p1.md` M2). *The Analyst illuminates risk structure and reports model outputs (including hedge ratios as math); it never recommends a specific trade / hedge / rebalance — THE_ANALYST §2.* Now enforced as a contract.

- **`sdk/riskmodels/interpretation.py`** — `recommendation_language_violations(text)` + `judgment_narrative_violations(judgment)`: scan a `Judgment`'s deterministic narrative text fields (`headline`, `summary`, `dna_insight`, …) for **advice framing** — `"you should …"`, `"we recommend …"`, `"consider buying / selling / trimming / hedging / rebalancing …"`, etc. **Low false-positive on purpose:** bare `buy`/`sell`/`hedge` in factual descriptions (*"the L3 market hedge ratio is 0.62"*, *"$0.62 of SPY per $1 of portfolio neutralizes the market leg"*) do **not** trip it — only recommendation *framing* does. Both are in `__all__` so the BWMACRO editorial engine imports the same check (it can't ship recommendation-laden text either).
- **`sdk/riskmodels/snapshots/contract_check.py`** — `check_one` and `check_one_fund`: when an editorial `Judgment` is attached to the snapshot, a violating one **fails the gate** — same class of guard as the no-mock-data rule. (The pre-render batch runs without an editorial Judgment today, so this is a no-op there for now; it future-proofs the batch and covers the PDF render path, which *does* attach a Judgment.)
- **Tests** (`sdk/tests/test_interpretation.py`) — advice-framing detection; clean-on-factual-descriptions; a recommendation-laden Judgment fails `judgment_narrative_violations`; `derive_default_judgment` output is clean. (19 pass in `test_interpretation.py`.)

This is the "load-bearing piece" of the evaluator registry (THE_ANALYST §6 — Ontology / Benchmark / Temporal / **Narrative** / Workflow); the full registry against the `riskmodels-portfolio-hedge-analyst` eval corpus is a P1/P2 follow-up.

## Test plan

- [x] `python -m pytest -p no:pytest_ethereum sdk/tests/test_interpretation.py -q` — 19 pass (4 new)
- [x] import smoke: `from riskmodels.snapshots.contract_check import check_one, check_one_fund` OK; `judgment_narrative_violations(Judgment(text={"headline":"You should sell NVDA."}))` → `["text.headline: 'you should'"]`
- [ ] CI: full `pytest` + the public-safety-audit gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)