### PR TITLE
feat(render-svc): filer_13f dispatch — return_composition_bars (+ #75 recovery)

### DIFF
--- a/services/render-svc/render_svc/artifacts.py
+++ b/services/render-svc/render_svc/artifacts.py
@@ -171,6 +171,8 @@ def _adapter_for(slug: str, subject_kind: str) -> Callable[[Any], Any]:
             return adapters.cumulative_return_series_from_filer_data
         if slug == "entity_header":
             return adapters.entity_header_from_filer_data
+        if slug == "return_composition_bars":
+            return adapters.attribution_waterfall_from_filer_data
         raise HTTPException(
             status_code=501,
             detail=(

--- a/services/render-svc/render_svc/artifacts.py
+++ b/services/render-svc/render_svc/artifacts.py
@@ -167,11 +167,16 @@ def _adapter_for(slug: str, subject_kind: str) -> Callable[[Any], Any]:
     if subject_kind == "filer_13f":
         if slug == "top_holdings_erm_stacked":
             return lambda fd: adapters.holdings_from_filer_data(fd, top_n=12)
+        if slug == "cumulative_return_strip":
+            return adapters.cumulative_return_series_from_filer_data
+        if slug == "entity_header":
+            return adapters.entity_header_from_filer_data
         raise HTTPException(
             status_code=501,
             detail=(
                 f"No filer_13f adapter wired for slug={slug!r} "
-                f"(only top_holdings_erm_stacked is widened so far)"
+                f"(widen APPLICABLE_SUBJECT_KINDS on the artifact module + "
+                f"add the matching adapter in BWMACRO adapters.py)"
             ),
         )
 

--- a/services/render-svc/tests/test_artifacts.py
+++ b/services/render-svc/tests/test_artifacts.py
@@ -27,6 +27,7 @@ import pytest
 
 from render_svc.artifacts import (
     ArtifactRenderRequest,
+    _adapter_for,
     _artifact_gcs_path,
     _cache_control_for,
     _payload_hash,
@@ -611,3 +612,70 @@ class TestFilerPath:
             )
         # 501 (filer cache miss), not 422 (wrong prefix).
         assert exc.value.status_code == 501
+
+
+# ── _adapter_for routing — verifies filer_13f dispatches by slug ──────────
+
+
+class TestFilerAdapterRouting:
+    """Direct tests on `_adapter_for` for the filer_13f subject_kind.
+
+    Verifies the slug → adapter map without going through the full
+    cache-miss path (which raises 501 before the adapter is invoked).
+    Touches BWMACRO via the same fake-adapters stub used by other tests.
+    """
+
+    def test_top_holdings_routes_to_holdings_from_filer(self, monkeypatch):
+        _install_fake_bwmacro_artifact(
+            monkeypatch,
+            slug="top_holdings_erm_stacked",
+            version="v1",
+            applicable=("fund", "filer_13f"),
+        )
+        # Add the filer adapter to the fake adapters module.
+        adapters_mod = sys.modules["bwmacro.snapshots.artifacts.adapters"]
+        adapters_mod.holdings_from_filer_data = lambda fd, top_n=12: list(
+            getattr(fd, "holdings", [])
+        )[:top_n]
+        fn = _adapter_for("top_holdings_erm_stacked", "filer_13f")
+        assert callable(fn)
+
+    def test_cumulative_return_strip_routes_to_filer_returns(self, monkeypatch):
+        _install_fake_bwmacro_artifact(
+            monkeypatch,
+            slug="cumulative_return_strip",
+            version="v1",
+            applicable=("fund", "filer_13f"),
+        )
+        adapters_mod = sys.modules["bwmacro.snapshots.artifacts.adapters"]
+        adapters_mod.cumulative_return_series_from_filer_data = lambda fd: fd
+        fn = _adapter_for("cumulative_return_strip", "filer_13f")
+        assert fn is adapters_mod.cumulative_return_series_from_filer_data
+
+    def test_entity_header_routes_to_filer_header(self, monkeypatch):
+        _install_fake_bwmacro_artifact(
+            monkeypatch,
+            slug="entity_header",
+            version="v1",
+            applicable=("fund", "filer_13f"),
+        )
+        adapters_mod = sys.modules["bwmacro.snapshots.artifacts.adapters"]
+        adapters_mod.entity_header_from_filer_data = lambda fd: fd
+        fn = _adapter_for("entity_header", "filer_13f")
+        assert fn is adapters_mod.entity_header_from_filer_data
+
+    def test_unwidened_slug_returns_501(self, monkeypatch):
+        """Slugs that haven't been widened to filer_13f yet (e.g.
+        risk_summary_panel, return_composition_bars) raise 501 with a
+        helpful message pointing to BWMACRO adapters.py."""
+        _install_fake_bwmacro_artifact(
+            monkeypatch,
+            slug="risk_summary_panel",
+            version="v1",
+            applicable=("fund",),
+        )
+        from fastapi import HTTPException
+        with pytest.raises(HTTPException) as exc:
+            _adapter_for("risk_summary_panel", "filer_13f")
+        assert exc.value.status_code == 501
+        assert "BWMACRO adapters.py" in str(exc.value.detail)

--- a/services/render-svc/tests/test_artifacts.py
+++ b/services/render-svc/tests/test_artifacts.py
@@ -554,7 +554,7 @@ class TestFilerPath:
         )
         store.write(path, cached, content_type="application/json")
 
-        data, mime, gcs_path, resolved_as_of, _ = render_artifact(
+        data, mime, gcs_path, resolved_as_of, _, _ = render_artifact(
             _req(subject_id=self.BERKSHIRE, as_of="2026-03-31"),
             store=store, prefix=PREFIX, persist=False,
         )
@@ -596,7 +596,7 @@ class TestFilerPath:
             f"{self.BERKSHIRE}/2026-03-31.json"
         )
         store.write(path, cached, content_type="application/json")
-        _, _, _, _, cache_control = render_artifact(
+        _, _, _, _, cache_control, _ = render_artifact(
             _req(subject_id=self.BERKSHIRE, as_of="2026-03-31"),
             store=store, prefix=PREFIX, persist=False,
         )
@@ -664,9 +664,21 @@ class TestFilerAdapterRouting:
         fn = _adapter_for("entity_header", "filer_13f")
         assert fn is adapters_mod.entity_header_from_filer_data
 
+    def test_return_composition_bars_routes_to_filer_waterfall(self, monkeypatch):
+        _install_fake_bwmacro_artifact(
+            monkeypatch,
+            slug="return_composition_bars",
+            version="v1",
+            applicable=("fund", "filer_13f"),
+        )
+        adapters_mod = sys.modules["bwmacro.snapshots.artifacts.adapters"]
+        adapters_mod.attribution_waterfall_from_filer_data = lambda fd: fd
+        fn = _adapter_for("return_composition_bars", "filer_13f")
+        assert fn is adapters_mod.attribution_waterfall_from_filer_data
+
     def test_unwidened_slug_returns_501(self, monkeypatch):
         """Slugs that haven't been widened to filer_13f yet (e.g.
-        risk_summary_panel, return_composition_bars) raise 501 with a
+        risk_summary_panel, active_risk_composition) raise 501 with a
         helpful message pointing to BWMACRO adapters.py."""
         _install_fake_bwmacro_artifact(
             monkeypatch,


### PR DESCRIPTION
## Summary

Companion to BWMACRO #21 (return_composition_bars filer adapter). Adds the fourth \`(slug, filer_13f)\` adapter route + folds back the orphaned PR #75 diff (cumulative_return_strip + entity_header filer routes — same stacked-PR-into-squash-merged-base pattern that hit #69 earlier).

End result: **all four** \`(top_holdings_erm_stacked, cumulative_return_strip, entity_header, return_composition_bars) × filer_13f\` routes wired together on main.

## What ships

- \`_adapter_for(slug, "filer_13f")\` routes \`return_composition_bars\` → \`adapters.attribution_waterfall_from_filer_data\`.
- Cherry-pick of PR [#75](https://github.com/BlueWaterCorp/RiskModels_API/pull/75) (cumulative_return_strip + entity_header routes) — squash-merged into the stacked-base but never reached main when #74 squash-merged.
- Tuple-unpack fixes for the 2 existing filer tests that were written pre-receipt-id (`_, _, _, _, cache_control = ...` → `_, _, _, _, cache_control, _ = ...`).

## Tests

**40/40 endpoint tests passing** (+1 new for return_composition_bars routing, +4 recovered from #75, +2 unpack fixes).

## Filer widening status (post-merge of this + BWMACRO #21)

**4/6 Phase 2 artifacts widened to filer_13f:**
- ✅ \`top_holdings_erm_stacked@v1\`
- ✅ \`cumulative_return_strip@v1\`
- ✅ \`entity_header@v1\`
- ✅ \`return_composition_bars@v1\` (this PR)

**Remaining:**
- \`risk_summary_panel@v1\` — consumes FundData directly via \`_section_iii_table.build_table_rows\`; needs a parallel \`_section_iii_table_filer\` or a refactor (dedicated PR).
- \`active_risk_composition@v1\` — needs \`total_vol_ann\` that FilerData doesn't carry; filer F1 dossier renders variance shares as direct % instead of vol pct.

## Depends on

BWMACRO #21 (return_composition_bars filer adapter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)