### PR TITLE
fix(funds): get_data_for_f1 — realized variance decomposition, not the naive top-N residual

### DIFF
--- a/sdk/riskmodels/snapshots/_fund_data.py
+++ b/sdk/riskmodels/snapshots/_fund_data.py
@@ -17,6 +17,70 @@ from typing import Any
 
 
 # ---------------------------------------------------------------------------
+# Realized fund variance decomposition (matches the canonical /api/snapshot
+# "realized_strips" basis — RiskModels_API #52). Computed from the per-filing
+# portfolio layer return strips in ds_portfolio.zarr; no "residuals are mutually
+# uncorrelated" assumption — var(residual_strip) carries every cross-holding
+# residual covariance.
+# ---------------------------------------------------------------------------
+
+# ds_portfolio.zarr is sparse (one strip per filing, ≈ quarterly), so this is a
+# floor on filing-aligned observations — ~12 ≈ three years.
+_MIN_REALIZED_FUND_OBS = 12
+
+
+def _realized_variance_shares(
+    layer_series: list[tuple[str, float, float, float, float]],
+) -> dict[str, float] | None:
+    """Fund variance decomposition from the layer return strips.
+
+    ``layer_series`` is ``[(teo, mkt, sec, sub, res), ...]`` — the per-filing
+    portfolio layer returns from ``ds_portfolio.zarr``, which sum to the
+    portfolio's gross return per period. Each layer's share of fund variance is
+    ``cov(strip_k, gross) / var(gross)``; since ``gross = mkt + sec + sub + res``
+    exactly, ``Σ_k cov(strip_k, gross) = cov(gross, gross) = var(gross)``, so the
+    four shares sum to exactly 1 before clamping. ``var(residual_strip)`` is the
+    *realized* portfolio residual variance — it already includes every
+    cross-holding residual covariance — so there is no uncorrelated-residuals
+    assumption anywhere.
+
+    A layer whose strip moved against the portfolio over the window (it hedged)
+    has negative covariance → negative share; for a clean shares-of-100% headline
+    those are clamped to 0 and the positives renormalized. Returns ``None`` when
+    there aren't enough observations or the fund variance is degenerate (caller
+    falls back to the naive top-N aggregation).
+    """
+    if len(layer_series) < _MIN_REALIZED_FUND_OBS:
+        return None
+    mkt = [float(t[1]) for t in layer_series]
+    sec = [float(t[2]) for t in layer_series]
+    sub = [float(t[3]) for t in layer_series]
+    res = [float(t[4]) for t in layer_series]
+    gross = [a + b + c + d for a, b, c, d in zip(mkt, sec, sub, res)]
+    n = len(gross)
+    g_mean = sum(gross) / n
+    g_var = sum((g - g_mean) ** 2 for g in gross) / n
+    if not (g_var > 1e-15):
+        return None
+
+    def _cov_with_gross(a: list[float]) -> float:
+        a_mean = sum(a) / n
+        return sum((a[i] - a_mean) * (gross[i] - g_mean) for i in range(n)) / n
+
+    raw = {
+        "market": _cov_with_gross(mkt) / g_var,
+        "sector": _cov_with_gross(sec) / g_var,
+        "subsector": _cov_with_gross(sub) / g_var,
+        "residual": _cov_with_gross(res) / g_var,
+    }
+    clamped = {k: max(0.0, v) for k, v in raw.items()}
+    total = sum(clamped.values())
+    if not (total > 1e-12):
+        return None
+    return {k: v / total for k, v in clamped.items()}
+
+
+# ---------------------------------------------------------------------------
 # FundData — the dataclass every F1/C1 renderer reads
 # ---------------------------------------------------------------------------
 
