### PR TITLE
fix(sdk): extract _decode_teo_array helper — consistent TEO encoding (P.7)

### DIFF
--- a/sdk/riskmodels/snapshots/_fund_data.py
+++ b/sdk/riskmodels/snapshots/_fund_data.py
@@ -577,6 +577,62 @@ def load_fund_from_fixture(
 ZARR_FUNDS_GCS_PREFIX = "rm_api_data/ERM3_Funds"
 
 
+def _decode_teo_array(teo_arr: Any) -> "Any":  # numpy ndarray
+    """Decode a zarr ``teo`` array into a ``datetime64[D]`` numpy array.
+
+    Per-fund zarr stores written by Funds_DAG over time settled on three
+    different ``teo`` encodings, and the four read sites in this module
+    historically each decoded inline with subtly different logic:
+
+      1. **CF int days** — ``units = "days since YYYY-MM-DD"`` on the array
+         attrs. Post-2026-05 xarray-aware writers (e.g. ds_ph rewritten by
+         the holdings pipeline) emit this.
+      2. **CF int seconds** — ``units = "seconds since YYYY-MM-DD"`` (rare;
+         covered defensively).
+      3. **Legacy int seconds-since-Unix-epoch** — older writers (notably
+         ds_portfolio) wrote a plain int64 without a ``units`` attr; the
+         caller decoded by passing dtype ``datetime64[s]`` to numpy.
+      4. **Native datetime64** — ds_nav historically wrote already-decoded
+         datetime64 values; the caller naively ``str(t)``-stringified them.
+         If a writer started emitting CF int days here, the naive stringify
+         silently produced raw integers ("12345") instead of dates, and
+         those rotted forward as if they were dates — a P.7 / silent date
+         misalignment bug.
+
+    This helper centralizes the decoding decision so all four stores
+    produce the same ``datetime64[D]`` output regardless of which writer
+    flavor is on disk. Returns a numpy ``datetime64[D]`` array shaped
+    like the input.
+    """
+    import numpy as np
+
+    raw = teo_arr[:]
+
+    # Native datetime64 already on disk → cast to day precision.
+    if hasattr(raw, "dtype") and raw.dtype.kind == "M":
+        return raw.astype("datetime64[D]")
+
+    units = ""
+    try:
+        units = dict(teo_arr.attrs).get("units", "")
+    except (AttributeError, TypeError):
+        pass
+
+    if units.startswith("days since "):
+        epoch_str = units.removeprefix("days since ").split(" ")[0]
+        epoch = np.datetime64(epoch_str)
+        return (epoch + raw.astype("timedelta64[D]")).astype("datetime64[D]")
+
+    if units.startswith("seconds since "):
+        epoch_str = units.removeprefix("seconds since ").split(" ")[0]
+        epoch = np.datetime64(epoch_str)
+        return (epoch + raw.astype("timedelta64[s]")).astype("datetime64[D]")
+
+    # Legacy default: integer seconds-since-Unix-epoch. ds_portfolio.zarr
+    # writers used this convention without setting a units attr.
+    return np.asarray(raw, dtype="datetime64[s]").astype("datetime64[D]")
+
+
 def _open_fund_zarr(bw_fund_id: str, store: str):
     """Return an open zarr group for one of the per-fund stores on GCS.
 
@@ -863,25 +919,9 @@ def get_data_for_f1(
             mv_real = adj_mv[mask]
             n_holdings_total = int(mask.sum())
             aum_usd = float(ph_aum[idx])
-            # teo decoding: post-2026-05 ds_ph.zarr is xarray-CF-encoded
-            # ("days since YYYY-MM-DD"), not raw seconds-since-epoch. Read
-            # the units from .zattrs and decode accordingly. Falls back
-            # to the legacy seconds-since-epoch interpretation for older
-            # zarrs that may still be on GCS.
             if "teo" in ph.array_keys():
-                teo_arr = ph["teo"]
-                teo_units = dict(teo_arr.attrs).get("units", "")
-                raw_teo = int(teo_arr[idx])
-                if teo_units.startswith("days since "):
-                    epoch_str = teo_units.removeprefix("days since ").split(" ")[0]
-                    teo_str = str(
-                        (np.datetime64(epoch_str) + np.timedelta64(raw_teo, "D"))
-                        .astype("datetime64[D]")
-                    )
-                else:
-                    teo_str = np.datetime_as_string(
-                        np.array(raw_teo, dtype="datetime64[s]"), unit="D"
-                    )
+                teo_decoded = _decode_teo_array(ph["teo"])
+                teo_str = str(teo_decoded[idx])
             order = np.argsort(-mv_real)[:top_n_holdings]
             top_syms = [str(sym_real[i]) for i in order]
             ticker_map = {s: {} for s in top_syms}
@@ -912,10 +952,10 @@ def get_data_for_f1(
     tr_fund: dict[str, float | None] = {}
     try:
         nv = _open_fund_zarr(bw_fund_id, "ds_nav.zarr")
-        nav_teo = nv["teo"][:]
+        nav_teo_decoded = _decode_teo_array(nv["teo"])
         nav_ret = nv["nav_return_monthly"][:]
         finite = np.isfinite(nav_ret)
-        nav_teo_all = [str(t) for t in nav_teo[finite]]
+        nav_teo_all = [str(t) for t in nav_teo_decoded[finite]]
         nav_ret_all = nav_ret[finite].tolist()
         if len(nav_ret_all) >= 12:
             ttm_window = np.array(nav_ret_all[-12:])
@@ -997,14 +1037,11 @@ def get_data_for_f1(
             sec_arr = pt["portfolio_sector_return"][:]
             sub_arr = pt["portfolio_subsector_return"][:]
             res_arr = pt["portfolio_idiosyncratic_return"][:]
-            teo_arr = pt["teo"][:]
+            teo_decoded = _decode_teo_array(pt["teo"])
             for i in nz:
-                d = np.datetime_as_string(
-                    np.array(int(teo_arr[i]), dtype="datetime64[s]"),
-                    unit="D",
-                )
+                d = str(teo_decoded[i])
                 layer_series.append((
-                    str(d),
+                    d,
                     float(mkt_arr[i]),
                     float(sec_arr[i]),
                     float(sub_arr[i]),
@@ -1149,19 +1186,7 @@ def get_data_for_f1(
         lag_basis_arr = list(fr["lag_basis"][:])
         report_idx = lag_basis_arr.index("report_date")
 
-        fr_teo_raw = fr["teo"][:]            # int64 days since some epoch
-        # Decode by reading the .zattrs units. zarr Python doesn't auto-decode
-        # CF date units the way xarray does; pull the units string and
-        # apply ourselves so we don't pay the xarray import cost on every
-        # F1 render.
-        teo_attrs = dict(fr["teo"].attrs)
-        units = teo_attrs.get("units", "")
-        if units.startswith("days since "):
-            epoch = np.datetime64(units.removeprefix("days since ").split(" ")[0])
-            fr_teo = (epoch + fr_teo_raw.astype("timedelta64[D]")).astype("datetime64[D]")
-        else:
-            # Fallback: assume already a recognizable encoding.
-            fr_teo = np.asarray(fr_teo_raw, dtype="datetime64[ns]").astype("datetime64[D]")
+        fr_teo = _decode_teo_array(fr["teo"])
 
         gross_d = fr["gross_return"][:, report_idx]
         l1_d    = fr["l1_market"][:, report_idx]

--- a/sdk/tests/test_fund_data_teo_decoder.py
+++ b/sdk/tests/test_fund_data_teo_decoder.py
@@ -1,0 +1,197 @@
+"""``_decode_teo_array`` — shared TEO decoder tests (MASTER_BACKLOG P.7).
+
+Per-fund zarr stores written by Funds_DAG over time settled on three
+different ``teo`` encodings, and four read sites in ``_fund_data.py``
+historically each decoded inline with subtly different logic. The
+worst was ``ds_nav``'s naive ``[str(t) for t in nav_teo[finite]]`` —
+if a writer started emitting CF int-days here, the stringify silently
+produced raw integers (``"12345"``) instead of dates, and those rotted
+forward as if they were dates. Silent date misalignment in the F1's
+NAV-vs-attribution comparison (the central narrative).
+
+This module centralizes the decoding decision so all four stores
+produce the same ``datetime64[D]`` output regardless of writer flavor.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from riskmodels.snapshots._fund_data import _decode_teo_array
+
+
+class _FakeTeoArr:
+    """Minimal zarr-array stand-in: subscriptable + ``.attrs`` dict."""
+
+    def __init__(self, data: np.ndarray, attrs: dict | None = None) -> None:
+        self._data = data
+        self.attrs = attrs or {}
+
+    def __getitem__(self, idx):
+        return self._data[idx]
+
+
+# ---------------------------------------------------------------------------
+# Encoding 1: CF int days (post-2026-05 ds_ph writers)
+# ---------------------------------------------------------------------------
+
+
+def test_decodes_days_since_epoch():
+    """``units = "days since 1970-01-01"`` + int64 days → datetime64[D]."""
+    arr = _FakeTeoArr(
+        data=np.array([0, 366, 20454], dtype=np.int64),
+        attrs={"units": "days since 1970-01-01"},
+    )
+    out = _decode_teo_array(arr)
+    assert out.dtype == np.dtype("datetime64[D]")
+    assert str(out[0]) == "1970-01-01"
+    assert str(out[1]) == "1971-01-02"  # 1970 wasn't a leap year, 366 days later
+    assert str(out[2]) == "2026-01-01"  # 20454 days = ~56 years
+
+
+def test_decodes_days_since_non_epoch_origin():
+    """``units = "days since 2000-01-01"`` with a non-Unix origin
+    still decodes correctly."""
+    arr = _FakeTeoArr(
+        data=np.array([0, 1, 366], dtype=np.int64),
+        attrs={"units": "days since 2000-01-01"},
+    )
+    out = _decode_teo_array(arr)
+    assert str(out[0]) == "2000-01-01"
+    assert str(out[1]) == "2000-01-02"
+    assert str(out[2]) == "2001-01-01"  # 2000 was a leap year (366 days)
+
+
+def test_decodes_days_since_with_trailing_time_component():
+    """``units = "days since YYYY-MM-DD HH:MM:SS"`` (xarray sometimes
+    writes the full timestamp) — the helper strips after the first space."""
+    arr = _FakeTeoArr(
+        data=np.array([100], dtype=np.int64),
+        attrs={"units": "days since 1970-01-01 00:00:00"},
+    )
+    out = _decode_teo_array(arr)
+    assert str(out[0]) == "1970-04-11"
+
+
+# ---------------------------------------------------------------------------
+# Encoding 2: CF int seconds (less common but covered)
+# ---------------------------------------------------------------------------
+
+
+def test_decodes_seconds_since_epoch_via_units():
+    """``units = "seconds since 1970-01-01"`` → datetime64[D] via the
+    explicit seconds-since branch."""
+    arr = _FakeTeoArr(
+        data=np.array([0, 86400, 86400 * 366], dtype=np.int64),
+        attrs={"units": "seconds since 1970-01-01"},
+    )
+    out = _decode_teo_array(arr)
+    assert str(out[0]) == "1970-01-01"
+    assert str(out[1]) == "1970-01-02"
+    assert str(out[2]) == "1971-01-02"
+
+
+# ---------------------------------------------------------------------------
+# Encoding 3: legacy int seconds-since-Unix-epoch (no units attr)
+# ---------------------------------------------------------------------------
+
+
+def test_decodes_legacy_seconds_when_no_units_attr():
+    """``ds_portfolio.zarr`` historically wrote int seconds-since-Unix-epoch
+    with no ``units`` attr — the helper falls back to that interpretation."""
+    arr = _FakeTeoArr(
+        data=np.array([0, 86400, 1_700_000_000], dtype=np.int64),
+        attrs={},  # no units → legacy seconds-since-epoch path
+    )
+    out = _decode_teo_array(arr)
+    assert str(out[0]) == "1970-01-01"
+    assert str(out[1]) == "1970-01-02"
+    # 2023-11-14 UTC ≈ 1700000000 unix seconds.
+    assert str(out[2]) == "2023-11-14"
+
+
+def test_decodes_legacy_seconds_when_units_unrelated():
+    """An unrelated ``units`` attr (not 'days since' nor 'seconds since')
+    falls back to legacy seconds-since-epoch — defensive."""
+    arr = _FakeTeoArr(
+        data=np.array([0], dtype=np.int64),
+        attrs={"units": "something_else"},
+    )
+    out = _decode_teo_array(arr)
+    assert str(out[0]) == "1970-01-01"
+
+
+# ---------------------------------------------------------------------------
+# Encoding 4: native datetime64 already on disk
+# ---------------------------------------------------------------------------
+
+
+def test_passes_through_native_datetime64_day():
+    """An array already of dtype ``datetime64[D]`` passes through unchanged."""
+    raw = np.array(["2025-11-30", "2025-12-31"], dtype="datetime64[D]")
+    arr = _FakeTeoArr(data=raw)
+    out = _decode_teo_array(arr)
+    assert out.dtype == np.dtype("datetime64[D]")
+    assert str(out[0]) == "2025-11-30"
+    assert str(out[1]) == "2025-12-31"
+
+
+def test_casts_native_datetime64_seconds_to_day_precision():
+    """A native ``datetime64[s]`` array gets cast down to day precision —
+    so consumers always see ``datetime64[D]`` regardless of input precision."""
+    raw = np.array(["2025-11-30T14:30:00", "2025-12-31T23:59:59"], dtype="datetime64[s]")
+    arr = _FakeTeoArr(data=raw)
+    out = _decode_teo_array(arr)
+    assert out.dtype == np.dtype("datetime64[D]")
+    assert str(out[0]) == "2025-11-30"
+    assert str(out[1]) == "2025-12-31"
+
+
+def test_casts_native_datetime64_nanoseconds_to_day():
+    """``datetime64[ns]`` (xarray's default) also casts cleanly to day
+    precision — confirms the helper handles the precision range we see
+    in practice."""
+    raw = np.array(["2025-11-30"], dtype="datetime64[ns]")
+    arr = _FakeTeoArr(data=raw)
+    out = _decode_teo_array(arr)
+    assert out.dtype == np.dtype("datetime64[D]")
+    assert str(out[0]) == "2025-11-30"
+
+
+# ---------------------------------------------------------------------------
+# Shape preservation + the bug this helper exists to prevent
+# ---------------------------------------------------------------------------
+
+
+def test_output_shape_matches_input():
+    arr = _FakeTeoArr(
+        data=np.array([0, 100, 200, 300], dtype=np.int64),
+        attrs={"units": "days since 1970-01-01"},
+    )
+    out = _decode_teo_array(arr)
+    assert out.shape == (4,)
+
+
+def test_the_p7_silent_misalignment_regression():
+    """**The P.7 fix.** Before this helper, ``ds_nav``'s decoder was:
+
+        nav_teo_all = [str(t) for t in nav_teo[finite]]
+
+    If a writer started emitting CF int days here, ``str(int64_scalar)``
+    produces ``"12345"`` not ``"2025-12-08"``. That value then flowed
+    into nav_teo_all and was used as if it were a date string, causing
+    silent misalignment between the NAV chart and the attribution
+    waterfall in the F1.
+
+    This test verifies the helper produces real date strings for CF int
+    days input — what the naive decoder would have silently corrupted."""
+    arr = _FakeTeoArr(
+        data=np.array([20454], dtype=np.int64),  # would naively stringify to "20454"
+        attrs={"units": "days since 1970-01-01"},
+    )
+    out = _decode_teo_array(arr)
+    decoded = str(out[0])
+    # The naive str(int64) bug would yield "20454"; the helper yields a real date.
+    assert decoded != "20454"
+    assert decoded.startswith("20")  # 4-digit ISO year
+    assert decoded.count("-") == 2   # YYYY-MM-DD shape


### PR DESCRIPTION
## Summary

Closes **MASTER_BACKLOG P.7** — the highest-priority P1 from the back-end Q/A audit. Per-fund zarr stores emit three different \`teo\` encodings (CF days-since, CF seconds-since, legacy int seconds-since-Unix-epoch, native datetime64), and four read sites in \`get_data_for_f1\` historically each decoded inline with subtly different logic.

The worst was **\`ds_nav\`'s naive decoder**:

\`\`\`python
nav_teo_all = [str(t) for t in nav_teo[finite]]
\`\`\`

This assumes \`nav_teo\` is already-decoded \`datetime64\`. If a writer started emitting CF int days here (which happened on the ds_ph migration in 2026-05), \`str(int64_scalar)\` produces \`\"12345\"\` not \`\"2025-12-08\"\` — and that value rotted forward as if it were a date. Silent date misalignment between the NAV chart (ds_nav) and the attribution waterfall (ds_portfolio) would corrupt the F1's central NAV-vs-attribution comparison narrative — the user couldn't tell anything was wrong unless they cross-checked the JSON timestamps cell by cell.

## The fix

Single helper, four call sites:

\`\`\`python
def _decode_teo_array(teo_arr) -> ndarray[datetime64[D]]:
    raw = teo_arr[:]
    if raw.dtype.kind == \"M\":         # native datetime64 — cast to day precision
        return raw.astype(\"datetime64[D]\")
    units = dict(teo_arr.attrs).get(\"units\", \"\")
    if units.startswith(\"days since \"):     # CF int days
        ...
    if units.startswith(\"seconds since \"):  # CF int seconds
        ...
    return np.asarray(raw, dtype=\"datetime64[s]\").astype(\"datetime64[D]\")  # legacy fallback
\`\`\`

All four read sites (\`ds_ph\`, \`ds_nav\`, \`ds_portfolio\`, \`ds_fund_returns_daily\`) now call \`_decode_teo_array\` and get back a consistent \`datetime64[D]\` array regardless of which writer flavor is on disk.

| Site | Before | After |
|---|---|---|
| ds_ph block | 14-line if/else with manual epoch math | 2 lines |
| ds_nav block | naive \`str(t)\` (the bug) | shared helper |
| ds_portfolio block | assumed seconds, no units check | shared helper |
| ds_fund_returns_daily block | duplicated CF-decode logic | 1 line |

Net diff: **−39 lines / +261** (most of the +261 is test coverage).

## Test plan

- [x] **+11 new tests** in \`sdk/tests/test_fund_data_teo_decoder.py\`:
  - CF days-since-epoch decoding (Unix origin + non-Unix origin + trailing time component)
  - CF seconds-since-epoch via units
  - Legacy int seconds-since-Unix-epoch (no units attr — the ds_portfolio.zarr case)
  - Native datetime64 passthrough at D / s / ns precision
  - Shape preservation
  - **Explicit regression test for the P.7 silent-misalignment bug** — verifies CF int-days input no longer stringifies to raw integers
- [x] **Full SDK suite: 386 passed** (was 375, +11)
- [x] **render-svc suite: 81 passed** (unchanged — public contract preserved)
- [x] Smoke: \`get_data_for_f1\` end-to-end imports + runs through all four zarr blocks

## Stacked-PR check

Leaf — no children stacked. \`scripts/check-stacked-pr.sh\` confirms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)