### PR TITLE
feat(13f): filer F1 dossier — composer + bulk renderer + CDN rewrite (D.8.34)

### DIFF
--- a/OPENAPI_SPEC.yaml
+++ b/OPENAPI_SPEC.yaml
@@ -7363,7 +7363,7 @@ paths:
         style attribution + ERM3 coverage diagnostics + modelability flag.
         NAV is intentionally absent (`_metadata.nav_applicable: false`) —
         filers have no NAV time series.
-        Adds `erm3_decomposition` from filer `ds_returns.zarr` (monthly L3 rows,
+        Adds `erm3_decomposition` from filer `ds_returns_monthly.zarr` (monthly L3 rows,
         variance share attrs, latest-month waterfall) when present (D.8.22).
         Holdings may include latest daily L3 ER shares per `bw_sym_id` from
         `security_history_latest`. `hedge_sleeve` is populated when filer

--- a/OPENAPI_SPEC.yaml
+++ b/OPENAPI_SPEC.yaml
@@ -7362,8 +7362,12 @@ paths:
         (filer_type and aum_tier partitions) + portfolio-derived 9-box
         style attribution + ERM3 coverage diagnostics + modelability flag.
         NAV is intentionally absent (`_metadata.nav_applicable: false`) —
-        filers have no NAV time series. Hedge ratios are Phase 3 (D.8.10)
-        and absent today.
+        filers have no NAV time series.
+        Adds `erm3_decomposition` from filer `ds_returns.zarr` (monthly L3 rows,
+        variance share attrs, latest-month waterfall) when present (D.8.22).
+        Holdings may include latest daily L3 ER shares per `bw_sym_id` from
+        `security_history_latest`. `hedge_sleeve` is populated when filer
+        `ds_hr.zarr` exists (D.8.10 Phase 3); otherwise null.
       operationId: getFilerSnapshot
       tags:
         - 13F Filers

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,6 +6,7 @@ import '@/styles/globals.css';
 import Navbar from '@/components/Navbar';
 import Footer from '@/components/Footer';
 import { ChatBubble } from '@/components/chat/ChatBubble';
+import { GoogleAdsTag } from '@/components/GoogleAdsTag';
 
 const inter = Inter({ subsets: ['latin'] });
 
@@ -91,6 +92,7 @@ export default async function RootLayout({
           <Footer />
         </div>
         <ChatBubble />
+        <GoogleAdsTag />
       </body>
     </html>
   );

--- a/components/GoogleAdsTag.tsx
+++ b/components/GoogleAdsTag.tsx
@@ -1,0 +1,23 @@
+import Script from 'next/script';
+
+/** Google Ads tag (gtag.js) for riskmodels.app — conversion / remarketing base tag */
+const GOOGLE_ADS_GTAG_ID = 'AW-18161098219';
+
+export function GoogleAdsTag() {
+  return (
+    <>
+      <Script
+        src={`https://www.googletagmanager.com/gtag/js?id=${GOOGLE_ADS_GTAG_ID}`}
+        strategy="afterInteractive"
+      />
+      <Script id="google-ads-gtag-init" strategy="afterInteractive">
+        {`
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);}
+          gtag('js', new Date());
+          gtag('config', '${GOOGLE_ADS_GTAG_ID}');
+        `}
+      </Script>
+    </>
+  );
+}

--- a/lib/13f/enrich-filer-holdings.ts
+++ b/lib/13f/enrich-filer-holdings.ts
@@ -1,0 +1,31 @@
+/**
+ * Enrich filer holdings from zarr with latest L3 ER + optional ticker labels
+ * via `security_history_latest` (same bw_sym_id key as fund V3 reads).
+ */
+
+import { fetchBatchLatestSummary } from "@/lib/dal/risk-engine-v3";
+import type { FilerHoldingsSnapshot } from "@/lib/dal/funds-zarr-reader";
+
+export async function enrichFilerHoldingsWithL3(
+  snap: FilerHoldingsSnapshot | null,
+): Promise<FilerHoldingsSnapshot | null> {
+  if (!snap?.holdings.length) return snap;
+
+  const ids = [...new Set(snap.holdings.map((h) => h.security_id).filter(Boolean))];
+  const batch = await fetchBatchLatestSummary(ids, "daily");
+
+  const holdings = snap.holdings.map((h) => {
+    const row = batch.get(h.security_id);
+    const m = row?.metrics;
+    if (!m) return { ...h };
+    return {
+      ...h,
+      l3_market_er: m.l3_mkt_er ?? null,
+      l3_sector_er: m.l3_sec_er ?? null,
+      l3_subsector_er: m.l3_sub_er ?? null,
+      l3_residual_er: m.l3_res_er ?? null,
+    };
+  });
+
+  return { ...snap, holdings };
+}

--- a/lib/13f/filer-snapshot-composer.ts
+++ b/lib/13f/filer-snapshot-composer.ts
@@ -47,7 +47,7 @@ export interface FilerSnapshotPrimitives {
   holdings: FilerHoldingsSnapshot | null;
   portfolioHistory: FilerPortfolioRow[];
   cohortRanks: FilerRankingRow[];
-  /** Monthly L3 from ``ds_returns.zarr`` (D.8.22); null when missing. */
+  /** Monthly L3 from ``ds_returns_monthly.zarr`` (D.8.22); null when missing. */
   returnsDecomposition: FilerReturnsDecomposition | null;
   /** Latest hedge legs when ``ds_hr.zarr`` exists (Phase 3). */
   hedgeSleeve: FundHedgeSnapshot | null;
@@ -122,7 +122,7 @@ export interface FilerSnapshot {
   } | null;
   /**
    * ERM3 monthly portfolio decomposition + variance attrs + latest-month
-   * component returns (``ds_returns.zarr``). Null when the artifact is absent.
+   * component returns (``ds_returns_monthly.zarr``). Null when the artifact is absent.
    */
   erm3_decomposition: FilerSnapshotErm3Decomposition | null;
   /** Hedge ETF legs at latest teo when ``ds_hr.zarr`` is populated. */

--- a/lib/13f/filer-snapshot-composer.ts
+++ b/lib/13f/filer-snapshot-composer.ts
@@ -13,7 +13,7 @@
  *     D.8.3 kernel — the only 9-box signal on the filer side.
  *   - A `coverage` block always reports the in-ERM3 fraction so consumers
  *     never confuse a low-coverage filer with a non-modelable one.
- *   - Hedge is absent today — Phase 3 follow-on (D.8.10).
+ *   - Hedge sleeve from ``ds_hr.zarr`` when present (D.8.10 Phase 3).
  */
 
 import type {
@@ -24,6 +24,8 @@ import type {
 import type {
   FilerHoldingsSnapshot,
   FilerPortfolioRow,
+  FilerReturnsDecomposition,
+  FundHedgeSnapshot,
 } from "@/lib/dal/funds-zarr-reader";
 import {
   formatFilerMetrics,
@@ -32,12 +34,23 @@ import {
 
 const FILER_LOOKBACK_MONTHS = 12;
 
+export interface FilerSnapshotErm3Decomposition {
+  monthly_returns: FilerReturnsDecomposition["rows"];
+  variance_shares_full: FilerReturnsDecomposition["variance_shares_full"];
+  variance_shares_recent: FilerReturnsDecomposition["variance_shares_recent"];
+  waterfall_latest_month: FilerReturnsDecomposition["waterfall_latest_month"];
+}
+
 export interface FilerSnapshotPrimitives {
   filer: FilerRow;
   latest: FilerPortfolioLatestRow | null;
   holdings: FilerHoldingsSnapshot | null;
   portfolioHistory: FilerPortfolioRow[];
   cohortRanks: FilerRankingRow[];
+  /** Monthly L3 from ``ds_returns.zarr`` (D.8.22); null when missing. */
+  returnsDecomposition: FilerReturnsDecomposition | null;
+  /** Latest hedge legs when ``ds_hr.zarr`` exists (Phase 3). */
+  hedgeSleeve: FundHedgeSnapshot | null;
 }
 
 export interface FilerCohortRankEntry {
@@ -107,6 +120,13 @@ export interface FilerSnapshot {
     partition_axes: Array<"filer_type" | "aum_tier">;
     ranks: FilerCohortRankEntry[];
   } | null;
+  /**
+   * ERM3 monthly portfolio decomposition + variance attrs + latest-month
+   * component returns (``ds_returns.zarr``). Null when the artifact is absent.
+   */
+  erm3_decomposition: FilerSnapshotErm3Decomposition | null;
+  /** Hedge ETF legs at latest teo when ``ds_hr.zarr`` is populated. */
+  hedge_sleeve: FundHedgeSnapshot | null;
   _metadata: {
     model_version: string | null;
     factor_set_id: string | null;
@@ -120,7 +140,15 @@ export interface FilerSnapshot {
 export function composeFilerSnapshot(
   p: FilerSnapshotPrimitives,
 ): FilerSnapshot {
-  const { filer, latest, holdings, portfolioHistory, cohortRanks } = p;
+  const {
+    filer,
+    latest,
+    holdings,
+    portfolioHistory,
+    cohortRanks,
+    returnsDecomposition,
+    hedgeSleeve,
+  } = p;
 
   const trimmed = trimToLookbackMonths(portfolioHistory, FILER_LOOKBACK_MONTHS);
 
@@ -188,6 +216,16 @@ export function composeFilerSnapshot(
           ranks,
         }
       : null,
+    erm3_decomposition:
+      returnsDecomposition && returnsDecomposition.rows.length > 0
+        ? {
+            monthly_returns: returnsDecomposition.rows,
+            variance_shares_full: returnsDecomposition.variance_shares_full,
+            variance_shares_recent: returnsDecomposition.variance_shares_recent,
+            waterfall_latest_month: returnsDecomposition.waterfall_latest_month,
+          }
+        : null,
+    hedge_sleeve: hedgeSleeve ?? null,
     _metadata: {
       model_version: latest?.model_version ?? null,
       factor_set_id: latest?.factor_set_id ?? null,

--- a/lib/13f/filer-snapshot-loader.ts
+++ b/lib/13f/filer-snapshot-loader.ts
@@ -13,11 +13,14 @@ import {
 import {
   readFilerHoldingsTopN,
   readFilerPortfolioSeries,
+  readFilerReturnsDecomposition,
+  readFilerHedgeLatest,
 } from "@/lib/dal/funds-zarr-reader";
 import {
   composeFilerSnapshot,
   type FilerSnapshot,
 } from "@/lib/13f/filer-snapshot-composer";
+import { enrichFilerHoldingsWithL3 } from "@/lib/13f/enrich-filer-holdings";
 
 const HOLDINGS_TOP_N = 25;
 const FILER_LOOKBACK_MONTHS = 12;
@@ -56,14 +59,22 @@ export async function loadFilerSnapshot(
     startDate = startWindow.toISOString().slice(0, 10);
   }
 
-  const [holdings, portfolioHistory, cohortRanks] = await Promise.all([
-    readFilerHoldingsTopN(bwFilerId, HOLDINGS_TOP_N),
-    readFilerPortfolioSeries(bwFilerId, {
-      startDate,
-      endDate: referenceDate ?? undefined,
-    }),
-    fetchFilerRanks(bwFilerId),
-  ]);
+  const [holdingsRaw, portfolioHistory, cohortRanks, returnsDec, hedgeSleeve] =
+    await Promise.all([
+      readFilerHoldingsTopN(bwFilerId, HOLDINGS_TOP_N),
+      readFilerPortfolioSeries(bwFilerId, {
+        startDate,
+        endDate: referenceDate ?? undefined,
+      }),
+      fetchFilerRanks(bwFilerId),
+      readFilerReturnsDecomposition(bwFilerId, {
+        startDate,
+        endDate: referenceDate ?? undefined,
+      }),
+      readFilerHedgeLatest(bwFilerId),
+    ]);
+
+  const holdings = await enrichFilerHoldingsWithL3(holdingsRaw);
 
   const snapshot = composeFilerSnapshot({
     filer,
@@ -71,6 +82,8 @@ export async function loadFilerSnapshot(
     holdings,
     portfolioHistory,
     cohortRanks,
+    returnsDecomposition: returnsDec,
+    hedgeSleeve,
   });
 
   return {

--- a/lib/dal/funds-zarr-reader.ts
+++ b/lib/dal/funds-zarr-reader.ts
@@ -13,8 +13,8 @@
  * Folder-as-entity-key convention (BWMACRO/docs/13f_pipeline_plan.md §2):
  * dataset names are universal (ds_ph, ds_portfolio); the path prefix
  * (`bw_fund_id/` vs `bw_filer_id/`) discriminates entity kind. ds_nav is
- * fund-only by design (no NAV time series for filers); ds_hr is fund-only
- * today and lands on the filer side in D.8 Phase 3.
+ * fund-only by design (no NAV time series for filers). ds_hr exists for filers
+ * when D.8.10 Phase 3 writes hedge sleeves (sparse — reader mirrors funds).
  *
  * Internal-only: never expose bucket names, gs:// URLs, or zarr paths in
  * thrown errors or API JSON.
@@ -950,6 +950,13 @@ export interface FilerHolding {
   adj_mv: number;
   /** Fraction of total in-portfolio AUM at this teo. Null when AUM is null/0. */
   weight: number | null;
+  /** Display ticker when enriched from Supabase `symbols` / registry (optional). */
+  ticker?: string | null;
+  /** Latest daily L3 explained-risk shares from `security_history_latest` (optional). */
+  l3_market_er?: number | null;
+  l3_sector_er?: number | null;
+  l3_subsector_er?: number | null;
+  l3_residual_er?: number | null;
 }
 
 export interface FilerHoldingsSnapshot {
@@ -1114,6 +1121,224 @@ export async function readFilerPortfolioSeries(
     rows.push(row as unknown as FilerPortfolioRow);
   }
   return rows;
+}
+
+const FILER_RETURNS_VARS = [
+  "portfolio_gross_return",
+  "portfolio_market_return",
+  "portfolio_sector_return",
+  "portfolio_subsector_return",
+  "portfolio_idiosyncratic_return",
+] as const;
+
+/** One monthly row from filer ``ds_returns.zarr`` (D.8.22). */
+export interface FilerMonthlyReturnRow {
+  teo: string;
+  portfolio_gross_return: number | null;
+  portfolio_market_return: number | null;
+  portfolio_sector_return: number | null;
+  portfolio_subsector_return: number | null;
+  portfolio_idiosyncratic_return: number | null;
+}
+
+export interface FilerVarianceSharesBlock {
+  market: number | null;
+  sector: number | null;
+  subsector: number | null;
+  residual: number | null;
+}
+
+export interface FilerReturnsDecomposition {
+  n_periods: number;
+  rows: FilerMonthlyReturnRow[];
+  variance_shares_full: FilerVarianceSharesBlock | null;
+  variance_shares_recent: FilerVarianceSharesBlock | null;
+  waterfall_latest_month: Partial<
+    Record<
+      | "portfolio_gross_return"
+      | "portfolio_market_return"
+      | "portfolio_sector_return"
+      | "portfolio_subsector_return"
+      | "portfolio_idiosyncratic_return",
+      number
+    >
+  > | null;
+}
+
+function filerVarianceSharesFromAttrs(attrs: Record<string, unknown>): {
+  full: FilerVarianceSharesBlock | null;
+  recent: FilerVarianceSharesBlock | null;
+} {
+  const num = (k: string): number | null => {
+    const v = attrs[k];
+    return typeof v === "number" && Number.isFinite(v) ? v : null;
+  };
+  const full: FilerVarianceSharesBlock = {
+    market: num("adjusted_l1_market_er"),
+    sector: num("adjusted_l2_sector_er"),
+    subsector: num("adjusted_l3_subsector_er"),
+    residual: num("adjusted_l3_residual_er"),
+  };
+  const recent: FilerVarianceSharesBlock = {
+    market: num("adjusted_recent_l1_market_er"),
+    sector: num("adjusted_recent_l2_sector_er"),
+    subsector: num("adjusted_recent_l3_subsector_er"),
+    residual: num("adjusted_recent_l3_residual_er"),
+  };
+  const hasAny = (v: FilerVarianceSharesBlock) =>
+    v.market != null || v.sector != null || v.subsector != null || v.residual != null;
+  return {
+    full: hasAny(full) ? full : null,
+    recent: hasAny(recent) ? recent : null,
+  };
+}
+
+function waterfallLatestFromSlices(
+  teos: string[],
+  slices: Record<(typeof FILER_RETURNS_VARS)[number], (number | null)[] | null>,
+): FilerReturnsDecomposition["waterfall_latest_month"] {
+  const n = teos.length;
+  if (n === 0) return null;
+  let idx: number | null = null;
+  for (let i = n - 1; i >= 0; i--) {
+    const g = slices.portfolio_gross_return?.[i];
+    if (g != null && Number.isFinite(g)) {
+      idx = i;
+      break;
+    }
+  }
+  if (idx == null) return null;
+  const keys = [
+    "portfolio_gross_return",
+    "portfolio_market_return",
+    "portfolio_sector_return",
+    "portfolio_subsector_return",
+    "portfolio_idiosyncratic_return",
+  ] as const;
+  const out: Partial<
+    Record<(typeof keys)[number], number>
+  > = {};
+  for (const k of keys) {
+    const v = slices[k]?.[idx];
+    if (v != null && Number.isFinite(v)) out[k] = v;
+  }
+  return Object.keys(out).length ? out : null;
+}
+
+/**
+ * Monthly L3 portfolio decomposition for a filer from ``ds_returns.zarr``.
+ * Null when zarr is missing or the date window is empty.
+ */
+export async function readFilerReturnsDecomposition(
+  bwFilerId: string,
+  options: FundPortfolioOptions = {},
+): Promise<FilerReturnsDecomposition | null> {
+  const grp = await openFilerZarrGroup(bwFilerId, "ds_returns.zarr");
+  if (!grp) return null;
+
+  const teos = await readTeoStrings(grp);
+  if (!teos || teos.length === 0) return null;
+
+  let t0 = 0;
+  let t1 = teos.length;
+  if (options.startDate) {
+    while (t0 < t1 && teos[t0]! < options.startDate) t0++;
+  }
+  if (options.endDate) {
+    while (t1 > t0 && teos[t1 - 1]! > options.endDate) t1--;
+  }
+  if (t0 >= t1) return null;
+
+  const series = await Promise.all(
+    FILER_RETURNS_VARS.map(async (varName) => ({
+      name: varName,
+      data: await readFloatSlice1d(grp, varName, t0, t1),
+    })),
+  );
+
+  const slices: Record<(typeof FILER_RETURNS_VARS)[number], (number | null)[] | null> = {
+    portfolio_gross_return: null,
+    portfolio_market_return: null,
+    portfolio_sector_return: null,
+    portfolio_subsector_return: null,
+    portfolio_idiosyncratic_return: null,
+  };
+  for (const s of series) {
+    if (s.name in slices) {
+      slices[s.name as keyof typeof slices] = s.data;
+    }
+  }
+
+  const trimmedTeos = teos.slice(t0, t1);
+  const rows: FilerMonthlyReturnRow[] = [];
+  for (let i = 0; i < t1 - t0; i++) {
+    rows.push({
+      teo: trimmedTeos[i]!,
+      portfolio_gross_return: slices.portfolio_gross_return?.[i] ?? null,
+      portfolio_market_return: slices.portfolio_market_return?.[i] ?? null,
+      portfolio_sector_return: slices.portfolio_sector_return?.[i] ?? null,
+      portfolio_subsector_return: slices.portfolio_subsector_return?.[i] ?? null,
+      portfolio_idiosyncratic_return: slices.portfolio_idiosyncratic_return?.[i] ?? null,
+    });
+  }
+
+  const attrs = (grp.attrs ?? {}) as Record<string, unknown>;
+  const { full, recent } = filerVarianceSharesFromAttrs(attrs);
+
+  return {
+    n_periods: rows.length,
+    rows,
+    variance_shares_full: full,
+    variance_shares_recent: recent,
+    waterfall_latest_month: waterfallLatestFromSlices(trimmedTeos, slices),
+  };
+}
+
+/**
+ * Latest hedge sleeve for a filer from ``ds_hr.zarr`` (same schema as funds).
+ */
+export async function readFilerHedgeLatest(
+  bwFilerId: string,
+): Promise<FundHedgeSnapshot | null> {
+  const grp = await openFilerZarrGroup(bwFilerId, "ds_hr.zarr");
+  if (!grp) return null;
+
+  const teos = await readTeoStrings(grp);
+  if (!teos || teos.length === 0) return null;
+
+  const symbols = await readSymbolStrings(grp);
+  if (!symbols || symbols.length === 0) return null;
+
+  const teoIdx = teos.length - 1;
+  const teo = teos[teoIdx]!;
+
+  const [l1, l2, l3] = await Promise.all([
+    readFloatRowAtTeo(grp, "L1_HR", teoIdx, symbols.length),
+    readFloatRowAtTeo(grp, "L2_HR", teoIdx, symbols.length),
+    readFloatRowAtTeo(grp, "L3_HR", teoIdx, symbols.length),
+  ]);
+
+  const symbolNames = symbols;
+  function pack(row: (number | null)[] | null): HedgeLeg[] {
+    if (!row) return [];
+    const legs: HedgeLeg[] = [];
+    for (let i = 0; i < row.length; i++) {
+      const v = row[i];
+      if (v != null) legs.push({ etf: symbolNames[i]!, hr: v });
+    }
+    return legs;
+  }
+
+  const out: FundHedgeSnapshot = {
+    teo,
+    L1: pack(l1),
+    L2: pack(l2),
+    L3: pack(l3),
+  };
+  if (out.L1.length === 0 && out.L2.length === 0 && out.L3.length === 0) {
+    return null;
+  }
+  return out;
 }
 
 // ===========================================================================

--- a/lib/dal/funds-zarr-reader.ts
+++ b/lib/dal/funds-zarr-reader.ts
@@ -1131,7 +1131,7 @@ const FILER_RETURNS_VARS = [
   "portfolio_idiosyncratic_return",
 ] as const;
 
-/** One monthly row from filer ``ds_returns.zarr`` (D.8.22). */
+/** One monthly row from filer ``ds_returns_monthly.zarr`` (D.8.22). */
 export interface FilerMonthlyReturnRow {
   teo: string;
   portfolio_gross_return: number | null;
@@ -1226,14 +1226,14 @@ function waterfallLatestFromSlices(
 }
 
 /**
- * Monthly L3 portfolio decomposition for a filer from ``ds_returns.zarr``.
+ * Monthly L3 portfolio decomposition for a filer from ``ds_returns_monthly.zarr``.
  * Null when zarr is missing or the date window is empty.
  */
 export async function readFilerReturnsDecomposition(
   bwFilerId: string,
   options: FundPortfolioOptions = {},
 ): Promise<FilerReturnsDecomposition | null> {
-  const grp = await openFilerZarrGroup(bwFilerId, "ds_returns.zarr");
+  const grp = await openFilerZarrGroup(bwFilerId, "ds_returns_monthly.zarr");
   if (!grp) return null;
 
   const teos = await readTeoStrings(grp);

--- a/mcp/data/openapi.json
+++ b/mcp/data/openapi.json
@@ -11238,7 +11238,7 @@
     "/13f/filers/{bw_filer_id}/snapshot": {
       "get": {
         "summary": "13F filer composed snapshot (JSON)",
-        "description": "Single-call composed snapshot for a 13F filer: registry + latest metrics + top-25 holdings + 12mo portfolio history + cohort ranks (filer_type and aum_tier partitions) + portfolio-derived 9-box style attribution + ERM3 coverage diagnostics + modelability flag. NAV is intentionally absent (`_metadata.nav_applicable: false`) — filers have no NAV time series. Adds `erm3_decomposition` from filer `ds_returns.zarr` (monthly L3 rows, variance share attrs, latest-month waterfall) when present (D.8.22). Holdings may include latest daily L3 ER shares per `bw_sym_id` from `security_history_latest`. `hedge_sleeve` is populated when filer `ds_hr.zarr` exists (D.8.10 Phase 3); otherwise null.\n",
+        "description": "Single-call composed snapshot for a 13F filer: registry + latest metrics + top-25 holdings + 12mo portfolio history + cohort ranks (filer_type and aum_tier partitions) + portfolio-derived 9-box style attribution + ERM3 coverage diagnostics + modelability flag. NAV is intentionally absent (`_metadata.nav_applicable: false`) — filers have no NAV time series. Adds `erm3_decomposition` from filer `ds_returns_monthly.zarr` (monthly L3 rows, variance share attrs, latest-month waterfall) when present (D.8.22). Holdings may include latest daily L3 ER shares per `bw_sym_id` from `security_history_latest`. `hedge_sleeve` is populated when filer `ds_hr.zarr` exists (D.8.10 Phase 3); otherwise null.\n",
         "operationId": "getFilerSnapshot",
         "tags": [
           "13F Filers"

--- a/mcp/data/openapi.json
+++ b/mcp/data/openapi.json
@@ -11238,7 +11238,7 @@
     "/13f/filers/{bw_filer_id}/snapshot": {
       "get": {
         "summary": "13F filer composed snapshot (JSON)",
-        "description": "Single-call composed snapshot for a 13F filer: registry + latest metrics + top-25 holdings + 12mo portfolio history + cohort ranks (filer_type and aum_tier partitions) + portfolio-derived 9-box style attribution + ERM3 coverage diagnostics + modelability flag. NAV is intentionally absent (`_metadata.nav_applicable: false`) — filers have no NAV time series. Hedge ratios are Phase 3 (D.8.10) and absent today.\n",
+        "description": "Single-call composed snapshot for a 13F filer: registry + latest metrics + top-25 holdings + 12mo portfolio history + cohort ranks (filer_type and aum_tier partitions) + portfolio-derived 9-box style attribution + ERM3 coverage diagnostics + modelability flag. NAV is intentionally absent (`_metadata.nav_applicable: false`) — filers have no NAV time series. Adds `erm3_decomposition` from filer `ds_returns.zarr` (monthly L3 rows, variance share attrs, latest-month waterfall) when present (D.8.22). Holdings may include latest daily L3 ER shares per `bw_sym_id` from `security_history_latest`. `hedge_sleeve` is populated when filer `ds_hr.zarr` exists (D.8.10 Phase 3); otherwise null.\n",
         "operationId": "getFilerSnapshot",
         "tags": [
           "13F Filers"

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -21,6 +21,15 @@ const nextConfig = {
       { source: '/docs', destination: '/docs/api', permanent: true },
     ];
   },
+  async rewrites() {
+    return [
+      {
+        source: '/snapshots/:file*',
+        destination:
+          'https://storage.googleapis.com/rm_api_public/snapshot/:file*',
+      },
+    ];
+  },
   images: {
     formats: ['image/avif', 'image/webp'],
   },

--- a/sdk/scripts/bulk_filer_f1_render.py
+++ b/sdk/scripts/bulk_filer_f1_render.py
@@ -1,0 +1,350 @@
+#!/usr/bin/env python3
+"""Bulk F1 institutional tearsheet PNGs for 13F filers (BWMACRO Matplotlib).
+
+Writes flat filenames for CDN probing (`riskmodels.app/snapshots/{bw_filer_id}_f1.png`):
+
+    {out_dir}/BW-FILER-CIK..._f1.png
+
+Prerequisites
+-------------
+- BWMACRO monorepo venv (imports ``bwmacro.snapshots.filers``).
+- ``FUNDS_DAG_ZARR_ROOT`` pointing at the directory that **contains**
+  ``bw_filer_id/`` (same convention as ``bwmacro.snapshots.filers._data``).
+
+PYTHONPATH must include ``sdk`` plus ``BWMACRO/src`` (see ``run_bulk_filer_f1.sh``).
+
+Examples
+--------
+    export FUNDS_DAG_ZARR_ROOT=/path/to/Funds_DAG/data/sec_data/zarr
+    PYTHONPATH=sdk:../BWMACRO/src ../BWMACRO/.venv/bin/python \\
+      sdk/scripts/bulk_filer_f1_render.py \\
+      --filers BW-FILER-CIK0001067983 BW-FILER-CIK0001336528 \\
+      --out-dir /tmp/filer_f1_out
+
+    # Discover every ``BW-FILER-*`` directory under the zarr root:
+    PYTHONPATH=sdk:../BWMACRO/src ../BWMACRO/.venv/bin/python \\
+      sdk/scripts/bulk_filer_f1_render.py --scan --upload-gcs
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import threading
+import time
+import traceback
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime, timezone
+from pathlib import Path
+
+_MATPLOTLIB_RENDER_LOCK = threading.Lock()
+_LOG_LOCK = threading.Lock()
+
+
+def _default_out_dir() -> Path:
+    if os.environ.get("BULK_SNAPSHOT_DIR"):
+        return Path(os.environ["BULK_SNAPSHOT_DIR"]).expanduser().resolve()
+    return Path("/Volumes/ext_2t/Filer_F1_Snapshots")
+
+
+def _default_filer_parent() -> Path:
+    raw = os.environ.get("FUNDS_DAG_ZARR_ROOT", "").strip()
+    if raw:
+        return Path(raw).expanduser().resolve()
+    # Developer fallback — mirrors BWMACRO `_data.py`
+    mac = Path("/Users/conradgann/BW_Code/Funds_DAG/data/sec_data/zarr")
+    if mac.is_dir():
+        return mac.resolve()
+    raise RuntimeError(
+        "Set FUNDS_DAG_ZARR_ROOT to the zarr directory that contains bw_filer_id/",
+    )
+
+
+def _filer_root(parent: Path) -> Path:
+    return parent / "bw_filer_id"
+
+
+def _discover_filers(root: Path) -> list[str]:
+    if not root.is_dir():
+        return []
+    out: list[str] = []
+    for p in sorted(root.iterdir()):
+        if p.is_dir() and p.name.startswith("BW-FILER-"):
+            out.append(p.name)
+    return out
+
+
+def _filers_from_registry(path: Path) -> list[str]:
+    data = json.loads(path.read_text())
+    rows = data if isinstance(data, list) else data.get("rows", [])
+    ids: list[str] = []
+    for row in rows:
+        if isinstance(row, dict):
+            fid = row.get("bw_filer_id")
+            if fid:
+                ids.append(str(fid))
+    return sorted(set(ids))
+
+
+def _rsync_out_dir_to_gcs(out_dir: Path, gcs_bucket: str) -> tuple[bool, str]:
+    cmd = [
+        "gcloud",
+        "storage",
+        "rsync",
+        "--recursive",
+        "--exclude",
+        r"^_bulk_.*\.(jsonl|json)$",
+        str(out_dir),
+        gcs_bucket,
+    ]
+    try:
+        proc = subprocess.run(cmd, check=True, capture_output=True, text=True)
+        return True, proc.stdout + proc.stderr
+    except subprocess.CalledProcessError as e:
+        return False, (e.stdout or "") + "\n" + (e.stderr or "")
+    except FileNotFoundError as e:
+        return False, f"gcloud not found: {e}"
+
+
+def _render_one(
+    bw_filer_id: str,
+    out_dir: Path,
+    funds_dag_zarr_parent: Path,
+    *,
+    upload_gcs: bool,
+    gcs_bucket: str,
+    resume: bool,
+    force: bool,
+    enrich_supabase: bool,
+) -> dict:
+    from bwmacro.snapshots.filers.f1_filer_tearsheet import render_f1_filer_for_id
+
+    t0 = time.perf_counter()
+    png = out_dir / f"{bw_filer_id}_f1.png"
+
+    if resume and not force and png.is_file():
+        return {
+            "bw_filer_id": bw_filer_id,
+            "status": "skipped_resume",
+            "duration_s": 0.0,
+            "png": str(png),
+        }
+
+    prev_root = os.environ.get("FUNDS_DAG_ZARR_ROOT")
+    os.environ["FUNDS_DAG_ZARR_ROOT"] = str(funds_dag_zarr_parent.resolve())
+
+    try:
+        with _MATPLOTLIB_RENDER_LOCK:
+            render_f1_filer_for_id(
+                bw_filer_id,
+                png,
+                fmt="png",
+                enrich_supabase=enrich_supabase,
+            )
+        uploaded = False
+        if upload_gcs:
+            dest = f"{gcs_bucket.rstrip('/')}/{png.name}"
+            try:
+                subprocess.run(
+                    ["gcloud", "storage", "cp", str(png), dest],
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                )
+                uploaded = True
+            except subprocess.CalledProcessError as e:
+                return {
+                    "bw_filer_id": bw_filer_id,
+                    "status": "uploaded_partial",
+                    "duration_s": round(time.perf_counter() - t0, 2),
+                    "png": str(png),
+                    "upload_error": e.stderr,
+                }
+        return {
+            "bw_filer_id": bw_filer_id,
+            "status": "ok",
+            "duration_s": round(time.perf_counter() - t0, 2),
+            "png": str(png),
+            "uploaded": uploaded,
+        }
+    except Exception as exc:
+        return {
+            "bw_filer_id": bw_filer_id,
+            "status": "error",
+            "duration_s": round(time.perf_counter() - t0, 2),
+            "error": str(exc),
+            "traceback": traceback.format_exc().splitlines()[-5:],
+        }
+    finally:
+        if prev_root is None:
+            os.environ.pop("FUNDS_DAG_ZARR_ROOT", None)
+        else:
+            os.environ["FUNDS_DAG_ZARR_ROOT"] = prev_root
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    ap.add_argument(
+        "--filer-zarr-parent",
+        type=Path,
+        default=None,
+        help="Directory containing bw_filer_id/ (default: FUNDS_DAG_ZARR_ROOT).",
+    )
+    ap.add_argument("--out-dir", type=Path, default=_default_out_dir())
+    ap.add_argument("--filers", nargs="*", help="Explicit bw_filer_id list.")
+    ap.add_argument("--filers-file", type=Path, help="Newline-delimited bw_filer_id.")
+    ap.add_argument(
+        "--registry-json",
+        type=Path,
+        default=None,
+        help="filers.json-style registry with bw_filer_id rows.",
+    )
+    ap.add_argument(
+        "--scan",
+        action="store_true",
+        help="Discover all BW-FILER-* dirs under bw_filer_id/.",
+    )
+    ap.add_argument("--upload-gcs", action="store_true")
+    ap.add_argument(
+        "--upload-mode",
+        choices=["none", "per-filer", "batch"],
+        default=None,
+    )
+    ap.add_argument("--gcs-bucket", default="gs://rm_api_public/snapshot")
+    ap.add_argument("--resume", action="store_true")
+    ap.add_argument("--force", action="store_true")
+    ap.add_argument(
+        "--no-supabase-enrich",
+        action="store_true",
+        help="Skip REST enrichment (faster bulk; stacked ER bars may be sparse).",
+    )
+    ap.add_argument("--workers", type=int, default=1)
+    ap.add_argument("--dry-run", action="store_true")
+    ap.add_argument("--limit", type=int, default=None)
+    args = ap.parse_args()
+
+    parent = (
+        Path(args.filer_zarr_parent).expanduser().resolve()
+        if args.filer_zarr_parent
+        else _default_filer_parent()
+    )
+    root = _filer_root(parent)
+
+    filers: list[str] = []
+    if args.filers:
+        filers.extend(args.filers)
+    if args.filers_file:
+        filers.extend(
+            ln.strip()
+            for ln in args.filers_file.read_text().splitlines()
+            if ln.strip()
+        )
+    if args.registry_json:
+        filers.extend(_filers_from_registry(args.registry_json))
+    if args.scan:
+        filers.extend(_discover_filers(root))
+
+    filers = sorted(set(filers))
+    if args.limit is not None:
+        filers = filers[: max(0, args.limit)]
+
+    upload_mode = args.upload_mode
+    if upload_mode is None:
+        upload_mode = "per-filer" if args.upload_gcs else "none"
+
+    per_upload = upload_mode == "per-filer"
+    enrich_supabase = not args.no_supabase_enrich
+
+    if args.dry_run:
+        print(f"funds_dag_zarr_parent: {parent}")
+        print(f"filer_root: {root}")
+        print(f"count: {len(filers)}")
+        print(f"first 15: {filers[:15]}")
+        return 0
+
+    if not root.is_dir():
+        print(f"FAIL: filer zarr root missing: {root}", file=sys.stderr)
+        return 2
+
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+    workers = max(1, int(args.workers or 1))
+
+    log_path = args.out_dir / "_bulk_run_log.jsonl"
+    summary_path = args.out_dir / "_bulk_summary.json"
+    counts: dict[str, int] = {"ok": 0, "skipped_resume": 0, "error": 0, "uploaded_partial": 0}
+
+    t_start = time.perf_counter()
+
+    def dispatch(i: int, fid: str, logf) -> None:
+        row = _render_one(
+            fid,
+            args.out_dir,
+            parent,
+            upload_gcs=per_upload,
+            gcs_bucket=args.gcs_bucket,
+            resume=args.resume,
+            force=args.force,
+            enrich_supabase=enrich_supabase,
+        )
+        row["i"] = i
+        row["ts"] = datetime.now(timezone.utc).isoformat()
+        with _LOG_LOCK:
+            counts[row["status"]] = counts.get(row["status"], 0) + 1
+            logf.write(json.dumps(row) + "\n")
+            logf.flush()
+            tag = {"ok": "ok", "skipped_resume": "skip", "error": "err", "uploaded_partial": "partial"}.get(
+                row["status"], "?"
+            )
+            print(f"  [{i:>4}/{len(filers)}] {tag} {fid}", flush=True)
+
+    with log_path.open("w") as logf:
+        if workers <= 1:
+            for i, fid in enumerate(filers, start=1):
+                dispatch(i, fid, logf)
+        else:
+            with ThreadPoolExecutor(max_workers=workers) as ex:
+                futs = [ex.submit(dispatch, i, fid, logf) for i, fid in enumerate(filers, start=1)]
+                for _ in as_completed(futs):
+                    pass
+
+    batch_upload: dict | None = None
+    if upload_mode == "batch":
+        print("\n=== batch upload (gcloud storage rsync) ===")
+        ok, msg = _rsync_out_dir_to_gcs(args.out_dir, args.gcs_bucket)
+        batch_upload = {"ok": ok, "output_tail": msg[-2000:] if msg else ""}
+        print(batch_upload["output_tail"])
+
+    duration = round(time.perf_counter() - t_start, 1)
+    summary_path.write_text(
+        json.dumps(
+            {
+                "started_at_utc": datetime.now(timezone.utc).isoformat(),
+                "duration_s": duration,
+                "count_total": len(filers),
+                "counts": counts,
+                "out_dir": str(args.out_dir),
+                "filer_root": str(root),
+                "upload_mode": upload_mode,
+                "workers": workers,
+                "batch_upload": batch_upload,
+                "log_file": str(log_path),
+            },
+            indent=2,
+        ),
+    )
+
+    print("\n=== Summary ===")
+    print(f"  duration : {duration}s")
+    for k, v in counts.items():
+        print(f"  {k:<18}: {v}")
+    exit_ok = counts.get("error", 0) == 0 and (
+        batch_upload is None or batch_upload.get("ok")
+    )
+    return 0 if exit_ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sdk/scripts/bulk_filer_f1_render.py
+++ b/sdk/scripts/bulk_filer_f1_render.py
@@ -54,12 +54,10 @@ def _default_filer_parent() -> Path:
     raw = os.environ.get("FUNDS_DAG_ZARR_ROOT", "").strip()
     if raw:
         return Path(raw).expanduser().resolve()
-    # Developer fallback — mirrors BWMACRO `_data.py`
-    mac = Path("/Users/conradgann/BW_Code/Funds_DAG/data/sec_data/zarr")
-    if mac.is_dir():
-        return mac.resolve()
     raise RuntimeError(
-        "Set FUNDS_DAG_ZARR_ROOT to the zarr directory that contains bw_filer_id/",
+        "FUNDS_DAG_ZARR_ROOT is not set. Point it at the zarr directory "
+        "that contains bw_filer_id/ (e.g. "
+        "<funds_dag_root>/data/sec_data/zarr).",
     )
 
 

--- a/sdk/scripts/run_bulk_filer_f1.sh
+++ b/sdk/scripts/run_bulk_filer_f1.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Bulk filer F1 PNG — uses BWMACRO monorepo venv + PYTHONPATH (sdk + BWMACRO/src).
+#
+#   export FUNDS_DAG_ZARR_ROOT=/path/to/Funds_DAG/data/sec_data/zarr
+#   ./sdk/scripts/run_bulk_filer_f1.sh --scan --upload-mode batch --resume
+
+set -euo pipefail
+
+: "${FUNDS_DAG_ZARR_ROOT:?Set FUNDS_DAG_ZARR_ROOT (parent of bw_filer_id/)}" >&2
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SDK_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$SDK_DIR/.." && pwd)"
+
+BWM="${BWMACRO_ROOT:-}"
+if [[ -z "$BWM" ]]; then
+  if bw="$(cd "$REPO_ROOT/../BWMACRO" 2>/dev/null && pwd)" && [[ -d "$bw/.venv/bin" ]]; then
+    BWM="$bw"
+  fi
+fi
+DEFAULT_PY=""
+if [[ -n "$BWM" ]]; then
+  DEFAULT_PY="$BWM/.venv/bin/python"
+fi
+PY="${PYTHON:-$DEFAULT_PY}"
+if [[ ! -x "$PY" ]]; then
+  echo "error: Python not found. Set BWMACRO_ROOT or PYTHON." >&2
+  exit 1
+fi
+
+BW_SRC=""
+if [[ -n "$BWM" ]]; then
+  BW_SRC="$BWM/src"
+fi
+
+cd "$REPO_ROOT"
+export PYTHONPATH="sdk${BW_SRC:+:${BW_SRC}}"
+
+exec "$PY" sdk/scripts/bulk_filer_f1_render.py "${@}"


### PR DESCRIPTION
## Summary

Institutional-parity F1 dossier for 13F filers — mirrors the fund F1 surface across the Snapshot route + the static-PNG CDN.

### Snapshot route (lib/13f/)

- **`filer-snapshot-composer.ts`** — \`FilerSnapshot\` gains \`erm3_decomposition\` (monthly L3 rows + variance shares + latest-month waterfall, gated on filer \`ds_returns_monthly.zarr\` presence) and \`hedge_sleeve\` (\`FundHedgeSnapshot | null\` when \`ds_hr.zarr\` exists; D.8.10 Phase 3).
- **`filer-snapshot-loader.ts`** — fans out \`readFilerReturnsDecomposition\` + \`readFilerHedgeLatest\` in the same parallel fetch as holdings / portfolio history / cohort ranks.
- **`enrich-filer-holdings.ts`** (new) — layers latest daily L3 ER shares (\`l3_mkt_er\` / \`l3_sec_er\` / \`l3_sub_er\` / \`l3_res_er\`) from \`security_history_latest\` onto holdings keyed by \`bw_sym_id\`, mirroring the fund V3 batch read.

### DAL (lib/dal/funds-zarr-reader.ts)

- **`readFilerReturnsDecomposition`** reads \`ds_returns_monthly.zarr\` (D.8.22) — teo window, monthly L3 series, variance attrs (\`adjusted_*\`), gross-anchored waterfall.
- **`FilerHolding`** gains optional \`ticker\` + L3 ER share fields populated by the enrichment step.

### CDN

- **`next.config.mjs`** rewrite: \`/snapshots/:file*\` → \`https://storage.googleapis.com/rm_api_public/snapshot/:file*\`. Once Dagster writes the PNGs, the Risk_Models portal probe URL (\`riskmodels.app/snapshots/{bwFilerId}_f1.png\`) resolves.

### Bulk renderer (sdk/scripts/)

- **`bulk_filer_f1_render.py`** — renders flat \`{bw_filer_id}_f1.png\` from BWMACRO matplotlib (institutional layout); supports \`--scan\` / \`--filers\` / \`--filers-file\` / \`--registry-json\` discovery, \`--upload-mode none|per-filer|batch\`, \`--workers\`, \`--resume\`, \`--no-supabase-enrich\`. Thread-safe matplotlib + log locks.
- **`run_bulk_filer_f1.sh`** wraps \`PYTHONPATH=sdk:BWMACRO/src\` + BWMACRO venv + the \`FUNDS_DAG_ZARR_ROOT\` guard for direct invocation and the ERM3 Dagster asset.

### OPENAPI

- Description note on \`GET /13f/filers/{id}/snapshot\` covers the new \`erm3_decomposition\` + \`hedge_sleeve\` fields. \`npm run build:openapi\` regenerated \`mcp/data/openapi.json\` (public/openapi.json mirror is gitignored, regenerated at deploy).

### Rename

\`ds_returns.zarr\` → \`ds_returns_monthly.zarr\` (filer-only; ERM3-side \`ds_erm3_returns_*.zarr\` is unrelated). Cadence-suffix the name so it's self-documenting and not misread as daily.

Companion PRs (D.8.34):
- Funds_DAG \`feat/d8-filer-master-backfill\` (#16) — registry backfill + writer rename
- ERM3 \`feat/d8-filer-f1-dagster\` (#23) — Dagster wiring
- BWMACRO \`feat/d8-filer-f1-parity\` — renderer + cross-repo doc

## Test plan

- [x] \`npm run typecheck\` clean across both commits
- [x] \`npm run build:openapi\` regenerates the description without schema changes
- [x] 24-PNG smoke (TRS / BRK / Pershing / Scion + 20 lowest-CIK filers): all serve HTTP 200 \`image/png\` (~355 KB each) via direct \`storage.googleapis.com\` URL
- [ ] \`riskmodels.app/snapshots/{id}_f1.png\` rewrite live after this PR deploys (today serves the AAPL/NVDA fund subdirs but not flat filer names)
- [ ] CI tests on PR open

🤖 Generated with [Claude Code](https://claude.com/claude-code)