### PR TITLE
ci(drift): also check capabilities.json against Risk_Models mirror (E.8)

### DIFF
--- a/.github/workflows/drift-detection.yml
+++ b/.github/workflows/drift-detection.yml
@@ -18,6 +18,7 @@ on:
       - "mcp/data/schema-paths.json"
       - "mcp/data/schemas/**"
       - "mcp/data/openapi.json"
+      - "mcp/data/capabilities.json"
       - "OPENAPI_SPEC.yaml"
   workflow_dispatch:
 
@@ -175,6 +176,37 @@ jobs:
             exit 1
           fi
 
+      - name: Check capabilities.json drift
+        id: capabilities
+        if: always()
+        run: |
+          echo "Comparing mcp/data/capabilities.json (canonical) to Risk_Models copy..."
+
+          LOCAL="mcp/data/capabilities.json"
+          REMOTE="risk_models/riskmodels_com/mcp-server/data/capabilities.json"
+
+          if [ ! -f "$LOCAL" ]; then
+            echo "❌ Local capabilities.json not found at $LOCAL"
+            exit 1
+          fi
+
+          if [ ! -f "$REMOTE" ]; then
+            echo "❌ Remote capabilities.json not found at $REMOTE"
+            exit 1
+          fi
+
+          if diff -q "$LOCAL" "$REMOTE" > /dev/null 2>&1; then
+            echo "✅ capabilities.json is in sync"
+            echo "drift_detected=false" >> $GITHUB_OUTPUT
+          else
+            echo "❌ DRIFT DETECTED: capabilities.json differs between repos"
+            echo ""
+            echo "=== Diff (first 120 lines) ==="
+            diff "$LOCAL" "$REMOTE" | head -120 || true
+            echo "drift_detected=true" >> $GITHUB_OUTPUT
+            exit 1
+          fi
+
       - name: Summary
         if: always()
         run: |
@@ -182,7 +214,7 @@ jobs:
           echo "Drift Detection Summary"
           echo "========================================"
 
-          if [ "${{ steps.schema_paths.outcome }}" == "success" ] && [ "${{ steps.schemas.outcome }}" == "success" ] && [ "${{ steps.openapi.outcome }}" == "success" ]; then
+          if [ "${{ steps.schema_paths.outcome }}" == "success" ] && [ "${{ steps.schemas.outcome }}" == "success" ] && [ "${{ steps.openapi.outcome }}" == "success" ] && [ "${{ steps.capabilities.outcome }}" == "success" ]; then
             echo "✅ All checks passed - no drift detected"
           else
             echo "❌ Drift detected! Please sync files:"
@@ -199,6 +231,10 @@ jobs:
             echo "3. Copy openapi.json (generated from OPENAPI_SPEC.yaml):"
             echo "   cp RiskModels_API/mcp/data/openapi.json \\"
             echo "      Risk_Models/riskmodels_com/mcp-server/data/openapi.json"
+            echo ""
+            echo "4. Copy capabilities.json:"
+            echo "   cp RiskModels_API/mcp/data/capabilities.json \\"
+            echo "      Risk_Models/riskmodels_com/mcp-server/data/capabilities.json"
             echo ""
             echo "Or after merge to main: run Actions -> \"Sync MCP data to Risk_Models\" (workflow_dispatch)."
             echo "See AGENTS.md for full sync rules."


### PR DESCRIPTION
## Summary

Closes **[MASTER_BACKLOG E.8](https://github.com/BlueWaterCorp/BWMACRO/blob/main/docs/ceo/MASTER_BACKLOG.md)** — chronic Risk_Models capabilities.json mirror lag has no automated guard.

Today's drift detection workflow compares schema-paths.json, schemas/, and openapi.json against the Risk_Models mirror, but **capabilities.json was missing from both the `paths:` filter and the check steps**. Result: PRs that edit capabilities.json without a paired Risk_Models mirror PR could land without surfacing the drift, which is exactly what produced the lag we hit earlier this session (Risk_Models mirror trailed canonical by 5 entries + 1 description across several PRs).

## What this PR adds

- `mcp/data/capabilities.json` is added to the workflow's `paths:` filter so PRs touching it trigger drift detection.
- A new `Check capabilities.json drift` step that diffs canonical vs mirror — same shape as the existing `openapi.json` check.
- The Summary block reports the new capabilities outcome + the matching sync instruction.

## What's NOT changed

The post-merge `sync-mcp-to-risk-models.yml` workflow already auto-pushes capabilities.json to Risk_Models on every push-to-main (verified locally — main mirror is in sync after today's PRs). So canonical → mirror remains automatic after merge. This guard catches the **pre-merge** case where a canonical PR forgets the paired mirror PR.

## Test plan

- [ ] After merge, the workflow's next run (any future PR touching capabilities.json or openapi.json) confirms the new step passes when mirror is in sync.
- [ ] Manual stress test: open a throwaway PR that edits only `mcp/data/capabilities.json` without a paired Risk_Models mirror PR → drift-detection should fail with the new step (and pass schemas + openapi).

🤖 Generated with [Claude Code](https://claude.com/claude-code)