### PR TITLE
feat(render-svc): filer_13f endpoint dispatch — Berkshire preload

### DIFF
--- a/services/render-svc/render_svc/artifacts.py
+++ b/services/render-svc/render_svc/artifacts.py
@@ -164,6 +164,17 @@ def _adapter_for(slug: str, subject_kind: str) -> Callable[[Any], Any]:
             ),
         )
 
+    if subject_kind == "filer_13f":
+        if slug == "top_holdings_erm_stacked":
+            return lambda fd: adapters.holdings_from_filer_data(fd, top_n=12)
+        raise HTTPException(
+            status_code=501,
+            detail=(
+                f"No filer_13f adapter wired for slug={slug!r} "
+                f"(only top_holdings_erm_stacked is widened so far)"
+            ),
+        )
+
     raise HTTPException(
         status_code=501,
         detail=(
@@ -225,6 +236,40 @@ def _resolve_client_portfolio(
     else:
         resolved_as_of = req.as_of
     return positions, resolved_subject_id, resolved_as_of
+
+
+def _resolve_filer_subject(req: "ArtifactRenderRequest") -> tuple[None, str, str]:
+    """Validate + resolve a filer_13f request.
+
+    Returns ``(subject_data=None, resolved_subject_id, resolved_as_of)``.
+
+    Filer subjects (Berkshire 13F, etc.) have **no SDK loader inside
+    render-svc** — the filer data lives behind `bwmacro.snapshots.filers.
+    _data.get_data_for_f1_filer` which reads from local zarrs and is part
+    of the private BWMACRO surface. The cache-hit path doesn't need
+    subject data (it returns bytes directly from GCS), so pre-rendered
+    filer artifacts work end-to-end. Cache miss for filer subjects
+    raises 501 — live-render requires the filer loader landing in
+    render-svc (Phase 2 follow-on).
+
+    For LANDING's Berkshire anonymous preload: the daily refresh job
+    pre-renders the artifact to GCS at an explicit `as_of` date (e.g.
+    `2026-03-31` for Berkshire's Q1 2026 13F); the workspace then
+    requests that exact date and gets a cache hit. `as_of="latest"`
+    is rejected because the server has no way to resolve "latest"
+    without a loader.
+    """
+    if req.as_of == "latest":
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "as_of='latest' not supported for subject_kind='filer_13f' "
+                "(no SDK loader inside render-svc to resolve the latest "
+                "filing date). Pass an explicit ISO date matching a "
+                "pre-rendered artifact."
+            ),
+        )
+    return None, req.subject_id, req.as_of
 
 
 def _load_subject_data(subject_id: str, subject_kind: str, as_of: str) -> Any:
@@ -313,8 +358,12 @@ def render_artifact(
     if subject_kind == "client_portfolio":
         # Subject data is supplied inline; cache key is payload-hash-derived.
         subject_data, resolved_subject_id, resolved_as_of = _resolve_client_portfolio(req)
+    elif subject_kind == "filer_13f":
+        # No SDK loader in render-svc — cache-hit path works for pre-rendered
+        # artifacts; cache miss raises 501 (live-render is Phase 2 follow-on).
+        subject_data, resolved_subject_id, resolved_as_of = _resolve_filer_subject(req)
     else:
-        # Loader-resolved path (fund today; etf / filer / cohort to follow).
+        # Loader-resolved path (fund today; etf / cohort to follow).
         subject_data, resolved_as_of = _load_subject_data(
             req.subject_id, subject_kind, req.as_of
         )
@@ -335,6 +384,22 @@ def render_artifact(
         )
 
     # Cache miss → live render.
+    if subject_kind == "filer_13f":
+        # No SDK loader inside render-svc means the adapter has no FilerData
+        # to consume. Pre-render the artifact via the LANDING daily refresh
+        # job (writes directly to gs://rm_api_public/.../artifacts/...) so
+        # subsequent requests hit the cache.
+        raise HTTPException(
+            status_code=501,
+            detail=(
+                f"Live render not supported for subject_kind='filer_13f'. "
+                f"Pre-render the artifact to GCS at "
+                f"{gcs_path!r} via the daily refresh job; "
+                f"subsequent requests will cache-hit. "
+                f"(Filer SDK loader inside render-svc is a Phase 2 follow-on.)"
+            ),
+        )
+
     mod = _import_artifact_module(req.slug, req.version)
 
     applicable = tuple(getattr(mod, "APPLICABLE_SUBJECT_KINDS", ()))

--- a/services/render-svc/tests/test_artifacts.py
+++ b/services/render-svc/tests/test_artifacts.py
@@ -492,3 +492,84 @@ class TestClientPortfolioPath:
         assert gcs_path1 == gcs_path2
         assert data1 == data2  # cached bytes, not the new fake's bytes
         assert b"DIFFERENT" not in data2
+
+
+# ── filer_13f subject (Phase 2 — LANDING Berkshire preload) ───────────────
+
+
+class TestFilerPath:
+    """Filer subjects use the pre-render-to-GCS path; cache hits work
+    end-to-end, cache misses raise 501 (no SDK loader inside render-svc).
+    """
+
+    BERKSHIRE = "BW-FILER-CIK0001067983"
+
+    def test_cache_hit_returns_pre_rendered_bytes(self, store, monkeypatch):
+        """The LANDING daily-refresh job pre-renders Berkshire artifacts
+        into GCS; subsequent requests hit the cache and never touch the
+        adapter chain."""
+        cached = b'{"slug":"top_holdings_erm_stacked","pre_rendered":true}'
+        path = (
+            "snapshots/artifacts/top_holdings_erm_stacked@v1/"
+            f"{self.BERKSHIRE}/2026-03-31.json"
+        )
+        store.write(path, cached, content_type="application/json")
+
+        data, mime, gcs_path, resolved_as_of, _ = render_artifact(
+            _req(subject_id=self.BERKSHIRE, as_of="2026-03-31"),
+            store=store, prefix=PREFIX, persist=False,
+        )
+
+        assert data == cached
+        assert mime == "application/json"
+        assert gcs_path == path
+        assert resolved_as_of == "2026-03-31"
+
+    def test_cache_miss_returns_501_with_pre_render_guidance(self, store, monkeypatch):
+        from fastapi import HTTPException
+        with pytest.raises(HTTPException) as exc:
+            render_artifact(
+                _req(subject_id=self.BERKSHIRE, as_of="2026-03-31"),
+                store=store, prefix=PREFIX,
+            )
+        assert exc.value.status_code == 501
+        msg = str(exc.value.detail)
+        assert "filer_13f" in msg
+        # Message tells the operator where to pre-render to.
+        assert "Pre-render" in msg or "pre-render" in msg
+        assert "daily refresh" in msg
+
+    def test_latest_as_of_rejected_for_filer(self, store):
+        from fastapi import HTTPException
+        with pytest.raises(HTTPException) as exc:
+            render_artifact(
+                _req(subject_id=self.BERKSHIRE, as_of="latest"),
+                store=store, prefix=PREFIX,
+            )
+        assert exc.value.status_code == 400
+        assert "latest" in str(exc.value.detail)
+        assert "filer_13f" in str(exc.value.detail)
+
+    def test_cache_hit_uses_immutable_cache_for_explicit_date(self, store):
+        cached = b'{"ok":true}'
+        path = (
+            "snapshots/artifacts/top_holdings_erm_stacked@v1/"
+            f"{self.BERKSHIRE}/2026-03-31.json"
+        )
+        store.write(path, cached, content_type="application/json")
+        _, _, _, _, cache_control = render_artifact(
+            _req(subject_id=self.BERKSHIRE, as_of="2026-03-31"),
+            store=store, prefix=PREFIX, persist=False,
+        )
+        assert "immutable" in cache_control
+
+    def test_subject_id_prefix_routing_for_filer(self, store):
+        """BW-FILER-* dispatches to filer_13f even when no cache + no payload."""
+        from fastapi import HTTPException
+        with pytest.raises(HTTPException) as exc:
+            render_artifact(
+                _req(subject_id="BW-FILER-CIK0000320193", as_of="2025-12-31"),
+                store=store, prefix=PREFIX,
+            )
+        # 501 (filer cache miss), not 422 (wrong prefix).
+        assert exc.value.status_code == 501


### PR DESCRIPTION
## Summary

Companion to BWMACRO [#19](https://github.com/BlueWaterCorp/BWMACRO/pull/19) (artifact widened to \`filer_13f\`). Wires render-svc to handle 13F filer subjects via the **pre-render-to-GCS** path: cache-hit returns bytes, cache-miss raises 501 with guidance on where to pre-render to.

## What ships

- **\`_adapter_for(slug, "filer_13f")\`** routes \`top_holdings_erm_stacked\` to \`bwmacro.snapshots.artifacts.adapters.holdings_from_filer_data\` (companion PR).
- **\`_resolve_filer_subject(req)\`** validates filer requests. Rejects \`as_of='latest'\` with 400 (no SDK loader to resolve the latest filing date); accepts explicit ISO dates that match a pre-rendered GCS object.
- **\`render_artifact(...)\`** branches on \`subject_kind == "filer_13f"\`:
  - **Cache-hit** returns pre-rendered bytes (common path for LANDING Berkshire preload).
  - **Cache-miss** raises 501 with the expected GCS path in the message — tells the operator exactly where the daily refresh job needs to write.

## Tests

**31/31 endpoint tests passing** (was 26, +5 for \`TestFilerPath\`): cache-hit returns pre-rendered bytes, cache-miss → 501 with guidance, \`as_of='latest'\` → 400, immutable cache-control for explicit dates, BW-FILER-* prefix routes correctly.

## Why this stops at 501 on cache miss

The filer data layer (\`bwmacro.snapshots.filers._data.get_data_for_f1_filer\`) reads from local zarrs and lives in the private BWMACRO surface. It's not in the SDK (\`riskmodels.snapshots\`), so render-svc can't load it directly. The pre-render path bypasses this: the LANDING daily refresh job runs in BWMACRO (full surface available), writes the artifact JSON to the registry's GCS prefix, and the workspace then cache-hits.

Live-render for filer subjects becomes possible once the filer loader lands in the SDK (Phase 2 follow-on).

## Depends on

BWMACRO [#19](https://github.com/BlueWaterCorp/BWMACRO/pull/19) (filer adapter + \`APPLICABLE_SUBJECT_KINDS\` widen)

🤖 Generated with [Claude Code](https://claude.com/claude-code)