### PR TITLE
feat(render-svc): filer_13f dispatch — active_risk_composition

### DIFF
--- a/services/render-svc/render_svc/artifacts.py
+++ b/services/render-svc/render_svc/artifacts.py
@@ -173,6 +173,8 @@ def _adapter_for(slug: str, subject_kind: str) -> Callable[[Any], Any]:
             return adapters.entity_header_from_filer_data
         if slug == "return_composition_bars":
             return adapters.attribution_waterfall_from_filer_data
+        if slug == "active_risk_composition":
+            return adapters.active_risk_composition_from_filer_data
         raise HTTPException(
             status_code=501,
             detail=(

--- a/services/render-svc/tests/test_artifacts.py
+++ b/services/render-svc/tests/test_artifacts.py
@@ -676,6 +676,18 @@ class TestFilerAdapterRouting:
         fn = _adapter_for("return_composition_bars", "filer_13f")
         assert fn is adapters_mod.attribution_waterfall_from_filer_data
 
+    def test_active_risk_composition_routes_to_filer_arc(self, monkeypatch):
+        _install_fake_bwmacro_artifact(
+            monkeypatch,
+            slug="active_risk_composition",
+            version="v1",
+            applicable=("fund", "filer_13f"),
+        )
+        adapters_mod = sys.modules["bwmacro.snapshots.artifacts.adapters"]
+        adapters_mod.active_risk_composition_from_filer_data = lambda fd: fd
+        fn = _adapter_for("active_risk_composition", "filer_13f")
+        assert fn is adapters_mod.active_risk_composition_from_filer_data
+
     def test_unwidened_slug_returns_501(self, monkeypatch):
         """Slugs that haven't been widened to filer_13f yet (e.g.
         risk_summary_panel, active_risk_composition) raise 501 with a


### PR DESCRIPTION
## Summary

Companion to BWMACRO [#23](https://github.com/BlueWaterCorp/BWMACRO/pull/23). Adds the **fifth** \`(slug, filer_13f)\` route, closing Berkshire preload endpoint coverage to 5/6 Phase 2 artifacts.

## What ships

- \`_adapter_for(slug, "filer_13f")\` routes \`active_risk_composition\` → \`adapters.active_risk_composition_from_filer_data\`.
- +1 routing test. **41/41 endpoint tests passing.**

## Filer dispatch table post-merge

- ✅ \`top_holdings_erm_stacked\`
- ✅ \`cumulative_return_strip\`
- ✅ \`entity_header\`
- ✅ \`return_composition_bars\`
- ✅ \`active_risk_composition\` (this PR)
- ❌ \`risk_summary_panel\` (FundData-coupled; dedicated refactor)

## Depends on

BWMACRO [#23](https://github.com/BlueWaterCorp/BWMACRO/pull/23) — adapter computes \`total_vol_ann\` from \`cumulative_gross\` series since FilerData doesn't carry the field directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)