### PR TITLE
feat(render-svc): X-Artifact-Receipt-Id header — masthead unification

### DIFF
--- a/services/render-svc/render_svc/app.py
+++ b/services/render-svc/render_svc/app.py
@@ -143,7 +143,7 @@ def _make_app(settings: Settings, store: ObjectStore) -> FastAPI:
         `render_data` / `render_figure`. Phase 1B scope: fund subjects +
         as_of='latest'. See ARTIFACT_REGISTRY_PHASE_1B_PLAN.md §10.
         """
-        data, mime, gcs_path, resolved_as_of, cache_control = render_artifact(
+        data, mime, gcs_path, resolved_as_of, cache_control, receipt_id = render_artifact(
             req,
             store=store,
             prefix=settings.prefix,
@@ -155,6 +155,7 @@ def _make_app(settings: Settings, store: ObjectStore) -> FastAPI:
             headers={
                 "X-Artifact-GCS-Path": f"gs://{settings.bucket}/{gcs_path}",
                 "X-Artifact-Resolved-As-Of": resolved_as_of,
+                "X-Artifact-Receipt-Id": receipt_id,
                 "Cache-Control": cache_control,
             },
         )

--- a/services/render-svc/render_svc/artifacts.py
+++ b/services/render-svc/render_svc/artifacts.py
@@ -285,6 +285,23 @@ def _render_bytes(mod: Any, data: Any, fmt: str) -> bytes:
     raise HTTPException(status_code=400, detail=f"Unsupported format: {fmt!r}")
 
 
+def _receipt_id(gcs_path: str) -> str:
+    """Stable 8-hex-char receipt token derived from the GCS path.
+
+    The masthead's "#run_seq" line on the LANDING workspace wants a short
+    versioned-record identifier. For artifact-registry-backed records this
+    is a deterministic hash of the GCS key (which already encodes
+    slug@version, subject_id, as_of, and format). Two views of the same
+    artifact instance share the same receipt id.
+
+    The portfolio_snapshots-backed path uses an integer ``run_seq`` from
+    its own table; the receipt id here looks visually identical when
+    rendered as "#a1b2c3d4". Soft unification per the artifact-registry →
+    LANDING handoff doc dated 2026-05-15.
+    """
+    return hashlib.sha256(gcs_path.encode("utf-8")).hexdigest()[:8]
+
+
 def _cache_control_for(requested_as_of: str) -> str:
     """Pick the Cache-Control header value.
 
@@ -303,10 +320,13 @@ def render_artifact(
     store: ObjectStore,
     prefix: str,
     persist: bool = True,
-) -> tuple[bytes, str, str, str, str]:
+) -> tuple[bytes, str, str, str, str, str]:
     """Render one artifact instance.
 
-    Returns ``(bytes, content_type, gcs_path, resolved_as_of, cache_control)``.
+    Returns ``(bytes, content_type, gcs_path, resolved_as_of, cache_control,
+    receipt_id)``. ``receipt_id`` is an 8-hex-char stable hash of the GCS
+    path — see ``_receipt_id`` for the LANDING-masthead unification
+    rationale.
     """
     subject_kind = _resolve_subject_kind(req.subject_id)
 
@@ -323,6 +343,7 @@ def render_artifact(
     gcs_path = _artifact_gcs_path(
         prefix, req.slug, req.version, resolved_subject_id, resolved_as_of, req.format
     )
+    receipt_id = _receipt_id(gcs_path)
 
     raw = store.read(gcs_path)
     if raw is not None:
@@ -332,6 +353,7 @@ def render_artifact(
             gcs_path,
             resolved_as_of,
             _cache_control_for(req.as_of),
+            receipt_id,
         )
 
     # Cache miss → live render.
@@ -361,4 +383,5 @@ def render_artifact(
         gcs_path,
         resolved_as_of,
         _cache_control_for(req.as_of),
+        receipt_id,
     )

--- a/services/render-svc/tests/test_artifacts.py
+++ b/services/render-svc/tests/test_artifacts.py
@@ -30,6 +30,7 @@ from render_svc.artifacts import (
     _artifact_gcs_path,
     _cache_control_for,
     _payload_hash,
+    _receipt_id,
     render_artifact,
 )
 
@@ -204,7 +205,7 @@ class TestRenderArtifactCacheMiss:
         )
         _patch_get_data_for_f1(monkeypatch, fd=FakeFundData(teo="2025-11-30"))
 
