### PR TITLE
feat(api): ETF base metrics endpoint /api/data/etf/{ticker} + funds-engine coalesce (L.6 / D.9)

### DIFF
--- a/OPENAPI_SPEC.yaml
+++ b/OPENAPI_SPEC.yaml
@@ -5904,6 +5904,72 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
 
+  /data/etf/{ticker}:
+    get:
+      summary: ETF base metrics (canonical PortfolioSurface)
+      description: >
+        Latest knowledge-mode metrics for a single ETF — registry-level metadata
+        (`portfolio_id`, `ticker`, `source_kind`, `teo_frequency`, `sponsor`) +
+        the latest aggregate metrics from the canonical PortfolioSurface zarr
+        (`aum_reported`, `aum_erm3`, `coverage_pct`, `n_total_holdings`,
+        `report_date`, `availability_date`).
+
+
+        Symmetric to `/api/data/funds/{bw_fund_id}` and
+        `/api/13f/filers/{bw_filer_id}` — closes the "base entity metrics"
+        parity gap for the ETF surface. MASTER_BACKLOG L.6 / D.9.
+
+
+        Bitemporal lineage on response headers — never collapsed: `X-Data-As-Of`
+        (= `report_date`) and `X-Data-Availability` (= `availability_date`). No
+        per-holding rows — call `/api/data/etf/{ticker}/holdings` for those.
+      operationId: getEtfMetricsDataPlane
+      tags: [Funds Data Plane]
+      security:
+        - BearerAuth: []
+        - {}
+      parameters:
+        - name: ticker
+          in: path
+          required: true
+          schema: { type: string }
+          example: IVV
+      responses:
+        "200":
+          description: ETF latest metrics block.
+          headers:
+            X-Data-As-Of:
+              schema: { type: string, format: date }
+              description: report_date — the sponsor's "Fund Holdings as of" date.
+            X-Data-Availability:
+              schema: { type: string, format: date }
+              description: availability_date — when that holdings file was first observed.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  portfolio_id: { type: string, example: BW-ETF-IVV }
+                  ticker: { type: string, example: IVV }
+                  source_kind: { type: string, enum: [etf] }
+                  teo_frequency: { type: string, enum: [daily] }
+                  sponsor: { type: string, nullable: true, example: ishares }
+                  report_date: { type: string, format: date }
+                  availability_date: { type: string, format: date, nullable: true }
+                  aum_reported: { type: number, nullable: true }
+                  aum_erm3: { type: number, nullable: true }
+                  coverage_pct:
+                    type: number
+                    nullable: true
+                    description: aum_erm3 / aum_reported — in-ERM3 share of the resolved sleeve.
+                  n_total_holdings: { type: integer }
+        "404":
+          description: ETF not found or no holdings available.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
   /data/etf/{ticker}/holdings:
     get:
       summary: ETF top-N holdings (canonical PortfolioSurface)

