### PR TITLE
feat(sdk): Supabase enrichment + identity fallback in get_data_for_f1 (P.1 + P.2)

### DIFF
--- a/sdk/riskmodels/snapshots/_fund_data.py
+++ b/sdk/riskmodels/snapshots/_fund_data.py
@@ -11,7 +11,7 @@ shares backed by RiskModels Supabase reads; pip consumers work without keys.
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Any
 
@@ -601,20 +601,208 @@ def _open_fund_zarr(bw_fund_id: str, store: str):
 
 
 def _fund_identity(bw_fund_id: str) -> dict[str, Any]:
-    """Read identity (ticker, fund_name, equity_style_9box) from funds.json.
+    """Read identity (ticker, fund_name, equity_style_9box, latest_*) for a fund.
 
-    The funds_latest.json fixture omits these display fields; funds.json
-    is the canonical identity registry. Returns ``{}`` on miss.
+    Tries two sources in priority order:
+
+    1. **Local ``funds.json``** under the path resolved by
+       :func:`_funds_latest_path` (sibling Funds_DAG clone, or
+       ``FUNDS_DAG_DATA_ROOT`` if set). This is the canonical source
+       on a laptop where the Funds_DAG clone is checked out next to
+       this repo.
+    2. **Supabase ``public.funds``** (fallback). Used when the local
+       file isn't present — the production Cloud Run case where the
+       SDK is installed under ``site-packages`` and the sibling path
+       doesn't exist, but Supabase credentials ARE wired.
+
+    Returns ``{}`` if neither source has the fund. This is the
+    structural half of MASTER_BACKLOG P.2 / O.9 (the operational
+    half — wiring ``FUNDS_DAG_DATA_ROOT`` on Cloud Run — stays
+    operator-side and is independent of this fix).
     """
     import json
     p = _funds_latest_path().parent / "funds.json"
-    if not p.exists():
+    if p.exists():
+        rows = json.loads(p.read_text())
+        for row in rows:
+            if row.get("bw_fund_id") == bw_fund_id:
+                return row
+    # Local funds.json unavailable (Cloud Run case) — try Supabase.
+    return _fund_identity_from_supabase(bw_fund_id)
+
+
+# ---------------------------------------------------------------------------
+# Supabase enrichment — moved from BWMACRO/src/bwmacro/snapshots/funds/_data.py
+# so the public SDK's get_data_for_f1 returns real tickers / fund identity by
+# default. Previously the enricher lived only in the BWMACRO renderer wrapper,
+# so render-svc (which calls the public SDK directly) bypassed it entirely
+# and rendered raw FIGI/symbol IDs (MASTER_BACKLOG P.1). All Supabase reads
+# soft-fail to an empty result when credentials are missing — pip consumers
+# without keys still work, the holdings just don't get enriched.
+# ---------------------------------------------------------------------------
+
+
+def _supabase_creds() -> tuple[str, str] | None:
+    """Resolve Supabase URL + key from env. Returns ``None`` when missing.
+
+    Checks both the server-style (``SUPABASE_URL`` + ``SUPABASE_SERVICE_ROLE_KEY``)
+    and Next.js-frontend-style (``NEXT_PUBLIC_SUPABASE_URL`` +
+    ``NEXT_PUBLIC_SUPABASE_ANON_KEY``) conventions so callers don't have to
+    care which one is wired in any given env.
+    """
+    import os
+    url = (
+        os.environ.get("SUPABASE_URL")
+        or os.environ.get("NEXT_PUBLIC_SUPABASE_URL")
+        or ""
+    ).strip().strip('"').strip("'").rstrip("/")
+    key = (
+        os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
+        or os.environ.get("NEXT_PUBLIC_SUPABASE_ANON_KEY")
+        or ""
+    ).strip().strip('"').strip("'")
+    if not url or not key:
+        return None
+    return url, key
+
+
+def _supabase_query(path: str, params: dict[str, str]) -> list[dict[str, Any]]:
+    """GET ``{SUPABASE_URL}/rest/v1/{path}?{params}`` and return rows.
+
+    Soft-fails (returns ``[]``) when credentials are missing or the request
+    raises — render-svc and pip consumers without keys behave as if the
+    enrichment didn't happen rather than crashing.
+    """
+    creds = _supabase_creds()
+    if creds is None:
+        return []
+    url, key = creds
+    try:
+        import httpx
+        r = httpx.get(
+            f"{url}/rest/v1/{path}",
+            params=params,
+            headers={"apikey": key, "Authorization": f"Bearer {key}"},
+            timeout=15,
+        )
+        r.raise_for_status()
+        rows = r.json()
+        return rows if isinstance(rows, list) else []
+    except Exception:
+        return []
+
+
+def _fund_identity_from_supabase(bw_fund_id: str) -> dict[str, Any]:
+    """Query ``public.funds`` for the fund identity row.
+
+    Returns the same shape ``funds.json`` rows would have — ``ticker``,
+    ``fund_name``, ``equity_style_9box``, ``latest_report_date``,
+    ``latest_total_adj_mv`` — so callers can treat both sources
+    interchangeably. ``{}`` when not found.
+    """
+    rows = _supabase_query(
+        "funds",
+        {
+            "bw_fund_id": f"eq.{bw_fund_id}",
+            "select": (
+                "bw_fund_id,ticker,fund_name,equity_style_9box,"
+                "latest_report_date,latest_total_adj_mv"
+            ),
+            "limit": "1",
+        },
+    )
+    return rows[0] if rows else {}
+
+
+def _resolve_holdings_metadata(symbols: list[str]) -> dict[str, dict[str, Any]]:
+    """Resolve ``symbol → {ticker, name, sector_etf, subsector_etf}``."""
+    if not symbols:
         return {}
-    rows = json.loads(p.read_text())
-    for row in rows:
-        if row.get("bw_fund_id") == bw_fund_id:
-            return row
-    return {}
+    in_clause = "(" + ",".join(symbols) + ")"
+    rows = _supabase_query(
+        "symbols",
+        {"symbol": f"in.{in_clause}", "select": "symbol,ticker,name,sector_etf,subsector_etf"},
+    )
+    return {r["symbol"]: r for r in rows}
+
+
+def _resolve_l3_decomposition(symbols: list[str]) -> dict[str, dict[str, float]]:
+    """Resolve ``symbol → ERM3 L3 explained-variance share dict``."""
+    if not symbols:
+        return {}
+    in_clause = "(" + ",".join(symbols) + ")"
+    rows = _supabase_query(
+        "security_history_latest",
+        {
+            "symbol": f"in.{in_clause}",
+            "periodicity": "eq.daily",
+            "select": "symbol,l3_mkt_er,l3_sec_er,l3_sub_er,l3_res_er",
+        },
+    )
+    return {
+        r["symbol"]: {
+            "market_share": float(r["l3_mkt_er"] or 0.0),
+            "sector_share": float(r["l3_sec_er"] or 0.0),
+            "subsector_share": float(r["l3_sub_er"] or 0.0),
+            "residual_share": float(r["l3_res_er"] or 0.0),
+        }
+        for r in rows
+    }
+
+
+def _share_or_fallback(
+    shares: dict[str, float],
+    key: str,
+    fallback: float | None,
+) -> float | None:
+    if not shares:
+        return fallback
+    v = shares.get(key)
+    return fallback if v is None else float(v)
+
+
+def enrich_fund_data_with_supabase(fd: FundData) -> FundData:
+    """Resolve tickers / sector ETFs / per-stock L3 shares for holdings.
+
+    The public SDK's ``get_data_for_f1`` calls this by default so renders
+    show real tickers (``AAPL``) instead of raw symbol/FIGI IDs
+    (``BW-FIGI-BBG000B9XRY4``). Soft-fails to an unchanged ``FundData``
+    when Supabase credentials are not wired (pip consumers; CI tests
+    without env access) — never raises.
+
+    Returns the input unchanged when holdings are empty.
+    """
+    if not fd.holdings:
+        return fd
+
+    syms = [h.symbol for h in fd.holdings]
+    ticker_map = _resolve_holdings_metadata(syms)
+    l3_map = _resolve_l3_decomposition(syms)
+    new_holdings: list[FundHolding] = []
+    for h in fd.holdings:
+        meta = ticker_map.get(h.symbol, {})
+        shares = l3_map.get(h.symbol, {})
+        new_holdings.append(
+            FundHolding(
+                symbol=h.symbol,
+                ticker=meta.get("ticker") or h.ticker,
+                company_name=(
+                    meta.get("name") or meta.get("ticker") or h.company_name
+                ),
+                weight=h.weight,
+                sector_etf=meta.get("sector_etf") or h.sector_etf,
+                subsector_etf=meta.get("subsector_etf") or h.subsector_etf,
+                market_share=_share_or_fallback(
+                    shares, "market_share", h.market_share),
+                sector_share=_share_or_fallback(
+                    shares, "sector_share", h.sector_share),
+                subsector_share=_share_or_fallback(
+                    shares, "subsector_share", h.subsector_share),
+                residual_share=_share_or_fallback(
+                    shares, "residual_share", h.residual_share),
+            )
+        )
+    return replace(fd, holdings=new_holdings)
 
 
 def get_data_for_f1(
@@ -624,6 +812,7 @@ def get_data_for_f1(
     benchmark_ticker: str = "SPY",        # ditto — benchmark wiring deferred
     top_n_holdings: int = 10,
     nav_lookback_months: int = 60,
+    enrich: bool = True,
 ) -> FundData:
     """Populate ``FundData`` directly from the per-fund GCS zarrs.
 
