### PR TITLE
feat(render-svc): filer_13f dispatch — entity_header + cumulative_return_strip

### DIFF
--- a/services/render-svc/render_svc/artifacts.py
+++ b/services/render-svc/render_svc/artifacts.py
@@ -167,11 +167,16 @@ def _adapter_for(slug: str, subject_kind: str) -> Callable[[Any], Any]:
     if subject_kind == "filer_13f":
         if slug == "top_holdings_erm_stacked":
             return lambda fd: adapters.holdings_from_filer_data(fd, top_n=12)
+        if slug == "cumulative_return_strip":
+            return adapters.cumulative_return_series_from_filer_data
+        if slug == "entity_header":
+            return adapters.entity_header_from_filer_data
         raise HTTPException(
             status_code=501,
             detail=(
                 f"No filer_13f adapter wired for slug={slug!r} "
-                f"(only top_holdings_erm_stacked is widened so far)"
+                f"(widen APPLICABLE_SUBJECT_KINDS on the artifact module + "
+                f"add the matching adapter in BWMACRO adapters.py)"
             ),
         )
 

--- a/services/render-svc/tests/test_artifacts.py
+++ b/services/render-svc/tests/test_artifacts.py
@@ -27,6 +27,7 @@ import pytest
 
 from render_svc.artifacts import (
     ArtifactRenderRequest,
+    _adapter_for,
     _artifact_gcs_path,
     _cache_control_for,
     _payload_hash,
@@ -573,3 +574,70 @@ class TestFilerPath:
             )
         # 501 (filer cache miss), not 422 (wrong prefix).
         assert exc.value.status_code == 501
+
+
+# ── _adapter_for routing — verifies filer_13f dispatches by slug ──────────
+
+
+class TestFilerAdapterRouting:
+    """Direct tests on `_adapter_for` for the filer_13f subject_kind.
+
+    Verifies the slug → adapter map without going through the full
+    cache-miss path (which raises 501 before the adapter is invoked).
+    Touches BWMACRO via the same fake-adapters stub used by other tests.
+    """
+
+    def test_top_holdings_routes_to_holdings_from_filer(self, monkeypatch):
+        _install_fake_bwmacro_artifact(
+            monkeypatch,
+            slug="top_holdings_erm_stacked",
+            version="v1",
+            applicable=("fund", "filer_13f"),
+        )
+        # Add the filer adapter to the fake adapters module.
+        adapters_mod = sys.modules["bwmacro.snapshots.artifacts.adapters"]
+        adapters_mod.holdings_from_filer_data = lambda fd, top_n=12: list(
+            getattr(fd, "holdings", [])
+        )[:top_n]
+        fn = _adapter_for("top_holdings_erm_stacked", "filer_13f")
+        assert callable(fn)
+
+    def test_cumulative_return_strip_routes_to_filer_returns(self, monkeypatch):
+        _install_fake_bwmacro_artifact(
+            monkeypatch,
+            slug="cumulative_return_strip",
+            version="v1",
+            applicable=("fund", "filer_13f"),
+        )
+        adapters_mod = sys.modules["bwmacro.snapshots.artifacts.adapters"]
+        adapters_mod.cumulative_return_series_from_filer_data = lambda fd: fd
+        fn = _adapter_for("cumulative_return_strip", "filer_13f")
+        assert fn is adapters_mod.cumulative_return_series_from_filer_data
+
+    def test_entity_header_routes_to_filer_header(self, monkeypatch):
+        _install_fake_bwmacro_artifact(
+            monkeypatch,
+            slug="entity_header",
+            version="v1",
+            applicable=("fund", "filer_13f"),
+        )
+        adapters_mod = sys.modules["bwmacro.snapshots.artifacts.adapters"]
+        adapters_mod.entity_header_from_filer_data = lambda fd: fd
+        fn = _adapter_for("entity_header", "filer_13f")
+        assert fn is adapters_mod.entity_header_from_filer_data
+
+    def test_unwidened_slug_returns_501(self, monkeypatch):
+        """Slugs that haven't been widened to filer_13f yet (e.g.
+        risk_summary_panel, return_composition_bars) raise 501 with a
+        helpful message pointing to BWMACRO adapters.py."""
+        _install_fake_bwmacro_artifact(
+            monkeypatch,
+            slug="risk_summary_panel",
+            version="v1",
+            applicable=("fund",),
+        )
+        from fastapi import HTTPException
+        with pytest.raises(HTTPException) as exc:
+            _adapter_for("risk_summary_panel", "filer_13f")
+        assert exc.value.status_code == 501
+        assert "BWMACRO adapters.py" in str(exc.value.detail)


### PR DESCRIPTION
## Summary

Companion to BWMACRO [#20](https://github.com/BlueWaterCorp/BWMACRO/pull/20) (adapter widening for the second two artifacts). Wires the new \`(slug, filer_13f)\` pairs into \`_adapter_for\` so LANDING's anonymous Berkshire preload can render an F1-shaped grid through the registry, not just the holdings bar.

**Stacked on [#74](https://github.com/BlueWaterCorp/RiskModels_API/pull/74)** (filer cache-miss path).

## What ships

\`_adapter_for(slug, "filer_13f")\` now routes:
- \`top_holdings_erm_stacked\` → \`holdings_from_filer_data\` (from #74)
- \`cumulative_return_strip\` → \`cumulative_return_series_from_filer_data\` (new)
- \`entity_header\` → \`entity_header_from_filer_data\` (new)

Other slugs return 501 with a clear message pointing at BWMACRO \`adapters.py\` — the artifact widening discipline is preserved.

## Tests

**+4 tests in \`TestFilerAdapterRouting\`** — each new slug routes to the correct adapter; un-widened slugs (e.g. \`risk_summary_panel\`) return 501 with the right error message. **35/35 endpoint tests passing** (was 31).

Cache behavior unchanged from #74: filer subjects use the pre-render-to-GCS path. Cache-hit returns bytes for any widened slug; cache-miss raises 501 with guidance.

## Depends on

- BWMACRO [#20](https://github.com/BlueWaterCorp/BWMACRO/pull/20) — adapter widening
- RiskModels_API [#74](https://github.com/BlueWaterCorp/RiskModels_API/pull/74) — filer cache-miss path (this PR's parent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)