### PR TITLE
feat(render-svc): subject_payload + client_portfolio dispatch

### DIFF
--- a/services/render-svc/render_svc/artifacts.py
+++ b/services/render-svc/render_svc/artifacts.py
@@ -32,9 +32,11 @@ Phase 1B deliberately defers
 
 from __future__ import annotations
 
+import hashlib
 import importlib
 import json
 import logging
+from datetime import datetime, timezone
 from typing import Any, Callable, Literal
 
 from fastapi import HTTPException
@@ -53,6 +55,7 @@ _SUBJECT_PREFIX_KIND: dict[str, str] = {
     "BW-FILER-": "filer_13f",
     "BW-COHORT-": "cohort",
     "BW-STOCK-": "stock",
+    "BW-PORTFOLIO-": "client_portfolio",
 }
 
 _FORMAT_MIME: dict[str, str] = {
@@ -74,6 +77,16 @@ class ArtifactRenderRequest(BaseModel):
         pattern=r"^(latest|\d{4}-\d{2}-\d{2})$",
     )
     format: Literal["json", "png", "svg"] = "json"
+    subject_payload: dict[str, Any] | None = Field(
+        default=None,
+        description=(
+            "Inline subject data for kinds the server can't resolve from a "
+            "stable identifier (today: client_portfolio). Required when "
+            "subject_kind == 'client_portfolio'; the GCS cache key is "
+            "derived from a stable hash of the payload so render-once "
+            "still holds for identical pastes."
+        ),
+    )
 
 
 def _resolve_subject_kind(subject_id: str) -> str:
@@ -116,33 +129,102 @@ def _import_artifact_module(slug: str, version: str) -> Any:
 def _adapter_for(slug: str, subject_kind: str) -> Callable[[Any], Any]:
     """Resolve the adapter for ``(slug, subject_kind)``.
 
-    Phase 1B only wires the fund adapters. Filer / ETF / cohort / client
-    adapters land alongside their Phase 2 artifact rows in
-    ``BWMACRO/src/bwmacro/snapshots/artifacts/adapters.py``.
+    Currently wired:
+      - fund: ``top_holdings_erm_stacked``, ``cumulative_return_strip``
+      - client_portfolio: ``top_holdings_erm_stacked``
+
+    Filer / ETF / cohort adapters land alongside their Phase 2 artifact
+    rows in ``BWMACRO/src/bwmacro/snapshots/artifacts/adapters.py``.
     """
-    if subject_kind != "fund":
+    from bwmacro.snapshots.artifacts import adapters
+
+    if subject_kind == "fund":
+        if slug == "top_holdings_erm_stacked":
+            return lambda fd: adapters.holdings_from_fund_data(fd, top_n=12)
+        if slug == "cumulative_return_strip":
+            return adapters.cumulative_return_series_from_fund_data
         raise HTTPException(
             status_code=501,
             detail=(
-                f"subject_kind={subject_kind!r} adapter not yet wired "
-                f"(Phase 2 task; see ARTIFACT_REGISTRY.md §13)"
+                f"No fund adapter wired for slug={slug!r} "
+                f"(add to bwmacro.snapshots.artifacts.adapters)"
             ),
         )
 
-    from bwmacro.snapshots.artifacts import adapters
-
-    if slug == "top_holdings_erm_stacked":
-        return lambda fd: adapters.holdings_from_fund_data(fd, top_n=12)
-    if slug == "cumulative_return_strip":
-        return adapters.cumulative_return_series_from_fund_data
+    if subject_kind == "client_portfolio":
+        if slug == "top_holdings_erm_stacked":
+            return lambda positions: adapters.holdings_from_client_portfolio(
+                positions, top_n=12
+            )
+        raise HTTPException(
+            status_code=501,
+            detail=(
+                f"No client_portfolio adapter wired for slug={slug!r} "
+                f"(only top_holdings_erm_stacked is widened so far)"
+            ),
+        )
 
     raise HTTPException(
         status_code=501,
         detail=(
-            f"No fund adapter wired for slug={slug!r} "
-            f"(add to bwmacro.snapshots.artifacts.adapters)"
+            f"subject_kind={subject_kind!r} adapter not yet wired "
+            f"(Phase 2 task; see ARTIFACT_REGISTRY.md §13)"
         ),
     )