-        data, mime, gcs_path, resolved_as_of, cache_control = render_artifact(
+        data, mime, gcs_path, resolved_as_of, cache_control, receipt_id = render_artifact(
             _req(), store=store, prefix=PREFIX,
         )
 
@@ -214,6 +215,9 @@ class TestRenderArtifactCacheMiss:
         assert resolved_as_of == "2025-11-30"
         assert gcs_path == "snapshots/artifacts/top_holdings_erm_stacked@v1/BW-FUND-S000004563/2025-11-30.json"
         assert cache_control == "public, max-age=3600"
+        # Receipt-id is 8-hex-char stable hash of the GCS path.
+        assert len(receipt_id) == 8
+        assert all(c in "0123456789abcdef" for c in receipt_id)
         # Bytes written to cache for subsequent hits.
         assert gcs_path in store.objects
 
@@ -226,7 +230,7 @@ class TestRenderArtifactCacheMiss:
         )
         _patch_get_data_for_f1(monkeypatch, fd=FakeFundData(teo="2025-11-30"))
 
-        data, mime, gcs_path, _, _ = render_artifact(
+        data, mime, gcs_path, _, _, _ = render_artifact(
             _req(format="png"), store=store, prefix=PREFIX,
         )
 
@@ -243,7 +247,7 @@ class TestRenderArtifactCacheMiss:
         )
         _patch_get_data_for_f1(monkeypatch, fd=FakeFundData(teo="2025-11-30"))
 
-        _, _, _, _, cache_control = render_artifact(
+        _, _, _, _, cache_control, _ = render_artifact(
             _req(as_of="2025-11-30"), store=store, prefix=PREFIX,
         )
         assert "immutable" in cache_control
@@ -258,7 +262,7 @@ class TestRenderArtifactCacheHit:
         path = "snapshots/artifacts/top_holdings_erm_stacked@v1/BW-FUND-S000004563/2025-11-30.json"
         store.write(path, cached, content_type="application/json")
 
-        data, mime, gcs_path, resolved_as_of, _ = render_artifact(
+        data, mime, gcs_path, resolved_as_of, _, _ = render_artifact(
             _req(), store=store, prefix=PREFIX, persist=False,
         )
 
@@ -355,6 +359,36 @@ def _patch_client_portfolio_adapter(monkeypatch):
     )
 
 
+class TestReceiptId:
+    """8-hex-char stable hash of the GCS path — for the LANDING masthead.
+
+    The masthead's "#run_seq" token reads `run_seq` for snapshot-table-backed
+    records and this `receipt_id` for artifact-registry-backed records.
+    Both render identically in the UI.
+    """
+
+    def test_receipt_id_is_8_hex_chars(self):
+        rid = _receipt_id("snapshots/artifacts/x@v1/BW-FUND-Y/2025-11-30.json")
+        assert len(rid) == 8
+        assert all(c in "0123456789abcdef" for c in rid)
+
+    def test_receipt_id_is_deterministic(self):
+        path = "snapshots/artifacts/x@v1/BW-FUND-Y/2025-11-30.json"
+        assert _receipt_id(path) == _receipt_id(path)
+
+    def test_receipt_id_changes_with_path(self):
+        a = _receipt_id("snapshots/artifacts/x@v1/BW-FUND-Y/2025-11-30.json")
+        b = _receipt_id("snapshots/artifacts/x@v1/BW-FUND-Z/2025-11-30.json")
+        assert a != b
+
+    def test_receipt_id_distinguishes_format(self):
+        """Same artifact in JSON vs PNG → different receipt id (the GCS path
+        differs by extension, so the masthead reads distinct records)."""
+        json_rid = _receipt_id("snapshots/artifacts/x@v1/BW-FUND-Y/2025-11-30.json")
+        png_rid = _receipt_id("snapshots/artifacts/x@v1/BW-FUND-Y/2025-11-30.png")
+        assert json_rid != png_rid
+
+
 class TestPayloadHash:
     def test_hash_is_stable_across_key_order(self):
         a = [{"ticker": "NVDA", "weight": 0.2}, {"weight": 0.1, "ticker": "AAPL"}]
@@ -390,13 +424,17 @@ class TestClientPortfolioPath:
             subject_id="BW-PORTFOLIO-",  # placeholder; server rewrites with hash
             subject_payload=self._payload(),
         )
