### PR TITLE
feat(chat): forbid fabricated portfolio composition + Aha-first response shape (The Analyst TA.NMD.1 + TA.M7.3)

### DIFF
--- a/lib/chat/system-prompt.ts
+++ b/lib/chat/system-prompt.ts
@@ -2,11 +2,19 @@ import { getChatToolReminderLines } from "@/lib/chat/tools";
 
 /**
  * System prompt for agentic chat — ERM3 semantics aligned with BWMACRO
- * portfolio-hedge-analyst skill. Encodes the contracted non-advisor boundary
- * (THE_ANALYST.md §2 in BWMACRO): illuminate risk structure + report model
- * outputs (incl. hedge ratios as math); never recommend a trade/hedge/rebalance
- * as an action, never assess suitability, never reason about the user's
- * personal circumstances, never execute.
+ * portfolio-hedge-analyst skill. Encodes three contracted rules from
+ * THE_ANALYST.md (BWMACRO):
+ *   §2  the non-advisor boundary — illuminate risk structure + report model
+ *       outputs (incl. hedge ratios as math); never recommend a trade/hedge/
+ *       rebalance as an action, never assess suitability, never reason about
+ *       the user's personal circumstances, never execute.
+ *   TA.NMD.1  no fabricated portfolio composition — no invented or
+ *             approximated holdings/weights for any fund/ETF/filer; decline +
+ *             redirect to user-supplied holdings (the surface has no
+ *             holdings-feed tool today).
+ *   TA.M7.3   Aha first, evidence second — lead with one sentence; detailed
+ *             per-row tables go inside a collapsible `<details>` block (or at
+ *             the end under "Details"), never at the top.
  */
 export function buildSystemPrompt(date?: string): string {
   const today = date ?? new Date().toISOString().slice(0, 10);
@@ -27,6 +35,32 @@ You **illuminate** how a portfolio behaves — what bets it is making, how large
 - Risk exposure is a portfolio feature, not a flaw. Concentrated sector bets, high market exposure, and large idiosyncratic exposure may be exactly what the investor intends. Illuminate; don't alarm.
 - If the user asks **"what should I do?" / "should I hedge?" / "is this too risky?"**, reframe to what you *can* answer — what each hedge leg would mechanically neutralize, what's driving the residual, the decomposition — and say plainly that RiskModels is an analytical tool, not an investment adviser, and nothing you say is a recommendation to buy, sell, or hold any security.
 
+## What you must NOT fabricate
+
+You have **no tool that returns a fund's, ETF's, or filer's holdings**. If a question requires knowing what a portfolio *contains* and the user has not given you the holdings:
+
+- **Decline honestly.** Say plainly: *"I don't have a live holdings feed for [fund/ETF/filer]."* Do **not** produce a holdings table. Do **not** list "approximate weights from recent filings." Do **not** say things like "Apple is around 10%, Microsoft 9%, …". **Even labeled-as-approximate fabrication is forbidden** — it's the same class of leak as inventing risk numbers, and it's the exact failure mode this product was built against.
+- **Offer the alternative the user can act on:** they can paste the tickers they care about (or run a snapshot on a portfolio) and you'll analyze the risk structure of *that*.
+- The same rule applies to "a typical large-cap growth fund" / "a generic 60/40 portfolio" / any synthetic stand-in — don't invent compositions. Ask the user to specify, or use only real, tool-fetched data. If you have a real tool that returns holdings, use it and report what it returns; otherwise, don't.
+
+This is a hard rule, not a style preference. Approximating a portfolio's composition from memory and labeling it "approximate" is still fabrication.
+
+## Response shape — Aha first, then evidence
+
+Lead with **one sentence** that answers the user's question — the "Aha", a single observation a PM would care about. Then a brief paragraph of context (2–4 lines). Put detailed per-row data — per-position L3 hedge-ratio tables, peer-rank dumps, multi-name comparisons — inside a collapsible block at the bottom:
+
+\`\`\`
+<details><summary>Per-position L3 hedge ratios</summary>
+
+| ticker | mkt HR | sec HR | sub HR | res ER |
+| --- | --- | --- | --- | --- |
+| NVDA | … | … | … | … |
+
+</details>
+\`\`\`
+
+If the surface doesn't render `<details>`, put the table at the very end under a "**Details**" heading — never at the top. **Default to restraint** — an institutional PM wants the one-liner first and the option to drill in second. Do **not** open the response with a multi-bullet "Key Observations" list, and do **not** lead with a wall-of-table. If the answer is one number, state it inline; if eight positions need comparing, lead with the conclusion of the comparison and collapse the rows.
+
 ## ERM3 concepts
 
 - **Hedge ratios (HR)**: model output — dollars of ETF that mechanically neutralize $1 of a given leg of stock risk (dollar ratio). L3 uses market + sector + subsector ETF legs. Reporting an HR is reporting the math, not recommending a trade.
@@ -42,6 +76,8 @@ ${toolLines}
 ## Rules
 
 - **Stay on the analysis side of the boundary above.** No trade/hedge/rebalance recommendations as actions; no suitability assessment; no personal-circumstance reasoning. Reframe "what should I do?" to what you can answer, and name the not-an-investment-adviser disclaimer when a user seems to be seeking advice.
+- **Never fabricate portfolio composition** — see "What you must NOT fabricate" above. No invented or approximated holdings/weights for any fund/ETF/filer; decline + redirect.
+- **Lead with the Aha, not the table** — see "Response shape" above. Per-position rows / full HR tables go inside a collapsible `<details>` block (or at the end under a "Details" heading); never at the top.
 - Always call tools before stating specific metrics, hedge ratios, or correlations for a ticker or portfolio. Never invent figures.
 - If the user gives a **company name** or ambiguous symbol, call search_tickers first, then fetch metrics.
 - If a **tool fails**, quote the error and suggestion from the tool result; do not guess numbers. Tell the user how to fix (e.g. try another ticker, top up balance).

--- a/lib/chat/system-prompt.ts
+++ b/lib/chat/system-prompt.ts
@@ -59,7 +59,7 @@ Lead with **one sentence** that answers the user's question — the "Aha", a sin
 </details>
 \`\`\`
 
-If the surface doesn't render `<details>`, put the table at the very end under a "**Details**" heading — never at the top. **Default to restraint** — an institutional PM wants the one-liner first and the option to drill in second. Do **not** open the response with a multi-bullet "Key Observations" list, and do **not** lead with a wall-of-table. If the answer is one number, state it inline; if eight positions need comparing, lead with the conclusion of the comparison and collapse the rows.
+If the surface doesn't render \`<details>\`, put the table at the very end under a "**Details**" heading — never at the top. **Default to restraint** — an institutional PM wants the one-liner first and the option to drill in second. Do **not** open the response with a multi-bullet "Key Observations" list, and do **not** lead with a wall-of-table. If the answer is one number, state it inline; if eight positions need comparing, lead with the conclusion of the comparison and collapse the rows.
 
 ## ERM3 concepts
 
@@ -77,7 +77,7 @@ ${toolLines}
 
 - **Stay on the analysis side of the boundary above.** No trade/hedge/rebalance recommendations as actions; no suitability assessment; no personal-circumstance reasoning. Reframe "what should I do?" to what you can answer, and name the not-an-investment-adviser disclaimer when a user seems to be seeking advice.
 - **Never fabricate portfolio composition** — see "What you must NOT fabricate" above. No invented or approximated holdings/weights for any fund/ETF/filer; decline + redirect.
-- **Lead with the Aha, not the table** — see "Response shape" above. Per-position rows / full HR tables go inside a collapsible `<details>` block (or at the end under a "Details" heading); never at the top.
+- **Lead with the Aha, not the table** — see "Response shape" above. Per-position rows / full HR tables go inside a collapsible \`<details>\` block (or at the end under a "Details" heading); never at the top.
 - Always call tools before stating specific metrics, hedge ratios, or correlations for a ticker or portfolio. Never invent figures.
 - If the user gives a **company name** or ambiguous symbol, call search_tickers first, then fetch metrics.
 - If a **tool fails**, quote the error and suggestion from the tool result; do not guess numbers. Tell the user how to fix (e.g. try another ticker, top up balance).

--- a/tests/system-prompt.test.ts
+++ b/tests/system-prompt.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { buildSystemPrompt } from "@/lib/chat/system-prompt";
+
+describe("buildSystemPrompt — contracted boundaries", () => {
+  const prompt = buildSystemPrompt("2026-05-12");
+
+  it("encodes the non-advisor boundary (THE_ANALYST §2)", () => {
+    expect(prompt).toMatch(/analyst, not an investment advisor/i);
+    expect(prompt).toMatch(/never recommend a specific trade, hedge, or rebalance/i);
+    expect(prompt).toMatch(/never assess.*suitable/i);
+    expect(prompt).toMatch(/not an investment adviser/i);
+  });
+
+  it("encodes the no-fabricated-portfolio rule (TA.NMD.1)", () => {
+    // Header + the unambiguous decline-and-redirect instruction.
+    expect(prompt).toMatch(/What you must NOT fabricate/);
+    expect(prompt).toMatch(/no tool that returns a fund's, ETF's, or filer's holdings/i);
+    expect(prompt).toMatch(/Even labeled-as-approximate fabrication is forbidden/i);
+    expect(prompt).toMatch(/Never fabricate portfolio composition/i);
+  });
+
+  it("encodes the Aha-first response shape (TA.M7.3)", () => {
+    expect(prompt).toMatch(/Response shape.*Aha first/);
+    expect(prompt).toMatch(/<details><summary>/);
+    expect(prompt).toMatch(/Lead with the Aha, not the table/);
+  });
+
+  it("frames hedge ratios as math, never as advice", () => {
+    expect(prompt).toMatch(/\$0\.62 of SPY per \$1 of portfolio neutralizes the market leg/);
+  });
+});


### PR DESCRIPTION
## Summary

Two new contracted rules in `lib/chat/system-prompt.ts` — the demo-readiness fixes the CEO flagged from a saved `/workspace` session (MASTER_BACKLOG "The Analyst — `.net` product surface" section, TA.NMD.1 + TA.M7.3).

### TA.NMD.1 — No fabricated portfolio composition

CEO asked the chat for FCNTX (Fidelity Contrafund) "major holdings" and got back a ~10-name table with weights labeled *"approximate based on recent public filings — not live fund data"*. The surface has **no holdings-feed tool today** — so those weights were invented from training data. **Labeled-as-approximate fabrication is the same class of leak as inventing risk numbers** — exactly the failure mode this product was built against (no-mock-data rule, `.cursor/skills/no-mock-data/SKILL.md`).

Prompt now adds a **"What you must NOT fabricate"** section: *"I don't have a live holdings feed for [fund/ETF/filer]"* → decline + offer to analyze tickers the user supplies as a portfolio. Same rule covers synthetic stand-ins (*"a typical large-cap growth fund"*, *"a generic 60/40 portfolio"*). Reinforced in `## Rules`.

### TA.M7.3 — Aha first, evidence second

Chat was leading with **wall-of-table** — per-position rows, full L3 HR tables, multi-bullet "Key Observations" — before any headline. An institutional PM wants the one-liner first and the option to drill in second.

Prompt now adds a **"Response shape — Aha first, then evidence"** section: lead with one sentence (the Aha), then a brief paragraph of context, then detailed per-row data inside a collapsible `<details><summary>...</summary>...</details>` block (or, if the surface doesn't render `<details>`, at the very end under a "**Details**" heading) — **never at the top**. Reinforced in `## Rules`.

### Where the contracted rules now live (post-merge)

| Source | Rule | Encoded as |
|---|---|---|
| THE_ANALYST §2 | non-advisor boundary | "## You are an analyst, not an investment advisor" (shipped #49) |
| TA.NMD.1 | no fabricated portfolio composition | **"## What you must NOT fabricate"** *(new)* |
| TA.M7.3 | Aha-first, no walls-of-tables | **"## Response shape — Aha first, then evidence"** *(new)* |

### Tests

`tests/system-prompt.test.ts` (new, vitest) — four assertions that each contracted rule survives in the rendered prompt (the non-advisor boundary, the no-fabrication rule, the Aha-first shape, and the HR-as-math framing — `$0.62 of SPY per $1 of portfolio neutralizes the market leg`). Catches an accidental removal in any future prompt edit.

### Not in this PR

- TA.M7.1 (chat latency — sequential per-ticker tool calls). A separate prompt+orchestration change (batch `get_risk_metrics`, parallelize independent tool calls).
- TA.M7.2 / TA.M7.4 — UI polish in the deck (the Portfolio-results placeholder; cost/telemetry hidden behind a debug flag) — likely partly handled by the G.11 ProcessDeck already; verify.
- Done in a **git worktree** off `origin/main` (`RiskModels_API_wt`) — the active checkout was on a follow-on `feat/surface-portfolios-api` branch and is left untouched.

## Test plan

- [x] `grep` sanity — every pattern the test expects is in the rendered prompt (worktree had no `node_modules` so vitest skipped locally; test asserts each rule by regex)
- [ ] CI: vitest (`npm test`) + lint/typecheck/build + the public-safety/licensed-identifier/secret-detection gates
- [ ] Manual: ask the chat *"what does FCNTX hold?"* → it should decline + offer to analyze tickers, **no holdings table even with an "approximate" caveat**. Ask *"what's driving NVDA's risk?"* → it should lead with the Aha, not a full L3 table; the table (if present) goes inside a `<details>` block at the end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)