@@ -1016,34 +1080,66 @@ def get_data_for_f1(
         pass
 
     # ── Portfolio variance shares ───────────────────────────────────────
-    # Preferred path: read the diversification-credited shares written
-    # to ds_portfolio.zarr attrs by Funds_DAG `aggregate_fund_portfolio`
-    # (strict CFR-ortho — see Funds_DAG/docs/PORTFOLIO_DIVERSIFICATION_FIX_PLAN.md).
-    #
-    # Fallback path (legacy): sum per-holding L3 ER × weight across the
-    # top-N holdings only. This top-N naive aggregation systematically
-    # over-states idio variance for diversified funds because it skips
-    # the LLN cancellation that diversified residuals provide. Kept as
-    # a fallback for older zarrs that haven't been re-materialized yet.
+    # Headline `portfolio_metrics`, in order of preference (`_basis` records it):
+    #   1. "realized_strips" — cov(strip_k, gross)/var(gross) over the per-filing
+    #      portfolio layer returns in ds_portfolio.zarr. Fully empirical: the
+    #      residual share is the realized portfolio residual variance, so it
+    #      already carries every cross-holding residual covariance — no "residuals
+    #      are mutually uncorrelated" assumption. Matches the canonical
+    #      /api/snapshot "realized_strips" basis (RiskModels_API #52). See
+    #      Funds_DAG/docs/PORTFOLIO_DIVERSIFICATION_FIX_PLAN.md.
+    #   2. "adjusted_attrs" — ds_portfolio.zarr `adjusted_*` attrs, if a Funds_DAG
+    #      asset ever precomputes them (dormant — none does today).
+    #   3. "naive_top_n" — sum per-holding L3 ER × weight over the top-N holdings.
+    #      Over-states idio variance for diversified funds (skips the LLN
+    #      cancellation diversified residuals provide). Last resort.
+    # `portfolio_metrics_naive` always carries the naive number for the F1
+    # side-by-side comparison, even when `portfolio_metrics` is realized.
     pm: dict[str, Any] | None = None
     pm_naive: dict[str, Any] | None = None
     pm_recent: dict[str, Any] | None = None
 
-    if adj_variance_shares:
+    realized = _realized_variance_shares(layer_series)
+    if realized is not None:
+        pm = {
+            "l1_market_er":    realized["market"],
+            "l2_sector_er":    realized["sector"],
+            "l3_subsector_er": realized["subsector"],
+            "l3_residual_er":  realized["residual"],
+            "_basis":          "realized_strips",
+        }
+        # "Recent" window = trailing slice of the same realized series, when
+        # there's a meaningful distinction (strictly more than the floor).
+        if len(layer_series) > _MIN_REALIZED_FUND_OBS:
+            realized_recent = _realized_variance_shares(
+                layer_series[-_MIN_REALIZED_FUND_OBS:]
+            )
+            if realized_recent is not None:
+                pm_recent = {
+                    "l1_market_er":    realized_recent["market"],
+                    "l2_sector_er":    realized_recent["sector"],
+                    "l3_subsector_er": realized_recent["subsector"],
+                    "l3_residual_er":  realized_recent["residual"],
+                    "_basis":          "realized_strips_recent",
+                }
+
+    if pm is None and adj_variance_shares:
         pm = {
             "l1_market_er":    adj_variance_shares["market"],
             "l2_sector_er":    adj_variance_shares["sector"],
             "l3_subsector_er": adj_variance_shares["subsector"],
             "l3_residual_er":  adj_variance_shares["residual"],
             "total_vol_ann":   adj_variance_shares.get("total_vol_ann", 0.0),
+            "_basis":          "adjusted_attrs",
         }
-    if adj_variance_shares_recent:
+    if pm_recent is None and adj_variance_shares_recent:
         pm_recent = {
             "l1_market_er":    adj_variance_shares_recent["market"],
             "l2_sector_er":    adj_variance_shares_recent["sector"],
             "l3_subsector_er": adj_variance_shares_recent["subsector"],
             "l3_residual_er":  adj_variance_shares_recent["residual"],
             "total_vol_ann":   adj_variance_shares_recent.get("total_vol_ann", 0.0),
+            "_basis":          "adjusted_attrs_recent",
         }
 
     if holdings_list:
@@ -1061,8 +1157,8 @@ def get_data_for_f1(
                 "l3_subsector_er": agg["subsector"] / total,
                 "l3_residual_er":  agg["residual"]  / total,
             }
-        if pm is None:
-            pm = pm_naive
+        if pm is None and pm_naive is not None:
+            pm = {**pm_naive, "_basis": "naive_top_n"}
 
     return FundData(
         bw_fund_id=bw_fund_id,

--- a/sdk/tests/test_realized_fund_variance_shares.py
+++ b/sdk/tests/test_realized_fund_variance_shares.py
@@ -1,0 +1,82 @@
+"""Unit tests for the realized fund variance decomposition helper.
+
+Mirrors RiskModels_API's TS `realizedVarianceShares` (canonical /api/snapshot):
+shares from cov(strip_k, gross)/var(gross), summing to 1; None below the obs
+floor or on degenerate variance; the residual share reflects realized
+cross-holding correlation, not a count formula; negative (hedging) layers are
+clamped to 0 and the positives renormalized.
+"""
+
+import random
+
+import pytest
+
+from riskmodels.snapshots._fund_data import (
+    _MIN_REALIZED_FUND_OBS,
+    _realized_variance_shares,
+)
+
+
+def _series(rows):
+    """rows = list of (mkt, sec, sub, res); teo is just a label."""
+    return [(f"2020-{i:02d}-01", m, s, u, r) for i, (m, s, u, r) in enumerate(rows, start=1)]
+
+
+def test_returns_none_below_observation_floor():
+    rows = [(0.01 * i, 0.0, 0.0, 0.0) for i in range(_MIN_REALIZED_FUND_OBS - 1)]
+    assert _realized_variance_shares(_series(rows)) is None
+
+
+def test_returns_none_for_degenerate_variance():
+    # gross = mkt + ... = constant ⇒ var(gross) ≈ 0
+    rows = [(0.01, 0.0, 0.0, 0.0) for _ in range(40)]
+    assert _realized_variance_shares(_series(rows)) is None
+
+
+def test_shares_sum_to_one_and_largest_amplitude_dominates():
+    rng = random.Random(1)
+    rows = []
+    for _ in range(60):
+        m = (rng.random() - 0.5) * 0.04          # widest
+        s = (rng.random() - 0.5) * 0.02
+        u = (rng.random() - 0.5) * 0.012
+        r = (rng.random() - 0.5) * 0.016
+        rows.append((m, s, u, r))
+    out = _realized_variance_shares(_series(rows))
+    assert out is not None
+    assert sum(out.values()) == pytest.approx(1.0, abs=1e-9)
+    for v in out.values():
+        assert 0.0 <= v <= 1.0
+    assert out["market"] > out["sector"]
+    assert out["market"] > out["subsector"]
+    assert out["market"] > out["residual"]
+
+
+def test_residual_share_reflects_realized_cross_holding_correlation():
+    # Two perfectly-correlated residual paths in the fund ⇒ residual variance
+    # does NOT diversify away; a count formula (~1/N of single-name) would put
+    # it far smaller. Here residual carries the bulk of the variance.
+    rng = random.Random(7)
+    rows = []
+    for _ in range(80):
+        m = (rng.random() - 0.5) * 0.01          # small market component
+        r = (rng.random() - 0.5) * 0.05          # large common residual path
+        rows.append((m, 0.0, 0.0, r))
+    out = _realized_variance_shares(_series(rows))
+    assert out is not None
+    assert out["residual"] > 0.6
+    assert out["sector"] == 0.0
+    assert out["subsector"] == 0.0
+
+
+def test_negative_hedging_layer_clamped_and_renormalized():
+    rng = random.Random(11)
+    rows = []
+    for _ in range(50):
+        m = (rng.random() - 0.5) * 0.03
+        r = -0.6 * m                              # residual strip moves against the rest
+        rows.append((m, 0.0, 0.0, r))
+    out = _realized_variance_shares(_series(rows))
+    assert out is not None
+    assert out["residual"] == 0.0
+    assert sum(out.values()) == pytest.approx(1.0, abs=1e-9)


### PR DESCRIPTION
## Summary

`get_data_for_f1` returned the fund's variance decomposition (market / sector / subsector / residual shares) as the **naive position-weighted sum** of the top-N holdings' per-stock L3 ER — which treats a 300-holding diversified fund as one weighted-average position and badly **over-states the residual** (idiosyncratic returns are largely uncorrelated, so a portfolio's idiosyncratic *variance* is far below the position-weighted sum of idiosyncratic ER). AGTHX was the obvious casualty.

The earlier "preferred path" read `adjusted_l1_market_er` / … attrs that a Funds_DAG `aggregate_fund_portfolio` asset was supposed to write to `ds_portfolio.zarr` — but that asset, and the `PORTFOLIO_DIVERSIFICATION_FIX_PLAN.md` it referenced, were never written, so every fund fell through to the naive number.

**This computes the decomposition from the realized portfolio layer return strips `ds_portfolio.zarr` already stores** (`portfolio_market_return` / `portfolio_sector_return` / `portfolio_subsector_return` / `portfolio_idiosyncratic_return`, one strip per filing):

```
share_layer = cov(strip_layer, gross) / var(gross)        gross = Σ_layers strip_layer
```

The four shares sum to exactly 1 before clamping (`Σ cov(strip, gross) = cov(gross, gross) = var(gross)`). `var(portfolio_idiosyncratic_return)` is the **realized** portfolio residual variance — it already carries every cross-holding residual covariance — so there is **no "residuals are mutually uncorrelated" assumption** anywhere. A layer whose strip moved against the portfolio (it hedged the book) → negative covariance → clamped to 0 and the positives renormalized. Same method and `_basis` name (`realized_strips`) as the canonical `/api/snapshot` (#52).

Priority order on `FundData.portfolio_metrics` (`_basis` records which): `realized_strips` → `adjusted_*` zarr attrs (still read if ever precomputed — dormant) → `naive_top_n` (last resort, below a ~12-strip floor or degenerate var). `portfolio_metrics_naive` always carries the naive figure for the F1 side-by-side; `portfolio_metrics_recent` gets a trailing-window realized decomposition when there are more than the floor.

`_realized_variance_shares` is exported + unit-tested (`sdk/tests/test_realized_fund_variance_shares.py`): shares sum to 1; None below the obs floor / on degenerate var; residual share tracks realized cross-holding correlation rather than a count formula; negative-layer clamp+renormalize. No Funds_DAG asset change — the strips already exist (doc: Funds_DAG `docs/PORTFOLIO_DIVERSIFICATION_FIX_PLAN.md`, separate PR — Cerebellum-Archive/Funds_DAG).

## Test plan

- [x] `tests/test_realized_fund_variance_shares.py`, `tests/test_canonical_fund_snapshot.py`, `tests/test_canonical_fund_snapshot_contract.py` — green
- [ ] Spot-check: `get_data_for_f1("BW-FUND-...AGTHX...")` → `portfolio_metrics["_basis"] == "realized_strips"`, residual share is single-digit-% (not the old inflated value), `portfolio_metrics_naive` carries the old number
- [ ] F1 tearsheet renders the new headline + the naive comparison

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### Relationship to `Funds_DAG/docs/PORTFOLIO_DIVERSIFICATION_FIX_PLAN.md`

That doc (status "scoping") specs a **producer-side** fix: a new `funds_dag/compute/portfolio_variance.py` computes `β²·σ²` layer variances + `w'Σ_residual w` for the idio layer (empirical residual covariance from the ERM3 returns zarr), writes `adjusted_l1_market_er` / … / `diversification_credit_idio` as new columns on `ds_portfolio.zarr`, then backfills the ~87 active funds and pushes to GCS — so every consumer (F1, this API, MCP, future C1) reads correct numbers.

This PR is the **on-read** implementation for `get_data_for_f1`: it's methodologically consistent (the residual quantity `var(portfolio_idiosyncratic_return)` over the strip *is* `w'Σ_residual w`), it makes the F1 reader correct **now** without the producer-side asset + backfill + GCS sync, and it still prefers the doc's `adjusted_*` zarr columns if they're ever present (priority #2). It does **not** replace the doc — the producer-side columns are still wanted for the non-F1 consumers — but it unblocks the F1 tearsheet and matches what the canonical `/api/snapshot` already does (#52).