-        data, mime, gcs_path, resolved_as_of, cache_control = render_artifact(
+        data, mime, gcs_path, resolved_as_of, cache_control, receipt_id = render_artifact(
             req, store=store, prefix=PREFIX,
         )
 
         assert mime == "application/json"
         body = json.loads(data)
         assert body["slug"] == "top_holdings_erm_stacked"
+        # Receipt-id is the 8-hex-char hash of the gcs_path — proves the
+        # masthead can read a stable record identifier without parsing the path.
+        assert len(receipt_id) == 8
+        assert all(c in "0123456789abcdef" for c in receipt_id)
 
         # GCS path uses BW-PORTFOLIO-<hash> + today's UTC date.
         from datetime import datetime, timezone
@@ -450,7 +488,7 @@ class TestClientPortfolioPath:
 
     def test_explicit_as_of_uses_immutable_cache(self, store, monkeypatch):
         _patch_client_portfolio_adapter(monkeypatch)
-        _, _, gcs_path, resolved_as_of, cache_control = render_artifact(
+        _, _, gcs_path, resolved_as_of, cache_control, _ = render_artifact(
             _req(
                 subject_id="BW-PORTFOLIO-",
                 subject_payload=self._payload(),
@@ -474,7 +512,7 @@ class TestClientPortfolioPath:
             subject_id="BW-PORTFOLIO-",
             subject_payload=self._payload(),
         )
-        data1, _, gcs_path1, _, _ = render_artifact(req1, store=store, prefix=PREFIX)
+        data1, _, gcs_path1, _, _, _ = render_artifact(req1, store=store, prefix=PREFIX)
 
         # Swap the adapter to return something obviously different — proves
         # the second call comes from cache, not from a fresh render.
@@ -487,7 +525,7 @@ class TestClientPortfolioPath:
             subject_id="BW-PORTFOLIO-",
             subject_payload=self._payload(),  # identical payload
         )
-        data2, _, gcs_path2, _, _ = render_artifact(req2, store=store, prefix=PREFIX)
+        data2, _, gcs_path2, _, _, _ = render_artifact(req2, store=store, prefix=PREFIX)
 
         assert gcs_path1 == gcs_path2
         assert data1 == data2  # cached bytes, not the new fake's bytes


### PR DESCRIPTION
## Summary

Phase 1B follow-on (G — soft unification with LANDING). Exposes an 8-hex-char stable receipt-id on every artifact response so the LANDING workspace masthead can render a versioned-record identifier (\`#receipt_id\`) identically to the \`#run_seq\` line on \`portfolio_snapshots\`-backed views.

## What ships

- **\`_receipt_id(gcs_path)\`** — \`sha256(gcs_path)[:8]\`. Deterministic. Two views of the same artifact instance share the same id. Distinguishes formats (JSON vs PNG vs SVG) because the GCS path encodes the extension.
- **\`render_artifact(...)\` returns receipt_id** as a sixth tuple element. All existing callsites updated.
- **\`POST /artifacts/render\`** emits \`X-Artifact-Receipt-Id\` alongside the existing \`X-Artifact-GCS-Path\` + \`X-Artifact-Resolved-As-Of\` headers.

## Tests

**30/30 endpoint tests passing** (was 26, +4 for \`TestReceiptId\`: shape, determinism, path-sensitivity, format distinction). Existing tuple-unpack sites updated.

## Why

LANDING v2 §"Masthead" calls for a \`#run_seq\` identifier on the versioned-record line:

\`\`\`
RiskModels · Risk snapshot · Berkshire Hathaway 13F · 2026-Q1 · #4812
\`\`\`

\`portfolio_snapshots.run_seq\` (LANDING PR 1) serves that for snapshot-table-backed views. The artifact registry is content-addressed (no natural integer counter), so the receipt hash serves the same purpose: a stable short token rendered as \`#a1b2c3d4\` in the masthead. Both surfaces use a one-line \`#{token}\` pattern; the implementation differs underneath.

## Cross-repo companion

Risk_Models PR adds the proxy passthrough + \`fetchArtifact\` shim type + the workspace preview rendering it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)