+
+
+def _payload_hash(positions: list[dict]) -> str:
+    """Stable 16-char hex hash of a positions list (for the GCS cache key).
+
+    Round-trips the list through ``json.dumps(sort_keys=True)`` so two
+    equivalent payloads with different key ordering hash to the same
+    digest. Truncates to 16 hex chars (64 bits) — enough collision
+    resistance for an artifact-registry cache key, short enough to stay
+    readable in URLs and logs.
+    """
+    canonical = json.dumps(positions, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:16]
+
+
+def _resolve_client_portfolio(
+    req: "ArtifactRenderRequest",
+) -> tuple[list[dict], str, str]:
+    """Validate + resolve a client_portfolio request.
+
+    Returns ``(positions, resolved_subject_id, resolved_as_of)``.
+
+    - ``positions`` is the raw list from ``subject_payload['positions']``.
+    - ``resolved_subject_id`` is ``BW-PORTFOLIO-<payload-hash>`` so two
+      pastes of the same portfolio hit the same GCS key (render-once).
+    - ``resolved_as_of`` is today's UTC date when the request asks for
+      ``latest`` (a pasted portfolio is time-anchored to the paste), or
+      the literal ISO date the caller supplied.
+    """
+    if req.subject_payload is None:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "subject_payload is required for subject_kind='client_portfolio'. "
+                "Pass the workspace snapshot positions list under the "
+                "'positions' key."
+            ),
+        )
+    positions = req.subject_payload.get("positions")
+    if not isinstance(positions, list) or not positions:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "subject_payload.positions must be a non-empty list of "
+                "position rows (ticker / weight / l3_*_er fields)."
+            ),
+        )
+
+    resolved_subject_id = f"BW-PORTFOLIO-{_payload_hash(positions)}"
+    if req.as_of == "latest":
+        resolved_as_of = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    else:
+        resolved_as_of = req.as_of
+    return positions, resolved_subject_id, resolved_as_of
 
 
 def _load_subject_data(subject_id: str, subject_kind: str, as_of: str) -> Any:
