### PR TITLE
fix(license-scan): add licensed-id-ok-file markers to H.24 scrub modules

### DIFF
--- a/lib/dal/sym-id-scrub.ts
+++ b/lib/dal/sym-id-scrub.ts
@@ -1,3 +1,4 @@
+// licensed-id-ok-file: this module's entire purpose is to prevent ISIN redistribution by detecting ISIN-flavored bw_sym_id values at the read boundary and substituting non-licensed equivalents (FIGI / ticker / RESTRICTED placeholder). Doc comments name ISIN to explain the substitution; no licensed identifier values are emitted to public responses. See MASTER_BACKLOG H.24.
 /**
  * `bw_sym_id` ISIN-leak scrub at the public-API read boundary.
  *

--- a/lib/dal/symbols-batch.ts
+++ b/lib/dal/symbols-batch.ts
@@ -1,3 +1,4 @@
+// licensed-id-ok-file: sibling of sym-id-scrub.ts (which carries the same marker). This module is the batch-resolver that feeds the scrub — it reads symbols.metadata.figi from Postgres to pick the FIGI substitute for ISIN-flavored bw_sym_ids. ISIN mentions in doc comments describe what we're scrubbing; no licensed identifier values leak to public responses. See MASTER_BACKLOG H.24.
 /**
  * Batch-resolve `bw_sym_id` → `{ticker, figi}` for the public-API scrub
  * helpers in `sym-id-scrub.ts`, plus the convenience helper


### PR DESCRIPTION
## Summary

PR #64 (H.24 ISIN scrub) shipped `lib/dal/sym-id-scrub.ts` and `lib/dal/symbols-batch.ts` with explanatory doc comments that mention "ISIN" — the substring the licensed-identifier scanner watches for. The scanner scans the entire `lib/` tree on every PR, so any later PR's CI run fails on those existing files even though the PR itself doesn't touch them.

This is currently blocking [PR #65 (artifact_registry migration)](https://github.com/BlueWaterCorp/RiskModels_API/pull/65) and will block every future PR until fixed.

## Why a file-level marker is the right call

Both files exist specifically to **prevent** ISIN redistribution — they detect ISIN-flavored `bw_sym_id` values at the read boundary and substitute non-licensed equivalents (FIGI / ticker / `BW-RESTRICTED`). Doc comments name "ISIN" to explain the substitution policy; **no licensed identifier values are emitted to public responses**.

This is the canonical use case for the scanner's `licensed-id-ok-file` marker. Per `scripts/check-licensed-identifiers.sh` header:

> Use file-level for translator endpoints that accept CUSIP/ISIN as INPUT and return our internal identifier (ticker / bw_sym_id / FIGI) — that's not redistribution of the licensed value, the user already had it.

That's exactly what these two modules do.

## Verified

```bash
$ bash scripts/check-licensed-identifiers.sh
::warning::Licensed-identifier exposures with AUDIT-PENDING markers:
  lib/dal/filers-engine.ts:29:  factset_entity_id: …  // AUDIT-PENDING
  lib/dal/filers-engine.ts:95:  …, factset_entity_id, …  // AUDIT-PENDING

These are tolerated for now but should be reviewed by the license team.

✓ No licensed-identifier leaks in API-exposed paths
```

The two `AUDIT-PENDING` warnings are pre-existing from earlier D.8 work on `filers-engine.ts` — not from this PR.

## Why this leaked through #64

PR #64's CI must have run before the scanner was hardened on the scan-paths list (or before these particular files existed long enough for a CI run to fully scope them). Whatever the slip, the gate is doing its job now — and the fix is one line per file.

## Test plan

- [x] `bash scripts/check-licensed-identifiers.sh` → passes (no failures; pre-existing AUDIT-PENDING warnings unchanged).
- [ ] Post-merge: re-run CI on #65 → licensed-identifier scan passes; PR #65 ready to merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)