@@ -1170,7 +1359,7 @@ def get_data_for_f1(
         if pm is None and pm_naive is not None:
             pm = {**pm_naive, "_basis": "naive_top_n"}
 
-    return FundData(
+    fd = FundData(
         bw_fund_id=bw_fund_id,
         ticker_primary=ticker_primary,
         fund_name=fund_name,
@@ -1198,6 +1387,14 @@ def get_data_for_f1(
         peer_cohort_size=identity.get("n_funds_in_cell_at_report_date"),
         **fit_kw,
     )
+    # Default-enrich holdings against Supabase so render-svc + every other
+    # public-SDK consumer gets real tickers / sector ETFs / per-stock L3
+    # shares. Soft-fails when Supabase creds aren't wired (returns ``fd``
+    # unchanged); callers can pass ``enrich=False`` to skip the round-trip
+    # entirely. Closes MASTER_BACKLOG P.1.
+    if enrich:
+        fd = enrich_fund_data_with_supabase(fd)
+    return fd
 
 
 __all__ = [

--- a/sdk/tests/test_fund_data_supabase_enrichment.py
+++ b/sdk/tests/test_fund_data_supabase_enrichment.py
@@ -1,0 +1,388 @@
+"""Public SDK enrichment + identity-fallback tests (MASTER_BACKLOG P.1 + P.2).
+
+P.1 — render-svc and other public-SDK consumers used to render raw FIGI /
+symbol IDs (e.g. ``BW-FIGI-BBG000B9XRY4``) instead of tickers because the
+Supabase ticker-enrichment helper lived in BWMACRO (a private renderer
+wrapper), not in the SDK that render-svc calls. The fix moves the
+enricher into the public SDK and chains it by default.
+
+P.2 — ``_fund_identity()`` used to return ``{}`` silently when local
+``funds.json`` wasn't on disk (Cloud Run case). The fix adds a Supabase
+``public.funds`` fallback so identity resolves from real data when the
+local file path doesn't resolve.
+
+Both paths **soft-fail** when Supabase credentials aren't wired — pip
+consumers and offline CI builds keep working; the holdings just aren't
+enriched and identity returns ``{}``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from riskmodels.snapshots import _fund_data
+from riskmodels.snapshots._fund_data import (
+    FundData,
+    FundHolding,
+    _fund_identity,
+    _fund_identity_from_supabase,
+    _resolve_holdings_metadata,
+    _resolve_l3_decomposition,
+    _supabase_creds,
+    _supabase_query,
+    enrich_fund_data_with_supabase,
+)
+
+
+# ---------------------------------------------------------------------------
+# Supabase credential resolution
+# ---------------------------------------------------------------------------
+
+
+def test_supabase_creds_returns_none_when_both_unset(monkeypatch):
+    for var in (
+        "SUPABASE_URL",
+        "SUPABASE_SERVICE_ROLE_KEY",
+        "NEXT_PUBLIC_SUPABASE_URL",
+        "NEXT_PUBLIC_SUPABASE_ANON_KEY",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    assert _supabase_creds() is None
+
+
+def test_supabase_creds_prefers_server_style(monkeypatch):
+    """SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY takes precedence when both
+    conventions are present."""
+    monkeypatch.setenv("SUPABASE_URL", "https://server.supabase.co")
+    monkeypatch.setenv("SUPABASE_SERVICE_ROLE_KEY", "server-key")
+    monkeypatch.setenv("NEXT_PUBLIC_SUPABASE_URL", "https://anon.supabase.co")
+    monkeypatch.setenv("NEXT_PUBLIC_SUPABASE_ANON_KEY", "anon-key")
+    creds = _supabase_creds()
+    assert creds == ("https://server.supabase.co", "server-key")
+
+
+def test_supabase_creds_falls_back_to_next_public(monkeypatch):
+    """When only the Next.js-style env vars are set, those are used."""
+    for var in ("SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("NEXT_PUBLIC_SUPABASE_URL", "https://x.supabase.co/")  # trailing slash
+    monkeypatch.setenv("NEXT_PUBLIC_SUPABASE_ANON_KEY", '"quoted-key"')  # quotes
+    creds = _supabase_creds()
+    # Trailing slash stripped; quotes stripped.
+    assert creds == ("https://x.supabase.co", "quoted-key")
+
+
+def test_supabase_query_returns_empty_when_no_creds(monkeypatch):
+    """Soft-fail: when credentials missing, queries return [] (not raise)."""
+    monkeypatch.setattr(_fund_data, "_supabase_creds", lambda: None)
+    assert _supabase_query("anything", {}) == []
+
+
+def test_supabase_query_soft_fails_on_httpx_exception(monkeypatch):
+    """Network error / HTTP error → [], not raise."""
+    monkeypatch.setattr(
+        _fund_data, "_supabase_creds", lambda: ("https://x", "k")
+    )
+
+    class _FakeHttpx:
+        @staticmethod
+        def get(*_args, **_kwargs):
+            raise RuntimeError("network down")
+
+    monkeypatch.setitem(__import__("sys").modules, "httpx", _FakeHttpx)
+    assert _supabase_query("funds", {}) == []
+
+
+# ---------------------------------------------------------------------------
+# Identity fallback chain (P.2)
+# ---------------------------------------------------------------------------
+
+
+def test_fund_identity_prefers_local_funds_json(monkeypatch, tmp_path):
+    """When local funds.json exists, it wins — Supabase fallback is NOT
+    queried (preserves laptop-developer behavior)."""
+    funds_json = tmp_path / "funds.json"
+    funds_json.write_text(
+        '[{"bw_fund_id": "BW-FUND-TEST", "ticker": "TEST", "fund_name": "Local Test Fund"}]'
+    )
+    monkeypatch.setattr(
+        _fund_data, "_funds_latest_path", lambda: tmp_path / "funds_latest.json"
+    )
+
+    sb_called = {"n": 0}
+
+    def _spy(_id):
+        sb_called["n"] += 1
+        return {}
+
+    monkeypatch.setattr(_fund_data, "_fund_identity_from_supabase", _spy)
+
+    row = _fund_identity("BW-FUND-TEST")
+    assert row["ticker"] == "TEST"
+    assert row["fund_name"] == "Local Test Fund"
+    assert sb_called["n"] == 0  # Supabase NOT consulted
+
+
+def test_fund_identity_falls_back_to_supabase_when_funds_json_missing(
+    monkeypatch, tmp_path
+):
+    """Cloud Run case: funds.json doesn't exist → Supabase ``public.funds``
+    answers."""
+    monkeypatch.setattr(
+        _fund_data, "_funds_latest_path", lambda: tmp_path / "funds_latest.json"
+    )
+    # funds.json (sibling) does NOT exist on this tmp_path.
+
+    monkeypatch.setattr(
+        _fund_data,
+        "_fund_identity_from_supabase",
+        lambda bw: (
+            {
+                "bw_fund_id": bw,
+                "ticker": "AGTHX",
+                "fund_name": "American Growth Fund",
+                "equity_style_9box": "Large Growth",
+            }
+            if bw == "BW-FUND-S000004563"
+            else {}
+        ),
+    )
+
+    row = _fund_identity("BW-FUND-S000004563")
+    assert row["ticker"] == "AGTHX"
+    assert row["fund_name"] == "American Growth Fund"
+    assert row["equity_style_9box"] == "Large Growth"
+
+
+def test_fund_identity_returns_empty_when_neither_source_has_fund(
+    monkeypatch, tmp_path
+):
+    """All sources empty → still ``{}`` (the existing contract is preserved)."""
+    monkeypatch.setattr(
+        _fund_data, "_funds_latest_path", lambda: tmp_path / "funds_latest.json"
+    )
+    monkeypatch.setattr(_fund_data, "_fund_identity_from_supabase", lambda _id: {})
+    assert _fund_identity("BW-FUND-UNKNOWN") == {}
+
+
+def test_fund_identity_from_supabase_queries_public_funds(monkeypatch):
+    """Verifies the actual ``public.funds`` table is queried with the
+    right filter + select clause."""
+    captured: dict[str, Any] = {}  # noqa: F821 (Any from typing in source)
+
+    def _fake_query(path, params):
+        captured["path"] = path
+        captured["params"] = params
+        return [
+            {
+                "bw_fund_id": "BW-FUND-S000004563",
+                "ticker": "AGTHX",
+                "fund_name": "American Growth Fund",
+                "equity_style_9box": "Large Growth",
+                "latest_report_date": "2025-11-30",
+                "latest_total_adj_mv": 285_000_000_000.0,
+            }
+        ]
+
+    monkeypatch.setattr(_fund_data, "_supabase_query", _fake_query)
+    row = _fund_identity_from_supabase("BW-FUND-S000004563")
+    assert captured["path"] == "funds"
+    assert captured["params"]["bw_fund_id"] == "eq.BW-FUND-S000004563"
+    assert "ticker" in captured["params"]["select"]
+    assert "latest_report_date" in captured["params"]["select"]
+    assert row["ticker"] == "AGTHX"
+    assert row["latest_total_adj_mv"] == 285_000_000_000.0
+
+
+def test_fund_identity_from_supabase_returns_empty_when_not_found(monkeypatch):
+    monkeypatch.setattr(_fund_data, "_supabase_query", lambda _p, _params: [])
+    assert _fund_identity_from_supabase("BW-FUND-MISSING") == {}
+
+
+# ---------------------------------------------------------------------------
+# Holdings enrichment (P.1)
+# ---------------------------------------------------------------------------
+
+
+def _fund_with_holdings(
+    symbols: list[str] | None = None,
+) -> FundData:
+    """Minimal FundData carrying holdings keyed by symbol — what render-svc
+    sees before enrichment (raw FIGI symbols, no tickers)."""
+    if symbols is None:
+        symbols = ["BW-FIGI-AAPL", "BW-FIGI-MSFT"]
+    return FundData(
+        bw_fund_id="BW-FUND-TEST",
+        ticker_primary="TEST",
+        fund_name="Test Fund",
+        teo="2025-11-30",
+        equity_style_9box=None,
+        aum_usd=None,
+        holdings=[
+            FundHolding(
+                symbol=s,
+                ticker=s,  # pre-enrichment: ticker is just the raw symbol
+                company_name=s,
+                weight=1.0 / len(symbols),
+            )
+            for s in symbols
+        ],
+    )
+
+
+def test_enrich_populates_tickers_from_symbols_table(monkeypatch):
+    """The headline P.1 fix: holdings get real tickers from
+    Supabase ``symbols``."""
+    monkeypatch.setattr(
+        _fund_data,
+        "_resolve_holdings_metadata",
+        lambda syms: {
+            "BW-FIGI-AAPL": {
+                "symbol": "BW-FIGI-AAPL",
+                "ticker": "AAPL",
+                "name": "Apple Inc.",
+                "sector_etf": "XLK",
+                "subsector_etf": "SOXX",
+            },
+            "BW-FIGI-MSFT": {
+                "symbol": "BW-FIGI-MSFT",
+                "ticker": "MSFT",
+                "name": "Microsoft Corp.",
+                "sector_etf": "XLK",
+                "subsector_etf": None,
+            },
+        },
+    )
+    monkeypatch.setattr(_fund_data, "_resolve_l3_decomposition", lambda _syms: {})
+
+    fd = _fund_with_holdings()
+    out = enrich_fund_data_with_supabase(fd)
+    assert [h.ticker for h in out.holdings] == ["AAPL", "MSFT"]
+    assert out.holdings[0].company_name == "Apple Inc."
+    assert out.holdings[0].sector_etf == "XLK"
+
+
+def test_enrich_populates_l3_shares_from_security_history_latest(monkeypatch):
+    monkeypatch.setattr(_fund_data, "_resolve_holdings_metadata", lambda _syms: {})
+    monkeypatch.setattr(
+        _fund_data,
+        "_resolve_l3_decomposition",
+        lambda syms: {
+            "BW-FIGI-AAPL": {
+                "market_share": 0.55,
+                "sector_share": 0.20,
+                "subsector_share": 0.05,
+                "residual_share": 0.20,
+            },
+        },
+    )
+    fd = _fund_with_holdings(symbols=["BW-FIGI-AAPL"])
+    out = enrich_fund_data_with_supabase(fd)
+    h = out.holdings[0]
+    assert h.market_share == pytest.approx(0.55)
+    assert h.residual_share == pytest.approx(0.20)
+
+
+def test_enrich_soft_fails_when_supabase_unreachable(monkeypatch):
+    """No creds → enricher returns the FundData unchanged (no raise)."""
+    monkeypatch.setattr(_fund_data, "_supabase_creds", lambda: None)
+    fd = _fund_with_holdings()
+    out = enrich_fund_data_with_supabase(fd)
+    # Tickers unchanged (still the raw symbol strings).
+    assert [h.ticker for h in out.holdings] == ["BW-FIGI-AAPL", "BW-FIGI-MSFT"]
+
+
+def test_enrich_is_noop_on_empty_holdings():
+    fd = FundData(
+        bw_fund_id="BW-FUND-EMPTY",
+        ticker_primary="EMPTY",
+        fund_name="Empty",
+        teo="2025-11-30",
+        equity_style_9box=None,
+        aum_usd=None,
+        holdings=[],
+    )
+    out = enrich_fund_data_with_supabase(fd)
+    assert out is fd  # identity preserved when there's nothing to enrich
+
+
+def test_enrich_preserves_existing_values_when_supabase_returns_none(monkeypatch):
+    """If Supabase has the symbol but missing some fields, the existing
+    FundHolding values survive (None doesn't overwrite real data)."""
+    monkeypatch.setattr(
+        _fund_data,
+        "_resolve_holdings_metadata",
+        lambda _syms: {
+            "BW-FIGI-AAPL": {"symbol": "BW-FIGI-AAPL", "ticker": "AAPL"}
+        },
+    )
+    monkeypatch.setattr(_fund_data, "_resolve_l3_decomposition", lambda _syms: {})
+    # Pre-seed sector_etf via the fund directly.
+    fd = FundData(
+        bw_fund_id="BW-FUND-TEST",
+        ticker_primary="TEST",
+        fund_name="Test Fund",
+        teo="2025-11-30",
+        equity_style_9box=None,
+        aum_usd=None,
+        holdings=[
+            FundHolding(
+                symbol="BW-FIGI-AAPL",
+                ticker="BW-FIGI-AAPL",
+                company_name="BW-FIGI-AAPL",
+                weight=1.0,
+                sector_etf="PRE-EXISTING",
+            )
+        ],
+    )
+    out = enrich_fund_data_with_supabase(fd)
+    h = out.holdings[0]
+    assert h.ticker == "AAPL"
+    # sector_etf wasn't in the Supabase row → existing value preserved.
+    assert h.sector_etf == "PRE-EXISTING"
+
+
+# ---------------------------------------------------------------------------
+# get_data_for_f1 default-enrich behavior
+# ---------------------------------------------------------------------------
+
+
+def test_get_data_for_f1_default_enriches(monkeypatch):
+    """The headline contract change: render-svc now gets enriched
+    FundData by default."""
+    captured = {"called": False}
+
+    def _spy_enrich(fd):
+        captured["called"] = True
+        return fd
+
+    monkeypatch.setattr(_fund_data, "enrich_fund_data_with_supabase", _spy_enrich)
+    monkeypatch.setattr(_fund_data, "_fund_identity", lambda _id: {})
+    # All zarr stores soft-fail (no real data needed for the enrich-default test).
+    monkeypatch.setattr(
+        _fund_data,
+        "_open_fund_zarr",
+        lambda *_a, **_kw: (_ for _ in ()).throw(FileNotFoundError("test")),
+    )
+    _fund_data.get_data_for_f1("BW-FUND-TEST")
+    assert captured["called"] is True
+
+
+def test_get_data_for_f1_enrich_false_skips_supabase(monkeypatch):
+    """Opt-out path: ``enrich=False`` skips the Supabase round-trip
+    entirely (useful for tests + offline CI)."""
+    captured = {"called": False}
+
+    def _spy_enrich(fd):
+        captured["called"] = True
+        return fd
+
+    monkeypatch.setattr(_fund_data, "enrich_fund_data_with_supabase", _spy_enrich)
+    monkeypatch.setattr(_fund_data, "_fund_identity", lambda _id: {})
+    monkeypatch.setattr(
+        _fund_data,
+        "_open_fund_zarr",
+        lambda *_a, **_kw: (_ for _ in ()).throw(FileNotFoundError("test")),
+    )
+    _fund_data.get_data_for_f1("BW-FUND-TEST", enrich=False)
+    assert captured["called"] is False


### PR DESCRIPTION
## Summary

Closes the **two P0 silent-degradation gaps** from MASTER_BACKLOG section P (back-end Q/A audit).

### P.1 — wrong display data: render-svc was showing raw FIGI instead of tickers

\`enrich_fund_data_with_supabase\` lived only in BWMACRO's private renderer wrapper. The **public SDK** never enriched holdings, so render-svc (which calls the public SDK directly) rendered:

| Before | After |
|---|---|
| \`BW-FIGI-BBG000B9XRY4\` | \`AAPL\` |
| \`BW-FIGI-BBG000BPH459\` | \`MSFT\` |

The fix moves the enricher into the public SDK and defaults \`get_data_for_f1\` to chain it.

### P.2 — empty identity: \`_fund_identity()\` silently returned \`{}\` on Cloud Run

\`_fund_identity()\` read local \`funds.json\` only. In production (SDK installed under \`site-packages\`, sibling Funds_DAG path doesn't resolve, \`FUNDS_DAG_DATA_ROOT\` not wired), this returned \`{}\` so renders showed:

- \`fund_name = bw_fund_id\` (e.g. \`BW-FUND-S000004988\`)
- \`equity_style_9box = None\` (blank style box)

The fix adds a Supabase \`public.funds\` fallback so identity resolves from real data when the local file path doesn't.

## Soft-fail contract preserved

Both paths return empty when Supabase credentials aren't wired — pip consumers + offline CI keep working, the holdings just don't get enriched and identity returns \`{}\`. No new hard dependency on Supabase.

## Code change

New helpers in \`sdk/riskmodels/snapshots/_fund_data.py\`:

| Helper | Purpose |
|---|---|
| \`_supabase_creds()\` | Resolves URL + key; checks \`SUPABASE_*\` first, falls back to \`NEXT_PUBLIC_SUPABASE_*\` |
| \`_supabase_query()\` | REST GET wrapper; soft-fails to \`[]\` on any error |
| \`_fund_identity_from_supabase()\` | Queries \`public.funds\` for fund identity |
| \`_resolve_holdings_metadata()\` | Moved from BWMACRO — queries \`symbols\` table |
| \`_resolve_l3_decomposition()\` | Moved from BWMACRO — queries \`security_history_latest\` |
| \`enrich_fund_data_with_supabase()\` | Moved from BWMACRO — the public API |

\`get_data_for_f1\` gets a new \`enrich=True\` kw arg (opt-out for callers that don't want the Supabase round-trip).

## Test plan

- [x] **+17 new tests** in \`sdk/tests/test_fund_data_supabase_enrichment.py\`:
  - Credential resolution: server-style preferred, NEXT_PUBLIC fallback, neither → \`None\`
  - Soft-fails: query returns \`[]\` on no-creds + on network errors
  - Identity: local \`funds.json\` wins; Supabase fallback when missing; \`{}\` when neither has it; correct PostgREST filter + select for \`public.funds\`
  - Enrichment: tickers populated from \`symbols\`; L3 shares from \`security_history_latest\`; soft-fails when no creds; no-op on empty holdings; preserves existing values when Supabase row missing fields
  - \`get_data_for_f1\`: default-enriches; \`enrich=False\` skips
- [x] **Full SDK suite: 367 passed** (was 350, +17)
- [x] **render-svc suite: 81 passed** (unchanged — public contract preserved)

## Follow-ups

1. **BWMACRO double-enrich.** The BWMACRO wrapper \`get_data_for_f1\` (in \`BWMACRO/src/bwmacro/snapshots/funds/_data.py\`) still calls the public SDK and then chains its own \`enrich_fund_data_with_supabase\`. Now that the public path also enriches by default, BWMACRO does the Supabase round-trip twice (idempotent — same result, just slow). One-line BWMACRO PR coming: pass \`enrich=False\` to the public call.

2. **Operational half of O.9 still open.** This PR closes the **code-side** of P.2 by adding the Supabase fallback. The original O.9 operational fix — wiring \`FUNDS_DAG_DATA_ROOT\` on Cloud Run + baking \`funds.json\` to a GCS-mounted root — is still useful (faster than Supabase, and provides offline resilience).

3. **MASTER_BACKLOG P.7** (TEO encoding misalignment) is the next P1 candidate.

## Stacked-PR check

Leaf — no children stacked. Independent of RM_API #79 (teo_str fallback chain on a different code path). Safe to squash-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)