### PR TITLE
feat(render-svc): install bwmacro artifact subtree + import-firewall smoke

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,9 @@ data/
 
 # Auto-generated smoke test reports (sdk/scripts/smoke_v3_all_endpoints.py)
 sdk/scripts/smoke_reports/
+
+# BWMACRO clone / symlink at repo root — used by services/render-svc Docker
+# build context (cloudbuild clones; local dev creates a symlink via
+# `ln -s ../BWMACRO bwmacro-src`). Never committed.
+bwmacro-src
+bwmacro-src/

--- a/services/render-svc/Dockerfile
+++ b/services/render-svc/Dockerfile
@@ -2,10 +2,19 @@
 #
 # Cloud Run render service image.
 #
-# Build context: repo root (so the SDK at ./sdk/ is reachable). Build via:
+# Build context: repo root.
+#   - ./sdk/ — public riskmodels-py SDK
+#   - ./bwmacro-src/ — BWMACRO clone (cloudbuild clones it; locally use a
+#                       symlink: `ln -s ../BWMACRO bwmacro-src` from repo root).
+#                       Only the leaf-clean `bwmacro.snapshots.artifacts.*`
+#                       subtree is exercised; a build-time import-firewall
+#                       smoke (below) asserts no Supabase / Moonshot /
+#                       requests-via-_data symbols transit at module scope.
+#
+# Build via:
 #   gcloud builds submit --config services/render-svc/cloudbuild.yaml .
 #
-# Or locally:
+# Or locally (from repo root, with the bwmacro-src symlink in place):
 #   docker build -f services/render-svc/Dockerfile -t render-svc .
 
 FROM python:3.12-slim
@@ -51,17 +60,40 @@ RUN pip install --no-deps /tmp/sdk && \
         'python-dotenv>=1.0,<2' && \
     rm -rf /tmp/sdk
 
-# 2. Install the service.
+# 2. Install BWMACRO narrowly. Only the artifact subtree is invoked at
+#    runtime (the artifact registry endpoint imports
+#    `bwmacro.snapshots.artifacts.{slug}.v{N}`). Install with --no-deps
+#    since BWMACRO's pyproject doesn't declare deps (managed by the shared
+#    BWMACRO venv in dev); the SDK + the runtime deps installed above are
+#    sufficient for the artifact-import path.
+COPY bwmacro-src/ /tmp/bwmacro/
+RUN pip install --no-deps /tmp/bwmacro && rm -rf /tmp/bwmacro
+
+# 3. Install the service.
 COPY services/render-svc/pyproject.toml services/render-svc/README.md /app/
 COPY services/render-svc/render_svc /app/render_svc
 RUN pip install /app
 
-# 3. Build-time import smoke. If aom or snapshots can't import, fail the
+# 4. Build-time import smoke. If aom or snapshots can't import, fail the
 #    BUILD here (with full traceback in build logs) instead of getting a
 #    masked Cloud Run startup error.
 RUN python -c "import riskmodels.aom; print('aom OK')" && \
     python -c "import riskmodels.snapshots; print('snapshots OK')" && \
     python -c "import render_svc.app; print('app OK')"
+
+# 5. Build-time import firewall — the artifact subtree must import without
+#    transitively dragging in the heavy BWMACRO private surface (Supabase,
+#    Moonshot, `requests` via `bwmacro.snapshots.funds._data`). If a future
+#    refactor reintroduces those at module scope, fail the BUILD instead of
+#    discovering it in production via image-size bloat or cold-start crash.
+RUN python -c "import sys; \
+import bwmacro.snapshots.artifacts; \
+import bwmacro.snapshots.artifacts.top_holdings_erm_stacked.v1; \
+import bwmacro.snapshots.artifacts.cumulative_return_strip.v1; \
+forbidden = ['bwmacro.snapshots.funds._ai_insight', 'bwmacro.snapshots.funds._data', 'supabase']; \
+hit = [m for m in forbidden if m in sys.modules]; \
+assert not hit, f'forbidden modules imported at artifact import: {hit}'; \
+print('artifact import firewall OK')"
 
 # 4. Run as non-root.
 RUN groupadd --system app && useradd --system --gid app --no-create-home app

--- a/services/render-svc/cloudbuild.yaml
+++ b/services/render-svc/cloudbuild.yaml
@@ -1,9 +1,46 @@
 # Cloud Build config for the render service.
 # Invoke from repo root:
 #   gcloud builds submit --config services/render-svc/cloudbuild.yaml .
