### PR TITLE
docs(render-svc): Phase 1B artifact registry ops checklist

### DIFF
--- a/services/render-svc/RUNBOOK.md
+++ b/services/render-svc/RUNBOOK.md
@@ -229,3 +229,142 @@ file /tmp/nvda.png
    resources (Supabase via private IP, etc.). Not needed for Phase 1.
 5. **Phase 2 — cache-miss live render** depends on the FundData reader
    promotion (tracker task #11).
+
+---
+
+## Phase 1B — artifact registry endpoint ops checklist
+
+After PRs [#68](https://github.com/BlueWaterCorp/RiskModels_API/pull/68)
++ [#70](https://github.com/BlueWaterCorp/RiskModels_API/pull/70) land
+(Dockerfile multi-repo build + `POST /artifacts/render` endpoint), the
+artifact registry is live in code but **not deployed** until the four
+steps below complete. They each need interactive auth and can't run from
+a Claude session.
+
+Cross-repo dependency map: parent SSOT is
+`BWMACRO/docs/architecture/intelligence_runtime/ARTIFACT_REGISTRY_PHASE_1B_PLAN.md`.
+Workspace consumer is `Risk_Models` PRs #82 (proxy + table prop) + #83
+(visible preview panel).
+
+### 1. Create the Secret Manager secret with a BWMACRO read token
+
+The Dockerfile clones BWMACRO into the build context at `bwmacro-src/` so
+`pip install --no-deps /tmp/bwmacro` can install the artifact subtree.
+Cloud Build needs a GitHub access token to do the clone (BWMACRO is
+private).
+
+Generate a PAT (or GitHub App installation token) with `repo:read` scope
+limited to `BlueWaterCorp/BWMACRO`, then store it:
+
+```bash
+echo -n "ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxx" | \
+  gcloud secrets create github-bwmacro-read \
+    --replication-policy="automatic" \
+    --data-file=-
+```
+
+Grant the Cloud Build service account access:
+
+```bash
+PROJECT_NUMBER=$(gcloud projects describe "$(gcloud config get-value project)" \
+  --format='value(projectNumber)')
+gcloud secrets add-iam-policy-binding github-bwmacro-read \
+  --member="serviceAccount:${PROJECT_NUMBER}@cloudbuild.gserviceaccount.com" \
+  --role="roles/secretmanager.secretAccessor"
+```
+
+### 2. Update the render-svc Cloud Build trigger to inject the token
+
+The current `cloudbuild.yaml` expects `_BWMACRO_GIT_TOKEN` as a build
+substitution; the prep step bails loudly if it's empty. Wire the secret
+into the trigger so the substitution gets populated automatically on
+each build (Console: Cloud Build → Triggers → `render-svc-deploy` →
+Edit → Substitutions → `_BWMACRO_GIT_TOKEN` mapped to
+`projects/<PROJECT_NUMBER>/secrets/github-bwmacro-read/versions/latest`).
+
+For ad-hoc CLI builds (no trigger), pass the token at submit time:
+
+```bash
+TOKEN=$(gcloud secrets versions access latest --secret=github-bwmacro-read)
+gcloud builds submit --config services/render-svc/cloudbuild.yaml \
+  --substitutions=_BWMACRO_GIT_TOKEN="${TOKEN}" .
+```
+
+### 3. Deploy the artifact-registry-aware image
+
+Once the trigger is wired (or you run an ad-hoc build), the next push to
+`main` rebuilds the image with the bwmacro artifact subtree. The
+Dockerfile's **import-firewall smoke (§5)** catches drift at BUILD time:
+if a future refactor reintroduces `bwmacro.snapshots.funds._ai_insight`
+/ `_data` / `supabase` at module scope, the build fails with the
+offending module listed instead of producing a bloated image. Verify
+the smoke output in the Cloud Build logs:
+
+```
+=== Step "build-image" ===
+...
+artifact import firewall OK
+```
+
+After the build, deploy the new revision:
+
+```bash
+gcloud run services update render-svc \
+  --image=us-central1-docker.pkg.dev/$(gcloud config get-value project)/cloud-run-source-deploy/render-svc:latest \
+  --region=us-central1
+```
+
+Smoke the endpoint (the Cloud Run URL is what feeds `RENDER_SVC_URL`
+below):
+
+```bash
+RENDER_URL=$(gcloud run services describe render-svc \
+  --region=us-central1 --format='value(status.url)')
+
+curl -X POST "${RENDER_URL}/artifacts/render" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "slug": "top_holdings_erm_stacked",
+    "version": "v1",
+    "subject_id": "BW-FUND-S000004563",
+    "as_of": "latest",
+    "format": "json"
+  }' \
+  -i | head -40
+```
+
+Expected:
+- `HTTP/2 200` with `X-Artifact-Resolved-As-Of: 2025-MM-DD`
+- `X-Artifact-GCS-Path: gs://rm_api_public/snapshots/artifacts/top_holdings_erm_stacked@v1/BW-FUND-S000004563/2025-MM-DD.json`
+- JSON body matching the `TopHoldingsErmStackedV1` shape in the SDK.
+
+### 4. Wire RENDER_SVC_URL on the Risk_Models Vercel project
+
+The Next.js proxy route (`riskmodels_com/src/app/api/artifacts/render/route.ts`)
+returns 503 with a friendly message when `RENDER_SVC_URL` is unset,
+so the workspace preview panel (Risk_Models PR #83) degrades cleanly.
+To activate it:
+
+```bash
+# Vercel CLI from riskmodels_com/:
+vercel env add RENDER_SVC_URL production
+# paste the Cloud Run URL from step 3
+vercel env add RENDER_SVC_URL preview   # if you want preview deploys to use it too
+vercel deploy --prod                    # or push a commit to trigger the build
+```
+
+Or via the Vercel UI: Project Settings → Environment Variables → add
+`RENDER_SVC_URL = <CLOUD_RUN_URL>` for Production (and Preview if desired).
+
+After redeploy, the AHA panel's "Artifact Registry · live preview"
+section should render AGTHX's top holdings within ~2 seconds of the
+snapshot landing.
+
+### Phase 2 follow-ons (not in this checklist)
+
+- Postgres `artifact_registry` UPSERT (Dagster reconciliation job).
+- `FundData` arbitrary `as_of` threaded through `get_data_for_f1`.
+- Widen `top_holdings_erm_stacked@v1` to `client_portfolio` + add adapter
+  + extend endpoint with `subject_payload` — at that point the workspace
+  preview goes away and the user's own positions render via the artifact path.
+- Nightly byte-compare Dagster job against real AGTHX zarr.

--- a/services/render-svc/render_svc/app.py
+++ b/services/render-svc/render_svc/app.py
@@ -14,6 +14,7 @@ import xarray as xr
 from fastapi import Body, FastAPI, HTTPException, Response
 from pydantic import BaseModel, Field
 
+from .artifacts import ArtifactRenderRequest, render_artifact
 from .gcs import GcsObjectStore, ObjectStore
 from .portfolio_evolution import KERNEL_VERSION, compute_portfolio_evolution
 from .render import (
@@ -130,6 +131,31 @@ def _make_app(settings: Settings, store: ObjectStore) -> FastAPI:
             headers={
                 "X-Canonical-Path": f"gs://{settings.bucket}/{result.gcs_path}",
                 "X-Cache-Written": "1" if result.written_to_cache else "0",
+            },
+        )
+
+    @app.post("/artifacts/render")
+    def post_artifacts_render(req: ArtifactRenderRequest = Body(...)):
+        """Artifact registry render endpoint — see render_svc.artifacts.
+
+        Cache-first; live-renders on GCS miss by importing
+        `bwmacro.snapshots.artifacts.{slug}.{version}` and calling its
+        `render_data` / `render_figure`. Phase 1B scope: fund subjects +
+        as_of='latest'. See ARTIFACT_REGISTRY_PHASE_1B_PLAN.md §10.
+        """
+        data, mime, gcs_path, resolved_as_of, cache_control = render_artifact(
+            req,
+            store=store,
+            prefix=settings.prefix,
+            persist=settings.persist_renders,
+        )
+        return Response(
+            content=data,
+            media_type=mime,
+            headers={
+                "X-Artifact-GCS-Path": f"gs://{settings.bucket}/{gcs_path}",
+                "X-Artifact-Resolved-As-Of": resolved_as_of,
+                "Cache-Control": cache_control,
             },
         )
 

--- a/services/render-svc/render_svc/artifacts.py
+++ b/services/render-svc/render_svc/artifacts.py
@@ -1,0 +1,274 @@
+"""``POST /artifacts/render`` — Phase 1B artifact registry endpoint.
+
+Cache-first artifact rendering for the artifact registry described in
+``BWMACRO/docs/architecture/intelligence_runtime/ARTIFACT_REGISTRY.md``.
+
+Request flow
+------------
+1. Validate the request shape (slug / version / subject_id / as_of / format).
+2. Resolve ``subject_kind`` from ``subject_id`` prefix.
+3. Load subject data via the public SDK (today: ``riskmodels.snapshots.
+   get_data_for_f1`` for funds).
+4. Compose the GCS key
+   ``{prefix}/artifacts/{slug}@{version}/{subject_id}/{resolved_as_of}.{ext}``.
+   ``resolved_as_of`` is whatever the loader actually picked (the SDK's
+   "latest valid period" today; an arbitrary historical as_of is Phase 2).
+5. Cache hit → return bytes.
+6. Cache miss → import ``bwmacro.snapshots.artifacts.{slug}.{version}``,
+   check ``subject_kind`` against the module's ``APPLICABLE_SUBJECT_KINDS``,
+   pick the matching adapter, render, write to GCS (idempotent on the
+   render-once key), return bytes.
+
+Phase 1B deliberately defers
+----------------------------
+- Postgres ``artifact_registry`` UPSERT — Dagster reconciliation job
+  populates the table from GCS in a follow-on. The GCS object existence
+  is the v1 source of truth.
+- Arbitrary historical ``as_of`` — the SDK loader doesn't yet accept an
+  as_of param; threading it through is a follow-on (returns 501 today).
+- ``subject_kind != fund`` — filer / ETF / cohort / client adapters land
+  as their Phase 2 artifact rows ship.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import logging
+from typing import Any, Callable, Literal
+
+from fastapi import HTTPException
+from pydantic import BaseModel, Field
+
+from .gcs import ObjectStore
+
+log = logging.getLogger(__name__)
+
+
+# Subject_id prefix → subject_kind, mirroring the artifact contract's
+# applicable_subject_kinds vocabulary.
+_SUBJECT_PREFIX_KIND: dict[str, str] = {
+    "BW-FUND-": "fund",
+    "BW-ETF-": "etf",
+    "BW-FILER-": "filer_13f",
+    "BW-COHORT-": "cohort",
+    "BW-STOCK-": "stock",
+}
+
+_FORMAT_MIME: dict[str, str] = {
+    "json": "application/json",
+    "png": "image/png",
+    "svg": "image/svg+xml",
+}
+
+
+class ArtifactRenderRequest(BaseModel):
+    """Request body for ``POST /artifacts/render``."""
+
+    slug: str = Field(..., min_length=1, max_length=64, pattern=r"^[a-z][a-z0-9_]*$")
+    version: str = Field(..., pattern=r"^v\d+$")
+    subject_id: str = Field(..., min_length=1, max_length=128)
+    as_of: str = Field(
+        ...,
+        description="ISO date 'YYYY-MM-DD' or the literal 'latest'",
+        pattern=r"^(latest|\d{4}-\d{2}-\d{2})$",
+    )
+    format: Literal["json", "png", "svg"] = "json"
+
+
+def _resolve_subject_kind(subject_id: str) -> str:
+    for prefix, kind in _SUBJECT_PREFIX_KIND.items():
+        if subject_id.startswith(prefix):
+            return kind
+    raise HTTPException(
+        status_code=422,
+        detail=(
+            f"Unrecognized subject_id prefix in {subject_id!r}; "
+            f"expected one of {sorted(_SUBJECT_PREFIX_KIND)}"
+        ),
+    )
+
+
+def _artifact_gcs_path(
+    prefix: str,
+    slug: str,
+    version: str,
+    subject_id: str,
+    resolved_as_of: str,
+    fmt: str,
+) -> str:
+    return f"{prefix.rstrip('/')}/artifacts/{slug}@{version}/{subject_id}/{resolved_as_of}.{fmt}"
+
+
+def _import_artifact_module(slug: str, version: str) -> Any:
+    """Lazy import of ``bwmacro.snapshots.artifacts.{slug}.{version}``."""
+    qualname = f"bwmacro.snapshots.artifacts.{slug}.{version}"
+    try:
+        return importlib.import_module(qualname)
+    except ImportError as exc:
+        log.warning("artifact module not found: %s", qualname)
+        raise HTTPException(
+            status_code=404,
+            detail=f"Artifact {slug}@{version} not found",
+        ) from exc
+
+
+def _adapter_for(slug: str, subject_kind: str) -> Callable[[Any], Any]:
+    """Resolve the adapter for ``(slug, subject_kind)``.
+
+    Phase 1B only wires the fund adapters. Filer / ETF / cohort / client
+    adapters land alongside their Phase 2 artifact rows in
+    ``BWMACRO/src/bwmacro/snapshots/artifacts/adapters.py``.
+    """
+    if subject_kind != "fund":
+        raise HTTPException(
+            status_code=501,
+            detail=(
+                f"subject_kind={subject_kind!r} adapter not yet wired "
+                f"(Phase 2 task; see ARTIFACT_REGISTRY.md §13)"
+            ),
+        )
+
+    from bwmacro.snapshots.artifacts import adapters
+
+    if slug == "top_holdings_erm_stacked":
+        return lambda fd: adapters.holdings_from_fund_data(fd, top_n=12)
+    if slug == "cumulative_return_strip":
+        return adapters.cumulative_return_series_from_fund_data
+
+    raise HTTPException(
+        status_code=501,
+        detail=(
+            f"No fund adapter wired for slug={slug!r} "
+            f"(add to bwmacro.snapshots.artifacts.adapters)"
+        ),
+    )
+
+
+def _load_subject_data(subject_id: str, subject_kind: str, as_of: str) -> Any:
+    """Load subject data + verify the loader's resolved as_of.
+
+    Phase 1B: only ``subject_kind == "fund"`` is wired, and only
+    ``as_of == "latest"`` (or an as_of matching the loader's resolved
+    latest_report_date) is supported. Arbitrary historical as_of is a
+    Phase 2 task (the SDK ``get_data_for_f1`` doesn't yet accept an
+    ``as_of`` parameter).
+    """
+    if subject_kind != "fund":
+        raise HTTPException(
+            status_code=501,
+            detail=f"subject_kind={subject_kind!r} loader not wired (Phase 2)",
+        )
+
+    from riskmodels.snapshots import get_data_for_f1
+
+    try:
+        fd = get_data_for_f1(subject_id)
+    except Exception as exc:  # noqa: BLE001
+        log.exception("get_data_for_f1 failed for %s", subject_id)
+        raise HTTPException(
+            status_code=502,
+            detail=f"Subject loader failed for {subject_id!r}: {exc}",
+        ) from exc
+
+    resolved = getattr(fd, "teo", None)
+    if not resolved:
+        raise HTTPException(
+            status_code=502,
+            detail=f"Subject {subject_id!r} has no resolved as_of from loader",
+        )
+
+    if as_of != "latest" and as_of != resolved:
+        raise HTTPException(
+            status_code=501,
+            detail=(
+                f"as_of={as_of!r} differs from loader's resolved {resolved!r}; "
+                f"specific historical as_of is Phase 2. Use as_of='latest' "
+                f"or as_of={resolved!r}."
+            ),
+        )
+
+    return fd, resolved
+
+
+def _render_bytes(mod: Any, data: Any, fmt: str) -> bytes:
+    """Materialize the artifact in the requested format."""
+    if fmt == "json":
+        return json.dumps(mod.render_data(data), separators=(",", ":")).encode("utf-8")
+    fig = mod.render_figure(data)
+    if fmt == "png":
+        return fig.to_image(format="png", scale=2.0)
+    if fmt == "svg":
+        return fig.to_image(format="svg")
+    raise HTTPException(status_code=400, detail=f"Unsupported format: {fmt!r}")
+
+
+def _cache_control_for(requested_as_of: str) -> str:
+    """Pick the Cache-Control header value.
+
+    Explicit ISO dates → forever-immutable (the render-once contract
+    means the bytes never change for that key). ``as_of=latest`` →
+    1 hour (so nightly re-renders propagate within the hour).
+    """
+    if requested_as_of == "latest":
+        return "public, max-age=3600"
+    return "public, max-age=31536000, immutable"
+
+
+def render_artifact(
+    req: ArtifactRenderRequest,
+    *,
+    store: ObjectStore,
+    prefix: str,
+    persist: bool = True,
+) -> tuple[bytes, str, str, str, str]:
+    """Render one artifact instance.
+
+    Returns ``(bytes, content_type, gcs_path, resolved_as_of, cache_control)``.
+    """
+    subject_kind = _resolve_subject_kind(req.subject_id)
+
+    subject_data, resolved_as_of = _load_subject_data(req.subject_id, subject_kind, req.as_of)
+
+    gcs_path = _artifact_gcs_path(
+        prefix, req.slug, req.version, req.subject_id, resolved_as_of, req.format
+    )
+
+    raw = store.read(gcs_path)
+    if raw is not None:
+        return (
+            raw,
+            _FORMAT_MIME[req.format],
+            gcs_path,
+            resolved_as_of,
+            _cache_control_for(req.as_of),
+        )
+
+    # Cache miss → live render.
+    mod = _import_artifact_module(req.slug, req.version)
+
+    applicable = tuple(getattr(mod, "APPLICABLE_SUBJECT_KINDS", ()))
+    if subject_kind not in applicable:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"Artifact {req.slug}@{req.version} not applicable to "
+                f"subject_kind={subject_kind!r} "
+                f"(supports: {list(applicable)})"
+            ),
+        )
+
+    adapter = _adapter_for(req.slug, subject_kind)
+    normalized = adapter(subject_data)
+    rendered = _render_bytes(mod, normalized, req.format)
+
+    if persist:
+        store.write(gcs_path, rendered, content_type=_FORMAT_MIME[req.format])
+
+    return (
+        rendered,
+        _FORMAT_MIME[req.format],
+        gcs_path,
+        resolved_as_of,
+        _cache_control_for(req.as_of),
+    )

--- a/services/render-svc/tests/test_artifacts.py
+++ b/services/render-svc/tests/test_artifacts.py
@@ -1,0 +1,328 @@
+"""Tests for the artifact registry endpoint (`POST /artifacts/render`).
+
+Uses the in-memory FakeStore from conftest. Mocks `riskmodels.snapshots.
+get_data_for_f1` + `bwmacro.snapshots.artifacts.adapters` so the test
+suite doesn't need GCS, zarr stores, or the BWMACRO sibling clone.
+
+Verifies:
+  - Cache hit path returns bytes directly without touching the live render.
+  - Cache miss path imports the artifact module, calls render_data /
+    render_figure, writes back, and returns bytes.
+  - Subject-kind validation (artifact's APPLICABLE_SUBJECT_KINDS).
+  - Unknown slug → 404.
+  - Arbitrary historical as_of → 501.
+  - Latest-as_of resolves to the loader's reported `teo`.
+  - Format MIME headers + Cache-Control vary correctly.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import types
+from dataclasses import dataclass, field
+from unittest.mock import patch
+
+import pytest
+
+from render_svc.artifacts import (
+    ArtifactRenderRequest,
+    _artifact_gcs_path,
+    _cache_control_for,
+    render_artifact,
+)
+
+
+PREFIX = "snapshots"
+
+
+# ── Fakes ─────────────────────────────────────────────────────────────────
+
+@dataclass
+class FakeFundData:
+    """Mimics the SDK's FundData where `teo` is the resolved as_of."""
+
+    teo: str = "2025-11-30"
+    bw_fund_id: str = "BW-FUND-S000004563"
+    holdings: list = field(default_factory=list)
+
+
+def _install_fake_bwmacro_artifact(monkeypatch, *, slug: str, version: str,
+                                    applicable: tuple[str, ...],
+                                    render_data_result: dict | None = None,
+                                    render_figure_result=None):
+    """Install a fake `bwmacro.snapshots.artifacts.{slug}.{version}` module."""
+    pkg_root = "bwmacro.snapshots.artifacts"
+    qualname = f"{pkg_root}.{slug}.{version}"
+
+    # Make the parent packages importable (empty namespace).
+    for p in [
+        "bwmacro",
+        "bwmacro.snapshots",
+        pkg_root,
+        f"{pkg_root}.{slug}",
+    ]:
+        if p not in sys.modules:
+            sys.modules[p] = types.ModuleType(p)
+
+    mod = types.ModuleType(qualname)
+    mod.ARTIFACT_SLUG = slug
+    mod.ARTIFACT_VERSION = version
+    mod.APPLICABLE_SUBJECT_KINDS = applicable
+    mod.render_data = lambda data: render_data_result or {"ok": True, "n": len(getattr(data, "items", data) or [])}
+
+    class _FakeFigure:
+        def to_image(self, *, format: str, scale: float = 1.0) -> bytes:
+            if format == "png":
+                return b"\x89PNG\r\n\x1a\nFAKE"
+            if format == "svg":
+                return b"<svg>FAKE</svg>"
+            raise ValueError(format)
+
+    mod.render_figure = lambda data: render_figure_result or _FakeFigure()
+    sys.modules[qualname] = mod
+
+    # Also seed a fake adapters module the endpoint will import.
+    adapters_qual = f"{pkg_root}.adapters"
+    if adapters_qual not in sys.modules:
+        adapters_mod = types.ModuleType(adapters_qual)
+        adapters_mod.holdings_from_fund_data = lambda fd, top_n=12: list(fd.holdings)[:top_n]
+        adapters_mod.cumulative_return_series_from_fund_data = lambda fd: []
+        sys.modules[adapters_qual] = adapters_mod
+        # Also expose the adapters under the package's attribute path so
+        # `from bwmacro.snapshots.artifacts import adapters` works.
+        sys.modules[pkg_root].adapters = adapters_mod  # type: ignore[attr-defined]
+    return mod
+
+
+def _patch_get_data_for_f1(monkeypatch, *, fd: FakeFundData):
+    """Install a fake `riskmodels.snapshots.get_data_for_f1` returning `fd`."""
+    fake_sdk_snapshots = types.ModuleType("riskmodels.snapshots.fake_stub_for_test")
+    # Patch the import the endpoint does:
+    #   from riskmodels.snapshots import get_data_for_f1
+    import riskmodels.snapshots as rs
+    monkeypatch.setattr(rs, "get_data_for_f1", lambda bw_fund_id, **kw: fd, raising=False)
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────
+
+
+def _req(**overrides):
+    base = dict(
+        slug="top_holdings_erm_stacked",
+        version="v1",
+        subject_id="BW-FUND-S000004563",
+        as_of="latest",
+        format="json",
+    )
+    base.update(overrides)
+    return ArtifactRenderRequest(**base)
+
+
+# ── Unit tests on helpers ─────────────────────────────────────────────────
+
+
+class TestPathBuilder:
+    def test_path_shape(self):
+        assert (
+            _artifact_gcs_path("snapshots", "top_holdings_erm_stacked", "v1",
+                               "BW-FUND-S000004563", "2025-11-30", "json")
+            == "snapshots/artifacts/top_holdings_erm_stacked@v1/BW-FUND-S000004563/2025-11-30.json"
+        )
+
+    def test_path_strips_trailing_slash(self):
+        assert (
+            _artifact_gcs_path("snapshots/", "x", "v1", "y", "2025-01-01", "png")
+            == "snapshots/artifacts/x@v1/y/2025-01-01.png"
+        )
+
+
+class TestCacheControl:
+    def test_latest_short(self):
+        assert _cache_control_for("latest") == "public, max-age=3600"
+
+    def test_explicit_date_immutable(self):
+        cc = _cache_control_for("2025-11-30")
+        assert "immutable" in cc
+        assert "max-age=31536000" in cc
+
+
+# ── Request validation ────────────────────────────────────────────────────
+
+
+class TestRequestValidation:
+    def test_invalid_slug_rejected(self):
+        with pytest.raises(ValueError):
+            ArtifactRenderRequest(
+                slug="Top-Holdings",  # bad: uppercase + hyphen
+                version="v1",
+                subject_id="BW-FUND-X",
+                as_of="latest",
+            )
+
+    def test_invalid_version_rejected(self):
+        with pytest.raises(ValueError):
+            ArtifactRenderRequest(
+                slug="top_holdings_erm_stacked",
+                version="1",  # bad: missing 'v' prefix
+                subject_id="BW-FUND-X",
+                as_of="latest",
+            )
+
+    def test_invalid_as_of_rejected(self):
+        with pytest.raises(ValueError):
+            ArtifactRenderRequest(
+                slug="x",
+                version="v1",
+                subject_id="BW-FUND-X",
+                as_of="2025/11/30",  # bad separator
+            )
+
+    def test_unknown_format_rejected(self):
+        with pytest.raises(ValueError):
+            ArtifactRenderRequest(
+                slug="x",
+                version="v1",
+                subject_id="BW-FUND-X",
+                as_of="latest",
+                format="pdf",  # not in Literal["json", "png", "svg"]
+            )
+
+
+# ── End-to-end render path ────────────────────────────────────────────────
+
+
+class TestRenderArtifactCacheMiss:
+    def test_json_render_fund_subject(self, store, monkeypatch):
+        _install_fake_bwmacro_artifact(
+            monkeypatch,
+            slug="top_holdings_erm_stacked",
+            version="v1",
+            applicable=("fund",),
+            render_data_result={"slug": "top_holdings_erm_stacked", "rows": []},
+        )
+        _patch_get_data_for_f1(monkeypatch, fd=FakeFundData(teo="2025-11-30"))
+
+        data, mime, gcs_path, resolved_as_of, cache_control = render_artifact(
+            _req(), store=store, prefix=PREFIX,
+        )
+
+        assert mime == "application/json"
+        body = json.loads(data)
+        assert body["slug"] == "top_holdings_erm_stacked"
+        assert resolved_as_of == "2025-11-30"
+        assert gcs_path == "snapshots/artifacts/top_holdings_erm_stacked@v1/BW-FUND-S000004563/2025-11-30.json"
+        assert cache_control == "public, max-age=3600"
+        # Bytes written to cache for subsequent hits.
+        assert gcs_path in store.objects
+
+    def test_png_render_uses_figure_path(self, store, monkeypatch):
+        _install_fake_bwmacro_artifact(
+            monkeypatch,
+            slug="top_holdings_erm_stacked",
+            version="v1",
+            applicable=("fund",),
+        )
+        _patch_get_data_for_f1(monkeypatch, fd=FakeFundData(teo="2025-11-30"))
+
+        data, mime, gcs_path, _, _ = render_artifact(
+            _req(format="png"), store=store, prefix=PREFIX,
+        )
+
+        assert mime == "image/png"
+        assert data.startswith(b"\x89PNG")
+        assert gcs_path.endswith(".png")
+
+    def test_explicit_as_of_matches_resolved_uses_immutable_cache(self, store, monkeypatch):
+        _install_fake_bwmacro_artifact(
+            monkeypatch,
+            slug="top_holdings_erm_stacked",
+            version="v1",
+            applicable=("fund",),
+        )
+        _patch_get_data_for_f1(monkeypatch, fd=FakeFundData(teo="2025-11-30"))
+
+        _, _, _, _, cache_control = render_artifact(
+            _req(as_of="2025-11-30"), store=store, prefix=PREFIX,
+        )
+        assert "immutable" in cache_control
+
+
+class TestRenderArtifactCacheHit:
+    def test_returns_cached_bytes_without_render(self, store, monkeypatch):
+        # Don't install a fake module — cache hit should never need to
+        # import it.
+        _patch_get_data_for_f1(monkeypatch, fd=FakeFundData(teo="2025-11-30"))
+        cached = b'{"cached":true}'
+        path = "snapshots/artifacts/top_holdings_erm_stacked@v1/BW-FUND-S000004563/2025-11-30.json"
+        store.write(path, cached, content_type="application/json")
+
+        data, mime, gcs_path, resolved_as_of, _ = render_artifact(
+            _req(), store=store, prefix=PREFIX, persist=False,
+        )
+
+        assert data == cached
+        assert mime == "application/json"
+        assert gcs_path == path
+        assert resolved_as_of == "2025-11-30"
+
+
+class TestRenderArtifactErrors:
+    def test_unknown_subject_prefix_returns_422(self, store, monkeypatch):
+        from fastapi import HTTPException
+        with pytest.raises(HTTPException) as exc:
+            render_artifact(
+                _req(subject_id="FOO-BAR-1"),
+                store=store, prefix=PREFIX,
+            )
+        assert exc.value.status_code == 422
+        assert "subject_id prefix" in str(exc.value.detail)
+
+    def test_etf_subject_returns_501(self, store, monkeypatch):
+        from fastapi import HTTPException
+        with pytest.raises(HTTPException) as exc:
+            render_artifact(
+                _req(subject_id="BW-ETF-IVV"),
+                store=store, prefix=PREFIX,
+            )
+        assert exc.value.status_code == 501
+        assert "subject_kind='etf'" in str(exc.value.detail)
+
+    def test_specific_historical_as_of_returns_501(self, store, monkeypatch):
+        _patch_get_data_for_f1(monkeypatch, fd=FakeFundData(teo="2025-11-30"))
+
+        from fastapi import HTTPException
+        with pytest.raises(HTTPException) as exc:
+            render_artifact(
+                _req(as_of="2024-12-31"),
+                store=store, prefix=PREFIX,
+            )
+        assert exc.value.status_code == 501
+        assert "Phase 2" in str(exc.value.detail)
+
+    def test_subject_kind_not_in_applicable_returns_422(self, store, monkeypatch):
+        _install_fake_bwmacro_artifact(
+            monkeypatch,
+            slug="top_holdings_erm_stacked",
+            version="v1",
+            applicable=("filer_13f",),  # excludes 'fund'
+        )
+        _patch_get_data_for_f1(monkeypatch, fd=FakeFundData(teo="2025-11-30"))
+
+        from fastapi import HTTPException
+        with pytest.raises(HTTPException) as exc:
+            render_artifact(_req(), store=store, prefix=PREFIX)
+        assert exc.value.status_code == 422
+        assert "not applicable" in str(exc.value.detail)
+
+    def test_unknown_slug_returns_404(self, store, monkeypatch):
+        _patch_get_data_for_f1(monkeypatch, fd=FakeFundData(teo="2025-11-30"))
+
+        from fastapi import HTTPException
+        with pytest.raises(HTTPException) as exc:
+            render_artifact(
+                _req(slug="nonexistent_artifact"),
+                store=store, prefix=PREFIX,
+            )
+        assert exc.value.status_code == 404
+        assert "nonexistent_artifact@v1" in str(exc.value.detail)


### PR DESCRIPTION
## Summary

Adds a Phase 1B-specific checklist to \`services/render-svc/RUNBOOK.md\` covering the four interactive-auth ops steps that turn the merged code into a live deployed endpoint:

1. **Secret Manager secret** \`github-bwmacro-read\` (PAT with read access to BlueWaterCorp/BWMACRO) + IAM grant to the Cloud Build SA.
2. **Cloud Build trigger** substitution: map \`_BWMACRO_GIT_TOKEN\` → the secret.
3. **Build + deploy** the artifact-registry-aware image; verify the Dockerfile §5 import-firewall smoke passes; smoke \`POST /artifacts/render\` for AGTHX.
4. **Vercel env**: set \`RENDER_SVC_URL\` on the Risk_Models project → redeploy → confirm the AHA panel preview ([Risk_Models #83](https://github.com/BlueWaterCorp/Risk_Models/pull/83)) renders.

Cross-repo SSOT pointer at the top so the operator can find the parent plan. Phase 2 follow-ons (Postgres UPSERT, arbitrary historical as_of, client_portfolio adapter, nightly byte-compare) listed at the bottom so they don't clutter the v1 path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)