@@ -228,10 +310,18 @@ def render_artifact(
     """
     subject_kind = _resolve_subject_kind(req.subject_id)
 
-    subject_data, resolved_as_of = _load_subject_data(req.subject_id, subject_kind, req.as_of)
+    if subject_kind == "client_portfolio":
+        # Subject data is supplied inline; cache key is payload-hash-derived.
+        subject_data, resolved_subject_id, resolved_as_of = _resolve_client_portfolio(req)
+    else:
+        # Loader-resolved path (fund today; etf / filer / cohort to follow).
+        subject_data, resolved_as_of = _load_subject_data(
+            req.subject_id, subject_kind, req.as_of
+        )
+        resolved_subject_id = req.subject_id
 
     gcs_path = _artifact_gcs_path(
-        prefix, req.slug, req.version, req.subject_id, resolved_as_of, req.format
+        prefix, req.slug, req.version, resolved_subject_id, resolved_as_of, req.format
     )
 
     raw = store.read(gcs_path)

--- a/services/render-svc/tests/test_artifacts.py
+++ b/services/render-svc/tests/test_artifacts.py
@@ -29,6 +29,7 @@ from render_svc.artifacts import (
     ArtifactRenderRequest,
     _artifact_gcs_path,
     _cache_control_for,
+    _payload_hash,
     render_artifact,
 )
 
@@ -326,3 +327,168 @@ class TestRenderArtifactErrors:
             )
         assert exc.value.status_code == 404
         assert "nonexistent_artifact@v1" in str(exc.value.detail)
+
+
+# ── client_portfolio subject_payload path ─────────────────────────────────
+
+
+def _patch_client_portfolio_adapter(monkeypatch):
+    """Wire a fake `holdings_from_client_portfolio` onto the bwmacro stub
+    package the test installs for `top_holdings_erm_stacked@v1`.
+
+    The adapter is called by the endpoint's client_portfolio dispatch
+    branch; without a fake it tries to import the real BWMACRO module.
+    """
+    _install_fake_bwmacro_artifact(
+        monkeypatch,
+        slug="top_holdings_erm_stacked",
+        version="v1",
+        applicable=("fund", "client_portfolio"),
+        render_data_result={
+            "slug": "top_holdings_erm_stacked",
+            "rows": [{"label": "NVDA", "weight_pct": 20.0}],
+        },
+    )
+    adapters_mod = sys.modules["bwmacro.snapshots.artifacts.adapters"]
+    adapters_mod.holdings_from_client_portfolio = (
+        lambda positions, top_n=12: list(positions)[:top_n]
+    )
+
+
+class TestPayloadHash:
+    def test_hash_is_stable_across_key_order(self):
+        a = [{"ticker": "NVDA", "weight": 0.2}, {"weight": 0.1, "ticker": "AAPL"}]
+        b = [{"weight": 0.2, "ticker": "NVDA"}, {"ticker": "AAPL", "weight": 0.1}]
+        assert _payload_hash(a) == _payload_hash(b)
+
+    def test_hash_changes_when_payload_changes(self):
+        a = [{"ticker": "NVDA", "weight": 0.2}]
+        b = [{"ticker": "NVDA", "weight": 0.3}]
+        assert _payload_hash(a) != _payload_hash(b)
+
+    def test_hash_is_16_chars(self):
+        h = _payload_hash([{"ticker": "X", "weight": 0.5}])
+        assert len(h) == 16
+        # hex-only
+        assert all(c in "0123456789abcdef" for c in h)
+
+
+class TestClientPortfolioPath:
+    def _payload(self):
+        return {
+            "positions": [
+                {"ticker": "NVDA", "weight": 0.2,
+                 "l3_mkt_er": 0.1, "l3_sec_er": 0.15,
+                 "l3_sub_er": 0.05, "l3_res_er": 0.7},
+                {"ticker": "AAPL", "weight": 0.1},
+            ]
+        }
+
+    def test_happy_path_renders_and_writes(self, store, monkeypatch):
+        _patch_client_portfolio_adapter(monkeypatch)
+        req = _req(
+            subject_id="BW-PORTFOLIO-",  # placeholder; server rewrites with hash
+            subject_payload=self._payload(),
+        )
+        data, mime, gcs_path, resolved_as_of, cache_control = render_artifact(
+            req, store=store, prefix=PREFIX,
+        )
+
+        assert mime == "application/json"
+        body = json.loads(data)
+        assert body["slug"] == "top_holdings_erm_stacked"
+
+        # GCS path uses BW-PORTFOLIO-<hash> + today's UTC date.
+        from datetime import datetime, timezone
+        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        expected_hash = _payload_hash(self._payload()["positions"])
+        expected_path = (
+            f"snapshots/artifacts/top_holdings_erm_stacked@v1/"
+            f"BW-PORTFOLIO-{expected_hash}/{today}.json"
+        )
+        assert gcs_path == expected_path
+        assert resolved_as_of == today
+        # `as_of=latest` cache-control is the short ttl for client_portfolio too.
+        assert cache_control == "public, max-age=3600"
+        # Persisted to the cache for subsequent identical pastes.
+        assert gcs_path in store.objects
+
+    def test_missing_subject_payload_returns_400(self, store, monkeypatch):
+        from fastapi import HTTPException
+        with pytest.raises(HTTPException) as exc:
+            render_artifact(
+                _req(subject_id="BW-PORTFOLIO-", subject_payload=None),
+                store=store, prefix=PREFIX,
+            )
+        assert exc.value.status_code == 400
+        assert "subject_payload" in str(exc.value.detail)
+
+    def test_empty_positions_returns_400(self, store, monkeypatch):
+        from fastapi import HTTPException
+        with pytest.raises(HTTPException) as exc:
+            render_artifact(
+                _req(
+                    subject_id="BW-PORTFOLIO-",
+                    subject_payload={"positions": []},
+                ),
+                store=store, prefix=PREFIX,
+            )
+        assert exc.value.status_code == 400
+        assert "positions" in str(exc.value.detail)
+
+    def test_non_list_positions_returns_400(self, store, monkeypatch):
+        from fastapi import HTTPException
+        with pytest.raises(HTTPException) as exc:
+            render_artifact(
+                _req(
+                    subject_id="BW-PORTFOLIO-",
+                    subject_payload={"positions": "not-a-list"},
+                ),
+                store=store, prefix=PREFIX,
+            )
+        assert exc.value.status_code == 400
+
+    def test_explicit_as_of_uses_immutable_cache(self, store, monkeypatch):
+        _patch_client_portfolio_adapter(monkeypatch)
+        _, _, gcs_path, resolved_as_of, cache_control = render_artifact(
+            _req(
+                subject_id="BW-PORTFOLIO-",
+                subject_payload=self._payload(),
+                as_of="2025-11-30",
+            ),
+            store=store, prefix=PREFIX,
+        )
+        assert resolved_as_of == "2025-11-30"
+        assert "/2025-11-30.json" in gcs_path
+        assert "immutable" in cache_control
+
+    def test_same_payload_hits_cache(self, store, monkeypatch):
+        """Two pastes of the same portfolio resolve to the same GCS key.
+
+        First call live-renders + writes. Second call hits the cache.
+        The fake adapter would return a different mutable object each
+        invocation, so cache identity means we hit step 1, not the adapter.
+        """
+        _patch_client_portfolio_adapter(monkeypatch)
+        req1 = _req(
+            subject_id="BW-PORTFOLIO-",
+            subject_payload=self._payload(),
+        )
+        data1, _, gcs_path1, _, _ = render_artifact(req1, store=store, prefix=PREFIX)
+
+        # Swap the adapter to return something obviously different — proves
+        # the second call comes from cache, not from a fresh render.
+        adapters_mod = sys.modules["bwmacro.snapshots.artifacts.adapters"]
+        adapters_mod.holdings_from_client_portfolio = lambda positions, top_n=12: []
+        mod = sys.modules["bwmacro.snapshots.artifacts.top_holdings_erm_stacked.v1"]
+        mod.render_data = lambda data: {"slug": "DIFFERENT", "rows": []}
+
+        req2 = _req(
+            subject_id="BW-PORTFOLIO-",
+            subject_payload=self._payload(),  # identical payload
+        )
+        data2, _, gcs_path2, _, _ = render_artifact(req2, store=store, prefix=PREFIX)
+
+        assert gcs_path1 == gcs_path2
+        assert data1 == data2  # cached bytes, not the new fake's bytes
+        assert b"DIFFERENT" not in data2


### PR DESCRIPTION
## Summary

Extends \`POST /artifacts/render\` with an optional \`subject_payload\` field and routes \`subject_kind == 'client_portfolio'\` (new \`BW-PORTFOLIO-*\` prefix) through the workspace-positions adapter shipped in BWMACRO [#14](https://github.com/BlueWaterCorp/BWMACRO/pull/14). The .net workspace can now render the user's pasted portfolio through the same artifact path AGTHX uses.

## What ships

- **\`ArtifactRenderRequest.subject_payload: dict | None\`** — required when \`subject_kind == 'client_portfolio'\`. GCS cache key is derived from a stable hash of \`positions\` so two pastes of the same portfolio collide on the same key.

- **New subject prefix** \`BW-PORTFOLIO-\` → \`client_portfolio\`. Caller passes \`subject_id='BW-PORTFOLIO-'\` (placeholder); server rewrites to \`BW-PORTFOLIO-<sha256(payload)[:16]>\` for the GCS key.

- **\`_resolve_client_portfolio(req)\`**:
  - 400 when \`subject_payload\` missing or \`positions\` not a non-empty list
  - \`resolved_as_of = today's UTC date\` for \`as_of=='latest'\` (pastes are time-anchored)
  - \`resolved_subject_id = BW-PORTFOLIO-<payload-hash>\`

- **\`_adapter_for(slug, 'client_portfolio')\`** routes \`top_holdings_erm_stacked\` to \`adapters.holdings_from_client_portfolio\`.

- **\`_payload_hash\`**: \`sha256(json.dumps(positions, sort_keys=True))[:16]\` — 64 bits of collision resistance, deterministic across key-order permutations.

## Tests

**26/26 passing** (+9 new):
- \`TestPayloadHash\`: stable across key order, changes with payload, 16-char hex
- \`TestClientPortfolioPath\`: happy path, missing payload → 400, empty/non-list positions → 400, explicit as_of → immutable cache, **same payload → cache hit** (proven by mutating the fake adapter between calls and asserting the bytes match the first call's output)

## Cache behavior

- Same paste → same hash → same GCS key → cache hit
- Different paste → different hash → different key → no cross-paste leakage
- \`as_of='latest'\` → \`max-age=3600\` (resolved date advances every UTC midnight); explicit ISO date → \`max-age=31536000, immutable\`

## Depends on

BWMACRO [#14](https://github.com/BlueWaterCorp/BWMACRO/pull/14) (client_portfolio adapter + APPLICABLE_SUBJECT_KINDS widen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)