--- a/app/api/data/etf/[ticker]/route.ts
+++ b/app/api/data/etf/[ticker]/route.ts
@@ -1,0 +1,56 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { verifyGatewayAuth } from "@/lib/gateway-auth";
+import { readEtfHoldingsTopN } from "@/lib/dal/funds-zarr-reader";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/data/etf/:ticker
+ *
+ * Latest knowledge-mode metrics for a single ETF — registry-level metadata
+ * (portfolio_id, ticker, source_kind, teo_frequency, sponsor) + the latest
+ * aggregate metrics from the canonical PortfolioSurface zarr (aum_reported,
+ * aum_erm3, coverage_pct, n_total_holdings, report_date, availability_date).
+ *
+ * Symmetric to `/api/data/funds/:bw_fund_id` and `/api/13f/filers/:bw_filer_id`
+ * — closes the "base entity metrics" parity gap for the ETF surface.
+ * MASTER_BACKLOG L.6 / D.9.
+ *
+ * Bitemporal lineage on response headers — never collapsed:
+ *   X-Data-As-Of:           report_date    (sponsor's "Fund Holdings as of")
+ *   X-Data-Availability:    availability_date (when that file was observed)
+ *
+ * No per-holding rows — call `/api/data/etf/:ticker/holdings` for those.
+ * Soft gateway auth (public read). 404 when no zarr or empty.
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ ticker: string }> },
+) {
+  const denied = verifyGatewayAuth(request);
+  if (denied) return denied;
+
+  const { ticker } = await params;
+  if (!ticker) {
+    return NextResponse.json({ error: "ticker is required" }, { status: 400 });
+  }
+
+  // n=0 → the metrics shell with an empty holdings array; we strip the array.
+  const snapshot = await readEtfHoldingsTopN(ticker, 1);
+  if (!snapshot) {
+    return NextResponse.json(
+      { error: "ETF not found or no holdings available" },
+      { status: 404 },
+    );
+  }
+
+  const headers = new Headers();
+  headers.set("X-Data-As-Of", snapshot.report_date);
+  if (snapshot.availability_date) {
+    headers.set("X-Data-Availability", snapshot.availability_date);
+  }
+
+  // Strip the holdings array — callers wanting top-N use /holdings.
+  const { holdings: _holdings, n_holdings_returned: _n, ...metrics } = snapshot;
+  return NextResponse.json(metrics, { headers });
+}

--- a/lib/dal/funds-engine.ts
+++ b/lib/dal/funds-engine.ts
@@ -78,7 +78,62 @@ const FUND_COLUMNS =
 const FUND_LATEST_COLUMNS =
   "bw_fund_id, report_date, filing_date, extracted_at, portfolio_gross_return, portfolio_market_return, portfolio_sector_return, portfolio_subsector_return, portfolio_idiosyncratic_return, identity_residual, weight_sum, n_holdings_active, effective_n, top10_weight_sum, total_adj_mv, equity_style_9box, n_funds_in_cell_at_report_date, model_version, factor_set_id, last_synced_at, metadata";
 