+#
+# Multi-repo note: the artifact registry endpoint imports
+# `bwmacro.snapshots.artifacts.*` (narrow leaf surface — see Dockerfile §5
+# import-firewall smoke). BWMACRO lives in a sibling repo; we clone it
+# into the build context as `./bwmacro-src/` before docker build runs.
+#
+# To enable the clone step in production: store a GitHub PAT (or App
+# token) with read access to BlueWaterCorp/BWMACRO in Secret Manager
+# under name `github-bwmacro-read`, then uncomment the secretEnv +
+# availableSecrets blocks below. For staging / local dev, fall back to
+# a symlink: `ln -s ../BWMACRO bwmacro-src` from the RiskModels_API
+# repo root before invoking `docker build` directly.
 
 steps:
+  # Phase 1B addition: clone BWMACRO into the build context so the
+  # Dockerfile's `COPY bwmacro-src/` step can install the artifact subtree.
+  - name: 'gcr.io/cloud-builders/git'
+    id: clone-bwmacro
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        set -euo pipefail
+        if [ -n "${_BWMACRO_GIT_TOKEN:-}" ]; then
+          git clone --depth=1 \
+            "https://x-access-token:${_BWMACRO_GIT_TOKEN}@github.com/BlueWaterCorp/BWMACRO.git" \
+            bwmacro-src
+        else
+          # No token configured — bail loudly so a misconfigured build
+          # fails the clone step instead of producing an image without
+          # the artifact subtree.
+          echo "ERROR: _BWMACRO_GIT_TOKEN substitution not set. Provide via" >&2
+          echo "  --substitutions=_BWMACRO_GIT_TOKEN=\$(gcloud secrets versions access latest --secret=github-bwmacro-read)" >&2
+          exit 1
+        fi
+        echo "BWMACRO HEAD: $(git -C bwmacro-src rev-parse HEAD)"
+
   - name: 'gcr.io/cloud-builders/docker'
+    id: build-image
+    waitFor: ['clone-bwmacro']
     args:
       - 'build'
       - '-t'
@@ -21,3 +58,9 @@ images:
 options:
   logging: CLOUD_LOGGING_ONLY
   machineType: 'E2_HIGHCPU_8'
+
+# Substitutions documented for the trigger config. Set `_BWMACRO_GIT_TOKEN`
+# at trigger time from a Secret Manager binding, e.g. via Console or:
+#   gcloud builds triggers update <trigger> --update-substitutions=_BWMACRO_GIT_TOKEN=...
+substitutions:
+  _BWMACRO_GIT_TOKEN: ''


### PR DESCRIPTION
## Summary

Phase 1B step 4 of the artifact registry plan ([BWMACRO ARTIFACT_REGISTRY_PHASE_1B_PLAN.md](https://github.com/BlueWaterCorp/BWMACRO/blob/main/docs/architecture/intelligence_runtime/ARTIFACT_REGISTRY_PHASE_1B_PLAN.md)). Unblocks the upcoming \`POST /artifacts/render\` endpoint by making \`bwmacro.snapshots.artifacts.*\` importable inside the render-svc image **without** breaking the explicit \"public-SDK-only\" boundary stated in \`services/render-svc/render_svc/render.py:178\`.

## What ships

- **\`Dockerfile\`** — installs BWMACRO from \`./bwmacro-src/\` (\`--no-deps\`) and adds a **build-time import firewall smoke (§5)** that asserts the artifact subtree imports cleanly without dragging in \`bwmacro.snapshots.funds._ai_insight\`, \`bwmacro.snapshots.funds._data\`, or \`supabase\`. If a future refactor reintroduces those at module scope, BUILD fails here instead of producing a bloated image or crashing on cold start.

- **\`cloudbuild.yaml\`** — new \`clone-bwmacro\` step uses \`gcr.io/cloud-builders/git\` to clone BWMACRO into the build context as \`bwmacro-src/\`. Token supplied via \`_BWMACRO_GIT_TOKEN\` substitution, expected to be wired from a Secret Manager secret named \`github-bwmacro-read\` on the Cloud Build trigger.

- **\`.gitignore\`** — \`bwmacro-src\` / \`bwmacro-src/\` so local symlinks don't get committed.

## Test plan

- [x] Local import firewall smoke passes (no \`_data\` / \`_ai_insight\` / \`supabase\` after artifact imports — only \`_contract\` + the two v1 modules + their parent packages)
- [ ] Docker build green (CI / Cloud Build)
- [ ] BWMACRO #11 (artifact imports via hoisted SDK location) lands first — otherwise the firewall correctly fails on the legacy \`funds._data\` transitive surface

## Production ops checklist (for after this PR merges)

- [ ] Create Secret Manager secret \`github-bwmacro-read\` containing a GitHub PAT (or App token) with read access to \`BlueWaterCorp/BWMACRO\`
- [ ] Grant Cloud Build SA \`roles/secretmanager.secretAccessor\` on that secret
- [ ] Update the render-svc Cloud Build trigger substitution to read \`_BWMACRO_GIT_TOKEN\` from the secret

## Depends on

BWMACRO #11 (artifact module imports via hoisted SDK location) — must land first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)