### PR TITLE
feat(render-svc): filer_13f dispatch — risk_summary_panel (Phase 2 complete)

### DIFF
--- a/services/render-svc/render_svc/artifacts.py
+++ b/services/render-svc/render_svc/artifacts.py
@@ -175,6 +175,8 @@ def _adapter_for(slug: str, subject_kind: str) -> Callable[[Any], Any]:
             return adapters.attribution_waterfall_from_filer_data
         if slug == "active_risk_composition":
             return adapters.active_risk_composition_from_filer_data
+        if slug == "risk_summary_panel":
+            return adapters.risk_summary_panel_from_filer_data
         raise HTTPException(
             status_code=501,
             detail=(

--- a/services/render-svc/tests/test_artifacts.py
+++ b/services/render-svc/tests/test_artifacts.py
@@ -688,18 +688,33 @@ class TestFilerAdapterRouting:
         fn = _adapter_for("active_risk_composition", "filer_13f")
         assert fn is adapters_mod.active_risk_composition_from_filer_data
 
-    def test_unwidened_slug_returns_501(self, monkeypatch):
-        """Slugs that haven't been widened to filer_13f yet (e.g.
-        risk_summary_panel, active_risk_composition) raise 501 with a
-        helpful message pointing to BWMACRO adapters.py."""
+    def test_risk_summary_panel_routes_to_filer_pass_through(self, monkeypatch):
+        """Phase 2 close-out: risk_summary_panel is the 6th and last
+        widened artifact. Adapter is a pass-through (the artifact's
+        render_data dispatches on FundData vs FilerData internally)."""
         _install_fake_bwmacro_artifact(
             monkeypatch,
             slug="risk_summary_panel",
+            version="v1",
+            applicable=("fund", "filer_13f"),
+        )
+        adapters_mod = sys.modules["bwmacro.snapshots.artifacts.adapters"]
+        adapters_mod.risk_summary_panel_from_filer_data = lambda fd: fd
+        fn = _adapter_for("risk_summary_panel", "filer_13f")
+        assert fn is adapters_mod.risk_summary_panel_from_filer_data
+
+    def test_unwidened_slug_returns_501(self, monkeypatch):
+        """All Phase 2 slugs are widened — this test exercises the 501
+        path with a hypothetical un-widened slug. Use a stub slug that's
+        registered as fund-only to assert the helpful error message."""
+        _install_fake_bwmacro_artifact(
+            monkeypatch,
+            slug="not_yet_widened_slug",
             version="v1",
             applicable=("fund",),
         )
         from fastapi import HTTPException
         with pytest.raises(HTTPException) as exc:
-            _adapter_for("risk_summary_panel", "filer_13f")
+            _adapter_for("not_yet_widened_slug", "filer_13f")
         assert exc.value.status_code == 501
         assert "BWMACRO adapters.py" in str(exc.value.detail)


### PR DESCRIPTION
## Summary

Wires \`risk_summary_panel\` into the \`filer_13f\` branch of \`_adapter_for\`. **Closes Phase 2 filer widening on the render-svc side** — all 6 Phase 2 artifacts now dispatch correctly for \`filer_13f\` subjects.

Pairs with BWMACRO [#25](https://github.com/BlueWaterCorp/BWMACRO/pull/25) which adds the BWMACRO-side adapter + the parallel filer row builder.

## How

Two lines added to \`_adapter_for(slug, subject_kind)\`:

\`\`\`python
if slug == "risk_summary_panel":
    return adapters.risk_summary_panel_from_filer_data
\`\`\`

Adapter is a **pass-through** — \`risk_summary_panel\` bypasses the typed-contract convention used by other artifacts. Its \`render_data\` dispatches on FundData vs FilerData internally, so the adapter just returns the FilerData unchanged.

## Test churn

The pre-existing \`test_unwidened_slug_returns_501\` used \`risk_summary_panel\` as its un-widened example. Since \`risk_summary_panel\` is now widened, the test would have produced a misleading green. Reworked it to use a hypothetical stub slug so the 501 path stays covered as more artifacts are widened in the future.

## Verified

- [x] \`pytest tests/test_artifacts.py\` — 42 passed (was 41)
- [x] All 6 Phase 2 artifacts now have filer_13f dispatch:
  - top_holdings_erm_stacked
  - cumulative_return_strip
  - entity_header
  - return_composition_bars
  - active_risk_composition
  - **risk_summary_panel** (this PR)

## Coordination

BWMACRO #25 should land first since this PR's dispatch path references the BWMACRO adapter. \`scripts/check-stacked-pr.sh\` confirms this is a leaf branch — safe to squash-merge once BWMACRO #25 is on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)