-export async function fetchFund(bwFundId: string): Promise<FundRow | null> {
+/**
+ * True when `public.funds.latest_total_adj_mv` is missing or non-finite or exactly 0.
+ * In those cases we coalesce from `funds_latest.total_adj_mv` so search/detail match
+ * the hot-cache row (registry denormalization can lag ds_ph sums).
+ */
+function registryMvNeedsCoalesce(mv: number | null | undefined): boolean {
+  if (mv == null) return true;
+  if (!Number.isFinite(mv)) return true;
+  return mv === 0;
+}
+
+/**
+ * Merge registry (`funds`) summary fields from `funds_latest` when the registry
+ * value is null/0/non-finite but the latest row has a usable value.
+ */
+export function mergeFundRegistryWithLatest(
+  fund: FundRow,
+  latest: FundLatestRow | null | undefined,
+): FundRow {
+  if (!latest) return fund;
+
+  const out: FundRow = { ...fund };
+  const t = latest.total_adj_mv;
+  if (
+    registryMvNeedsCoalesce(fund.latest_total_adj_mv) &&
+    t != null &&
+    Number.isFinite(t) &&
+    t !== 0
+  ) {
+    out.latest_total_adj_mv = t;
+  }
+
+  if (
+    (fund.latest_n_holdings == null || fund.latest_n_holdings === 0) &&
+    latest.n_holdings_active != null &&
+    latest.n_holdings_active > 0
+  ) {
+    out.latest_n_holdings = latest.n_holdings_active;
+  }
+
+  const eff = latest.effective_n;
+  if (
+    (fund.latest_effective_n == null || fund.latest_effective_n === 0) &&
+    eff != null &&
+    Number.isFinite(eff) &&
+    eff !== 0
+  ) {
+    out.latest_effective_n = eff;
+  }
+
+  return out;
+}
+
+async function fetchFundRegistryRow(
+  bwFundId: string,
+): Promise<FundRow | null> {
   try {
     const admin = createAdminClient();
     const { data, error } = await admin
@@ -95,6 +150,12 @@ export async function fetchFund(bwFundId: string): Promise<FundRow | null> {
     console.error(`[Funds DAL] Error fetching fund ${bwFundId}:`, error);
     return null;
   }
+}
+
+/** Registry row + `funds_latest` coalesced fields (single-fund reads). */
+export async function fetchFund(bwFundId: string): Promise<FundRow | null> {
+  const resolved = await resolveFundById(bwFundId);
+  return resolved?.fund ?? null;
 }
 
 export async function fetchFundLatest(
@@ -128,11 +189,11 @@ export async function resolveFundById(
   bwFundId: string,
 ): Promise<FundWithLatest | null> {
   const [fund, latest] = await Promise.all([
-    fetchFund(bwFundId),
+    fetchFundRegistryRow(bwFundId),
     fetchFundLatest(bwFundId),
   ]);
   if (!fund) return null;
-  return { fund, latest };
+  return { fund: mergeFundRegistryWithLatest(fund, latest), latest };
 }
 
 export async function resolveFundsByIds(
@@ -166,9 +227,10 @@ export async function resolveFundsByIds(
     }
 
     for (const fund of (fundsRes.data ?? []) as FundRow[]) {
+      const latest = latestById.get(fund.bw_fund_id) ?? null;
       result.set(fund.bw_fund_id, {
-        fund,
-        latest: latestById.get(fund.bw_fund_id) ?? null,
+        fund: mergeFundRegistryWithLatest(fund, latest),
+        latest,
       });
     }
     return result;
@@ -210,7 +272,25 @@ export async function searchFunds(
       console.error("[Funds DAL] searchFunds error:", error);
       return [];
     }
-    return (data ?? []) as FundRow[];
+    const rows = (data ?? []) as FundRow[];
+    if (rows.length === 0) return [];
+
+    const ids = rows.map((r) => r.bw_fund_id);
+    const { data: latestData, error: latestErr } = await admin
+      .from("funds_latest")
+      .select(FUND_LATEST_COLUMNS)
+      .in("bw_fund_id", ids);
+    if (latestErr) {
+      console.error("[Funds DAL] searchFunds funds_latest batch error:", latestErr);
+      return rows;
+    }
+    const latestById = new Map<string, FundLatestRow>();
+    for (const row of (latestData ?? []) as FundLatestRow[]) {
+      latestById.set(row.bw_fund_id, row);
+    }
+    return rows.map((fund) =>
+      mergeFundRegistryWithLatest(fund, latestById.get(fund.bw_fund_id)),
+    );
   } catch (error) {
     console.error("[Funds DAL] searchFunds error:", error);
     return [];

--- a/mcp/data/capabilities.json
+++ b/mcp/data/capabilities.json
@@ -1046,6 +1046,29 @@
     "tags": ["13f", "filer", "search", "discovery"]
   },
   {
+    "id": "etf-metrics",
+    "name": "ETF Base Metrics (canonical PortfolioSurface)",
+    "description": "Latest knowledge-mode metrics for a single ETF — registry-level metadata (portfolio_id, ticker, source_kind, teo_frequency, sponsor) + the latest aggregate metrics from the canonical PortfolioSurface zarr (aum_reported, aum_erm3, coverage_pct, n_total_holdings, report_date, availability_date). Symmetric to /api/data/funds/{bw_fund_id} and /api/13f/filers/{bw_filer_id} — closes the 'base entity metrics' parity gap for the ETF surface. MASTER_BACKLOG L.6 / D.9.",
+    "endpoint": "/api/data/etf/{ticker}",
+    "method": "GET",
+    "parameters": {
+      "ticker": { "type": "string", "required": true, "description": "ETF ticker, e.g. IVV." }
+    },
+    "pricing": { "model": "per_request", "cost_usd": 0.001, "currency": "USD", "billing_code": "etf_metrics_v1" },
+    "performance": {
+      "avg_latency_ms": 100,
+      "p95_latency_ms": 200,
+      "availability_sla": 99.5,
+      "rate_limit_per_minute": 120
+    },
+    "confidence": {
+      "data_quality_score": 0.98,
+      "update_frequency": "daily",
+      "sources": ["ishares_holdings", "erm3_secmaster"]
+    },
+    "tags": ["etf", "metrics", "portfolio-surface", "funds"]
+  },
+  {
     "id": "etf-holdings",
     "name": "ETF Holdings (canonical PortfolioSurface)",
     "description": "Top-N current holdings of an ETF from its canonical PortfolioSurface zarr (Funds_DAG etf_holdings_zarr — source_kind=etf, teo_frequency=daily; iShares today, State Street/Vanguard follow). In-ERM3 sleeve only — every holding carries a bw_sym_id. Surfaces report_date (sponsor 'Fund Holdings as of') and availability_date (when observed) distinctly. MASTER_BACKLOG L.6 / D.9.",

--- a/mcp/data/openapi.json
+++ b/mcp/data/openapi.json
@@ -8829,6 +8829,123 @@
         }
       }
     },
+    "/data/etf/{ticker}": {
+      "get": {
+        "summary": "ETF base metrics (canonical PortfolioSurface)",
+        "description": "Latest knowledge-mode metrics for a single ETF — registry-level metadata (`portfolio_id`, `ticker`, `source_kind`, `teo_frequency`, `sponsor`) + the latest aggregate metrics from the canonical PortfolioSurface zarr (`aum_reported`, `aum_erm3`, `coverage_pct`, `n_total_holdings`, `report_date`, `availability_date`).\n\nSymmetric to `/api/data/funds/{bw_fund_id}` and `/api/13f/filers/{bw_filer_id}` — closes the \"base entity metrics\" parity gap for the ETF surface. MASTER_BACKLOG L.6 / D.9.\n\nBitemporal lineage on response headers — never collapsed: `X-Data-As-Of` (= `report_date`) and `X-Data-Availability` (= `availability_date`). No per-holding rows — call `/api/data/etf/{ticker}/holdings` for those.\n",
+        "operationId": "getEtfMetricsDataPlane",
+        "tags": [
+          "Funds Data Plane"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {}
+        ],
+        "parameters": [
+          {
+            "name": "ticker",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "IVV"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ETF latest metrics block.",
+            "headers": {
+              "X-Data-As-Of": {
+                "schema": {
+                  "type": "string",
+                  "format": "date"
+                },
+                "description": "report_date — the sponsor's \"Fund Holdings as of\" date."
+              },
+              "X-Data-Availability": {
+                "schema": {
+                  "type": "string",
+                  "format": "date"
+                },
+                "description": "availability_date — when that holdings file was first observed."
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "portfolio_id": {
+                      "type": "string",
+                      "example": "BW-ETF-IVV"
+                    },
+                    "ticker": {
+                      "type": "string",
+                      "example": "IVV"
+                    },
+                    "source_kind": {
+                      "type": "string",
+                      "enum": [
+                        "etf"
+                      ]
+                    },
+                    "teo_frequency": {
+                      "type": "string",
+                      "enum": [
+                        "daily"
+                      ]
+                    },
+                    "sponsor": {
+                      "type": "string",
+                      "nullable": true,
+                      "example": "ishares"
+                    },
+                    "report_date": {
+                      "type": "string",
+                      "format": "date"
+                    },
+                    "availability_date": {
+                      "type": "string",
+                      "format": "date",
+                      "nullable": true
+                    },
+                    "aum_reported": {
+                      "type": "number",
+                      "nullable": true
+                    },
+                    "aum_erm3": {
+                      "type": "number",
+                      "nullable": true
+                    },
+                    "coverage_pct": {
+                      "type": "number",
+                      "nullable": true,
+                      "description": "aum_erm3 / aum_reported — in-ERM3 share of the resolved sleeve."
+                    },
+                    "n_total_holdings": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "ETF not found or no holdings available.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/data/etf/{ticker}/holdings": {
       "get": {
         "summary": "ETF top-N holdings (canonical PortfolioSurface)",

--- a/tests/funds-engine.test.ts
+++ b/tests/funds-engine.test.ts
@@ -11,6 +11,7 @@ import {
   fetchStyleCohortLatest,
   fetchStyleRankings,
   getStyleCellMembers,
+  mergeFundRegistryWithLatest,
   resolveFundById,
   resolveFundsByIds,
   searchFunds,
@@ -110,7 +111,10 @@ beforeEach(() => {
 
 describe("fetchFund", () => {
   it("returns the row when found", async () => {
-    setMockClient({ funds: { data: FUND_VFINX, error: null } });
+    setMockClient({
+      funds: { data: FUND_VFINX, error: null },
+      funds_latest: { data: FUND_LATEST_VFINX, error: null },
+    });
     const r = await fetchFund("BW-FUND-S000004310");
     expect(r?.bw_fund_id).toBe("BW-FUND-S000004310");
     expect(r?.ticker).toBe("VFINX");
@@ -119,15 +123,31 @@ describe("fetchFund", () => {
   it("returns null on error", async () => {
     setMockClient({
       funds: { data: null, error: { message: "boom" } },
+      funds_latest: { data: null, error: null },
     });
     const r = await fetchFund("BW-FUND-MISSING");
     expect(r).toBeNull();
   });
 
   it("returns null when no row", async () => {
-    setMockClient({ funds: { data: null, error: null } });
+    setMockClient({
+      funds: { data: null, error: null },
+      funds_latest: { data: null, error: null },
+    });
     const r = await fetchFund("BW-FUND-MISSING");
     expect(r).toBeNull();
+  });
+
+  it("coalesces latest_total_adj_mv from funds_latest when registry MV is 0", async () => {
+    setMockClient({
+      funds: {
+        data: { ...FUND_VFINX, latest_total_adj_mv: 0 },
+        error: null,
+      },
+      funds_latest: { data: FUND_LATEST_VFINX, error: null },
+    });
+    const r = await fetchFund("BW-FUND-S000004310");
+    expect(r?.latest_total_adj_mv).toBe(25_000_000_000);
   });
 });
 
@@ -204,16 +224,40 @@ describe("resolveFundsByIds", () => {
 
 describe("searchFunds", () => {
   it("returns rows when DB returns rows", async () => {
-    setMockClient({ funds: { data: [FUND_VFINX], error: null } });
+    setMockClient({
+      funds: { data: [FUND_VFINX], error: null },
+      funds_latest: { data: [], error: null },
+    });
     const r = await searchFunds({ q: "VFINX", limit: 10 });
     expect(r.length).toBe(1);
     expect(r[0].ticker).toBe("VFINX");
   });
 
   it("clamps limit at 500 (does not throw)", async () => {
-    setMockClient({ funds: { data: [], error: null } });
+    setMockClient({
+      funds: { data: [], error: null },
+      funds_latest: { data: [], error: null },
+    });
     const r = await searchFunds({ limit: 999_999 });
     expect(r).toEqual([]);
+  });
+});
+
+describe("mergeFundRegistryWithLatest", () => {
+  it("fills zero registry MV from latest.total_adj_mv", () => {
+    const merged = mergeFundRegistryWithLatest(
+      { ...FUND_VFINX, latest_total_adj_mv: 0 },
+      FUND_LATEST_VFINX,
+    );
+    expect(merged.latest_total_adj_mv).toBe(25_000_000_000);
+  });
+
+  it("does not overwrite non-zero registry MV", () => {
+    const merged = mergeFundRegistryWithLatest(FUND_VFINX, {
+      ...FUND_LATEST_VFINX,
+      total_adj_mv: 99,
+    });
+    expect(merged.latest_total_adj_mv).toBe(25_000_000_000);
   });
 });
 


### PR DESCRIPTION
## Summary

- New route `GET /api/data/etf/{ticker}` — latest knowledge-mode metrics for a single ETF (portfolio_id, ticker, source_kind, teo_frequency, sponsor, report_date, availability_date, aum_reported, aum_erm3, coverage_pct, n_total_holdings). Symmetric to `/api/data/funds/{bw_fund_id}` and `/api/13f/filers/{bw_filer_id}` — closes the most visible "base entity metrics" parity gap on the ETF surface.
- `etf-metrics` capability registered in `mcp/data/capabilities.json` ($0.001 per call, same pricing as `etf-holdings`). OpenAPI extended; `mcp/data/openapi.json` mirror rebuilt via `npm run build:openapi`.
- `lib/dal/funds-engine.ts` refactor: `fetchFund` is now a thin wrapper around `resolveFundById`, and `mergeFundRegistryWithLatest` coalesces missing/zero/non-finite registry MV + n_holdings + effective_n from `funds_latest`. Fixes a class of single-fund reads where `public.funds.latest_total_adj_mv` lagged behind `funds_latest.total_adj_mv` (the hot cache). TypeScript-side analog of the Funds_DAG `reconcile_funds_registry_with_latest` work.

This is the third of three serialized PRs from a small interoperability sweep on the funds / 13F filers / ETFs / benchmarks API surface (per the master backlog L.6–L.9 + D.8.x arc). Each lands separately, off main (no stacking, per the G.16 lesson):

1. ✅ Merged-able — [RiskModels_API#60](https://github.com/BlueWaterCorp/RiskModels_API/pull/60) — register 6 filer MCP capabilities (D.8.8 tail).
2. ✅ Merged-able — [Funds_DAG#17](https://github.com/BlueWaterCorp/Funds_DAG/pull/17) — D.8.23 consumer-side rename (prefer `ds_portfolio.zarr` for filer latest metrics).
3. **This PR** — ETF base metrics endpoint + funds-engine coalesce.

ETF surface goes from 3 routes → 4. Remaining ETF parity gaps (deferred to follow-up PRs):
- `/api/data/etf/search` — needs a Funds_DAG-side `export_etf_master_json.py` (mirroring `export_benchmark_master_json.py`) + a JSON mirror at `RiskModels_API/mcp/data/etf_master.json`, then a DAL `searchEtfs` + route + capability. ~3-4h.
- `/api/data/etf/{ticker}/snapshot` + `/snapshot.pdf` — composed-JSON + Playwright-rendered tearsheets. Needs an `EtfSnapshotLoader` mirroring `FundSnapshotLoader`. ~1-2d.

## Protected paths

The user explicitly called out two CDN PNGs that must keep generating; **neither path goes through this code**:
- `riskmodels.app/snapshots/agthx_f1.png` — AGTHX fund F1 PNG. BWMACRO `bwmacro.snapshots.funds.*` reads zarr via Python directly; doesn't touch this TS DAL.
- `riskmodels.app/snapshots/nvda_dd_latest.png` — NVDA DD PNG. BWMACRO `bwmacro.snapshots.stock.stock_deep_dive` reads zarr via Python directly; doesn't touch this TS DAL.

## Test plan

- [x] `npm run build:openapi` clean — `public/openapi.json` + `mcp/data/openapi.json` mirror rebuilt.
- [x] `npx tsc --noEmit` — zero errors in `app/api/data/etf/` or `lib/dal/funds-engine.ts`; the 12 pre-existing `lib/chat/anthropic-agent.ts` type errors are unchanged from main (`@anthropic-ai/sdk` missing locally; CI environment has it).
- [x] `tests/funds-engine.test.ts` extended for the coalesce behavior (in the 18048e1 commit; ~52 new test lines).
- [ ] Smoke after merge: `curl https://riskmodels.app/api/data/etf/IVV` returns 200 with the metrics block (sponsor=ishares, source_kind=etf, n_total_holdings ≈ 494 per L.6's live numbers).
- [ ] Smoke: `curl https://riskmodels.app/api/data/etf/NONEXISTENT` returns 404 with `{ error: "ETF not found or no holdings available" }`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)