### PR TITLE
feat(snapshot): wire benchmark= resolution into /api/snapshot (L.8-v2 #2)

### DIFF
--- a/OPENAPI_SPEC.yaml
+++ b/OPENAPI_SPEC.yaml
@@ -703,6 +703,14 @@ components:
         Canonical JSON portfolio snapshot: L3 variance decomposition, frozen-weight daily
         attribution (gross and factor strips), cumulative return and drawdown, and risk summary.
         Response also includes `_metadata` and `_agent` (see other metered POST routes).
+
+
+        When the request supplies a `benchmark` (alias like `SPY` or `70/30`, or a `BW-BENCH-*`
+        id), both `snapshot.benchmark_context_id` and `metadata.benchmark_context_id` carry the
+        resolved `BenchmarkContext` id — the same id consumers can fetch from
+        `/api/data/benchmark/{id}` for methodology / components / `benchmark_kind`. The raw
+        `benchmark` string still echoes back unchanged; unresolved values produce a `null`
+        `benchmark_context_id` (and the raw string is preserved for back-compat).
       required: [snapshot, time_behavior, attribution, risk_summary, metadata]
       properties:
         snapshot:

--- a/lib/portfolio/canonical-snapshot.ts
+++ b/lib/portfolio/canonical-snapshot.ts
@@ -3,6 +3,7 @@
  * Reuses runPortfolioRiskComputation + V3 Zarr history (fetchBatchHistory); no duplicated risk math.
  */
 
+import { resolveBenchmarkId } from "@/lib/dal/funds-zarr-reader";
 import { getRiskMetadata } from "@/lib/dal/risk-metadata";
 import {
   fetchBatchHistory,
@@ -43,6 +44,13 @@ export type CanonicalSnapshotResponse = {
     lookback_trading_days: number;
     mode: "frozen";
     benchmark: string | null;
+    /**
+     * Resolved `BenchmarkContext` id (e.g. `BW-BENCH-SPY`) when `benchmark` is
+     * a known alias or `BW-BENCH-*` id; `null` if `benchmark` is null or
+     * unresolvable. Lets consumers chase the resolved id back to its
+     * definition via `/api/data/benchmark/{id}` (L.8-v2 #2).
+     */
+    benchmark_context_id: string | null;
     /** Populated only when the request was `type: "ticker"`. */
     ticker_meta?: {
       ticker: string;
@@ -138,6 +146,8 @@ export type CanonicalSnapshotResponse = {
     lookback_days: number;
     mode: string;
     benchmark: string | null;
+    /** Mirror of `snapshot.benchmark_context_id` (additive — L.8-v2 #2). */
+    benchmark_context_id: string | null;
   };
 };
 
@@ -405,6 +415,9 @@ export async function buildCanonicalPortfolioSnapshot(input: {
   { ok: true; body: CanonicalSnapshotResponse } | { ok: false; error: string; status: number; details?: unknown }
 > {
   const { positions, lookbackDays, mode, benchmark } = input;
+  // L.8-v2 #2: resolve once via the catalog mirror; null when benchmark is null
+  // or the alias / id is unknown. Raw string still echoes back unchanged.
+  const benchmark_context_id = benchmark ? resolveBenchmarkId(benchmark) : null;
   const years = yearsForLookback(lookbackDays);
 
   const core = await runPortfolioRiskComputation(positions, {
@@ -637,6 +650,7 @@ export async function buildCanonicalPortfolioSnapshot(input: {
       lookback_trading_days: teoS.length,
       mode,
       benchmark: benchmark,
+      benchmark_context_id,
       positions: perPositions,
       variance_decomposition: {
         market: decomp.market,
@@ -679,6 +693,7 @@ export async function buildCanonicalPortfolioSnapshot(input: {
       lookback_days: lookbackDays,
       mode,
       benchmark: benchmark,
+      benchmark_context_id,
     },
   };
 

--- a/mcp/data/capabilities.json
+++ b/mcp/data/capabilities.json
@@ -667,7 +667,7 @@
   {
     "id": "portfolio-risk-snapshot",
     "name": "Snapshot — portfolio or ticker",
-    "description": "Canonical JSON snapshot (POST /api/snapshot) for either a weighted portfolio (type=portfolio) or a single ticker (type=ticker — shim over /metrics + /decompose). Returns L3 decomposition, hedge ratios, frozen-weight return attribution, cumulative return / drawdown, and risk summary in one unified shape. Also serves the bundled PDF/JSON via POST /api/portfolio/risk-snapshot. Bundled charge; internal DAL only.",
+    "description": "Canonical JSON snapshot (POST /api/snapshot) for either a weighted portfolio (type=portfolio) or a single ticker (type=ticker — shim over /metrics + /decompose). Returns L3 decomposition, hedge ratios, frozen-weight return attribution, cumulative return / drawdown, and risk summary in one unified shape. When the request includes `benchmark` (alias like 'SPY' / '70/30' or a BW-BENCH-* id), the response also carries `snapshot.benchmark_context_id` + `metadata.benchmark_context_id` — the resolved `BenchmarkContext` id (or null when unknown), chaseable via `/api/data/benchmark/{id}`. Also serves the bundled PDF/JSON via POST /api/portfolio/risk-snapshot. Bundled charge; internal DAL only.",
     "endpoint": "/api/portfolio/risk-snapshot",
     "method": "POST",
     "parameters": {

--- a/mcp/data/openapi.json
+++ b/mcp/data/openapi.json
@@ -714,7 +714,7 @@
       },
       "CanonicalSnapshotResponse": {
         "type": "object",
-        "description": "Canonical JSON portfolio snapshot: L3 variance decomposition, frozen-weight daily attribution (gross and factor strips), cumulative return and drawdown, and risk summary. Response also includes `_metadata` and `_agent` (see other metered POST routes).\n",
+        "description": "Canonical JSON portfolio snapshot: L3 variance decomposition, frozen-weight daily attribution (gross and factor strips), cumulative return and drawdown, and risk summary. Response also includes `_metadata` and `_agent` (see other metered POST routes).\n\nWhen the request supplies a `benchmark` (alias like `SPY` or `70/30`, or a `BW-BENCH-*` id), both `snapshot.benchmark_context_id` and `metadata.benchmark_context_id` carry the resolved `BenchmarkContext` id — the same id consumers can fetch from `/api/data/benchmark/{id}` for methodology / components / `benchmark_kind`. The raw `benchmark` string still echoes back unchanged; unresolved values produce a `null` `benchmark_context_id` (and the raw string is preserved for back-compat).\n",
         "required": [
           "snapshot",
           "time_behavior",

--- a/tests/canonical-snapshot.test.ts
+++ b/tests/canonical-snapshot.test.ts
@@ -215,4 +215,77 @@ describe("buildCanonicalPortfolioSnapshot", () => {
     expect(r.body.time_behavior.teo.length).toBe(3);
     expect(r.body.attribution.gross.length).toBe(3);
   });
+
+  // L.8-v2 #2 — benchmark resolution via the catalog mirror.
+  describe("benchmark_context_id (L.8-v2 #2)", () => {
+    it("null benchmark → benchmark_context_id is null on snapshot + metadata", async () => {
+      const r = await buildCanonicalPortfolioSnapshot({
+        positions: [{ ticker: "MSFT", weight: 1 }],
+        lookbackDays: 5,
+        mode: "frozen",
+        benchmark: null,
+      });
+      expect(r.ok).toBe(true);
+      if (!r.ok) return;
+      expect(r.body.snapshot.benchmark).toBeNull();
+      expect(r.body.snapshot.benchmark_context_id).toBeNull();
+      expect(r.body.metadata.benchmark).toBeNull();
+      expect(r.body.metadata.benchmark_context_id).toBeNull();
+    });
+
+    it("alias 'SPY' resolves to BW-BENCH-SPY; raw string still echoed", async () => {
+      const r = await buildCanonicalPortfolioSnapshot({
+        positions: [{ ticker: "MSFT", weight: 1 }],
+        lookbackDays: 5,
+        mode: "frozen",
+        benchmark: "SPY",
+      });
+      expect(r.ok).toBe(true);
+      if (!r.ok) return;
+      expect(r.body.snapshot.benchmark).toBe("SPY");
+      expect(r.body.snapshot.benchmark_context_id).toBe("BW-BENCH-SPY");
+      expect(r.body.metadata.benchmark).toBe("SPY");
+      expect(r.body.metadata.benchmark_context_id).toBe("BW-BENCH-SPY");
+    });
+
+    it("alias '70/30' resolves to BW-BENCH-EQ70-30 (blend kind)", async () => {
+      const r = await buildCanonicalPortfolioSnapshot({
+        positions: [{ ticker: "MSFT", weight: 1 }],
+        lookbackDays: 5,
+        mode: "frozen",
+        benchmark: "70/30",
+      });
+      expect(r.ok).toBe(true);
+      if (!r.ok) return;
+      expect(r.body.snapshot.benchmark).toBe("70/30");
+      expect(r.body.snapshot.benchmark_context_id).toBe("BW-BENCH-EQ70-30");
+    });
+
+    it("bw-bench id passthrough is uppercased + preserved as benchmark_context_id", async () => {
+      const r = await buildCanonicalPortfolioSnapshot({
+        positions: [{ ticker: "MSFT", weight: 1 }],
+        lookbackDays: 5,
+        mode: "frozen",
+        benchmark: "BW-BENCH-EQ70-30",
+      });
+      expect(r.ok).toBe(true);
+      if (!r.ok) return;
+      expect(r.body.snapshot.benchmark).toBe("BW-BENCH-EQ70-30");
+      expect(r.body.snapshot.benchmark_context_id).toBe("BW-BENCH-EQ70-30");
+    });
+
+    it("unknown alias → benchmark_context_id null, raw string preserved (back-compat)", async () => {
+      const r = await buildCanonicalPortfolioSnapshot({
+        positions: [{ ticker: "MSFT", weight: 1 }],
+        lookbackDays: 5,
+        mode: "frozen",
+        benchmark: "totally-unknown",
+      });
+      expect(r.ok).toBe(true);
+      if (!r.ok) return;
+      expect(r.body.snapshot.benchmark).toBe("totally-unknown");
+      expect(r.body.snapshot.benchmark_context_id).toBeNull();
+      expect(r.body.metadata.benchmark_context_id).toBeNull();
+    });
+  });
 });


### PR DESCRIPTION
## Closes "benchmark is first-class everywhere"

Before #57 (catalog mirror), `/api/snapshot` accepted `benchmark` as an opaque echoed-back string. Now that `resolveBenchmarkId` reads the committed `mcp/data/benchmark_master.json` catalog, the snapshot can attach the resolved `BenchmarkContext` id alongside the raw string — consumers can chase it through `/api/data/benchmark/{id}` for methodology, components, and `benchmark_kind`.

**Wire-side additive only — back-compat preserved.** The raw `benchmark` string still echoes back unchanged on both `snapshot.benchmark` and `metadata.benchmark`; the new `benchmark_context_id` is `null` when `benchmark` is `null` or the alias / id is unknown.

## Changes

| File | Why |
|---|---|
| `lib/portfolio/canonical-snapshot.ts` | Import `resolveBenchmarkId` from `@/lib/dal/funds-zarr-reader`; resolve once at the top of `buildCanonicalPortfolioSnapshot`; attach `benchmark_context_id` to `snapshot` + `metadata`. `buildCanonicalTickerSnapshot` delegates → inherits the field automatically. |
| `tests/canonical-snapshot.test.ts` | 5 new tests under `describe("benchmark_context_id (L.8-v2 #2)")`: null → null on both surfaces; `'SPY'` → `BW-BENCH-SPY`; `'70/30'` → `BW-BENCH-EQ70-30`; `BW-BENCH-*` passthrough; unknown alias → `null` with raw preserved. |
| `OPENAPI_SPEC.yaml` | Extend `CanonicalSnapshotResponse` description (additive; `snapshot` / `metadata` already `additionalProperties: true` so the new field structurally validates without further schema edits). |
| `mcp/data/openapi.json` | Regenerated mirror via `npm run build:openapi`. |
| `mcp/data/capabilities.json` | Extend `portfolio-risk-snapshot` description with the benchmark_context_id behaviour. |

## Wire shape

```jsonc
// POST /api/snapshot  { type: "portfolio", portfolio: [...], benchmark: "SPY" }
{
  "snapshot": {
    "as_of": "...",
    "benchmark": "SPY",                          // unchanged
    "benchmark_context_id": "BW-BENCH-SPY",      // new — chase via /api/data/benchmark/BW-BENCH-SPY
    "positions": [ ... ],
    ...
  },
  "metadata": {
    "benchmark": "SPY",
    "benchmark_context_id": "BW-BENCH-SPY",      // new (mirrors snapshot.*)
    ...
  }
}
```

Unknown alias → both `benchmark` echoed raw, `benchmark_context_id: null`. `null` benchmark → both `null`.

## Verification

- ✅ `npx vitest run` — 257 / 257 tests green
- ✅ `npx tsc --noEmit` — clean
- ✅ `bash scripts/check-licensed-identifiers.sh` — no new exposures
- ✅ `node -e "JSON.parse(...)"` on both `openapi.json` mirrors — parse clean

## L.8-v2 ledger

Closes **#2** in [`BWMACRO/docs/cursor_plans/benchmark_v2_followups.md`](../../BWMACRO/docs/cursor_plans/benchmark_v2_followups.md) — the doc gets a ✅ marker in a follow-up commit once this lands. **BenchmarkFit sub-block** (originally noted as an optional addition in #2) deferred — that's #3 in the v2 ledger ("factor-based tracking error in BenchmarkFit") and is a meaningfully bigger slice, kept separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)