### PR TITLE
feat(sdk): hoist F1 / artifact primitives into _plotly_theme

### DIFF
--- a/sdk/riskmodels/snapshots/_plotly_theme.py
+++ b/sdk/riskmodels/snapshots/_plotly_theme.py
@@ -325,3 +325,51 @@ def apply_theme() -> None:
     # Set default color sequences for px
     px.defaults.color_discrete_sequence = PRISM
     px.defaults.color_continuous_scale = G10
+
+
+# ── F1 / artifact primitives ────────────────────────────────────────────────
+#
+# The canonical decomposition palette used by the F1 fund tearsheet and by
+# every artifact module under ``bwmacro.snapshots.artifacts.*``. Hoisted from
+# the legacy `bwmacro.snapshots.funds.f1_tearsheet` so the artifact modules
+# don't need to import the full monolithic renderer just to reach the four
+# layer colors + the empty-panel helper.
+
+LAYER_COLORS: dict[str, str] = {
+    "market":    "#64748B",   # slate-500
+    "sector":    "#14B8A6",   # teal-500
+    "subsector": "#8B5CF6",   # violet-500
+    "residual":  "#4FA48A",   # desaturated emerald — calmer green, less dominant
+}
+"""F1 ontology layer palette (Market → Sector → Subsector → Residual)."""
+
+FUND_LINE_COLOR: str = "#4F46E5"   # indigo-600
+"""F1 fund / portfolio gross-return line color."""
+
+BENCH_LINE_COLOR: str = "#94A3B8"  # slate-400
+"""F1 benchmark line color."""
+
+
+def _empty_panel_placeholder(message: str) -> go.Figure:
+    """A blank Plotly figure with a single centered "data unavailable" line.
+
+    Used for any panel whose underlying real data isn't yet wired —
+    explicitly tells the viewer the field is empty rather than inventing
+    a synthetic shape. Fundamental rule: no mock data leaks into a
+    rendered F1 page or artifact.
+    """
+    fnt = PLOTLY_THEME.fonts
+    fig = go.Figure()
+    apply_theme()
+    PLOTLY_THEME.style(fig)
+    fig.add_annotation(
+        x=0.5, y=0.5, xref="paper", yref="paper",
+        text=message, showarrow=False,
+        font=dict(family=fnt.family, size=fnt.body + 2, color="#94a3b8"),
+    )
+    fig.update_layout(
+        xaxis=dict(visible=False),
+        yaxis=dict(visible=False),
+        margin=dict(t=10, b=10, l=10, r=10),
+    )
+    return fig


### PR DESCRIPTION
## Summary

Additive SDK change — promotes four F1-flavored Plotly primitives from the BWMACRO private monolith into the public SDK so artifact modules can reach them without dragging the full F1 renderer into the render-svc Docker image.

Hoisted symbols (previously in \`bwmacro.snapshots.funds.f1_tearsheet\`):
- \`LAYER_COLORS\` — Market / Sector / Subsector / Residual canonical decomposition palette
- \`FUND_LINE_COLOR\` (indigo-600) and \`BENCH_LINE_COLOR\` (slate-400) — F1 line colors
- \`_empty_panel_placeholder\` — the \"data unavailable\" Plotly Figure factory

## Why now (Phase 1B SDK-hoist)

The artifact registry build-out has two shipped artifact modules — \`top_holdings_erm_stacked@v1\` and \`cumulative_return_strip@v1\` — that today import these symbols from \`bwmacro.snapshots.funds.f1_tearsheet\`. That import drags in the 77.5 KB monolithic F1 renderer + \`bwmacro.snapshots.funds._data\` (which pulls \`requests\`), violating the \"public-SDK-only\" boundary that \`services/render-svc/render_svc/render.py:178\` calls out explicitly.

The Phase 1B plan ([\`docs/architecture/intelligence_runtime/ARTIFACT_REGISTRY_PHASE_1B_PLAN.md\`](https://github.com/BlueWaterCorp/BWMACRO/blob/main/docs/architecture/intelligence_runtime/ARTIFACT_REGISTRY_PHASE_1B_PLAN.md) on BWMACRO main) recommends Option B: hoist these primitives, keep BWMACRO consuming them via SDK import. This PR is step 1 of that plan.

## What does NOT land here

- BWMACRO f1_tearsheet + artifact-module import swap (separate PR on BWMACRO).
- render-svc Dockerfile changes (later in the Phase 1B sequence).

## Test plan

- [ ] CI green (zero existing SDK consumer changes behavior — additive only)
- [x] Local smoke: \`python -c \"from riskmodels.snapshots._plotly_theme import LAYER_COLORS, FUND_LINE_COLOR, BENCH_LINE_COLOR, _empty_panel_placeholder\"\` works
- [x] BWMACRO artifact parity tests (27/27) pass against this SDK locally after the follow-on import swap

🤖 Generated with [Claude Code](https://claude.com/claude-code)