### PR TITLE
chore(observability): WARN when silent fallbacks fire — P.4 + P.6 + P.8

### DIFF
--- a/sdk/riskmodels/snapshots/_fund_data.py
+++ b/sdk/riskmodels/snapshots/_fund_data.py
@@ -11,9 +11,12 @@ shares backed by RiskModels Supabase reads; pip consumers work without keys.
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Any
+
+log = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
@@ -1246,8 +1249,19 @@ def get_data_for_f1(
             if len(gross_d_safe) >= 252:
                 ttm_window = gross_d_safe[-252:]
                 tr_fund["1y"] = float(np.prod(1.0 + ttm_window) - 1.0)
-    except (FileNotFoundError, KeyError):
-        pass
+    except (FileNotFoundError, KeyError) as e:
+        # P.4 — surface the silent monthly downgrade so operators see
+        # which funds are rendering coarse charts. The chart still draws
+        # (cum_nav from the monthly NAV block above remains the
+        # authority) but with ~12 monthly points instead of ~252 daily.
+        # WARN-level: a missing daily store IS a degradation worth
+        # noticing, not a normal absence.
+        log.warning(
+            "ds_fund_returns_daily.zarr unavailable for %s (%s); F1 chart "
+            "falls back to monthly NAV granularity. Daily store is the "
+            "preferred source for the cumulative-return strip.",
+            bw_fund_id, type(e).__name__,
+        )
 
     # ── ERM3 fit row from fund_fit_parquet ──────────────────────────
     # Joined ERM3 vs yfinance NAV stats (coverage, monthly correlation,

--- a/sdk/tests/test_fund_data_silent_downgrade_warnings.py
+++ b/sdk/tests/test_fund_data_silent_downgrade_warnings.py
@@ -1,0 +1,114 @@
+"""``get_data_for_f1`` — silent-downgrade visibility tests (MASTER_BACKLOG P.4).
+
+When ``ds_fund_returns_daily.zarr`` is missing for a fund, the loader used
+to silently fall back to monthly NAV granularity. The fix logs a WARNING
+so operators can see in render-svc logs which funds are rendering coarse
+charts (12 monthly points instead of ~252 daily) without having to spot
+the difference visually.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from riskmodels.snapshots import _fund_data
+
+
+def _make_open_zarr_that_only_misses_daily(monkeypatch):
+    """Patch _open_fund_zarr to raise FileNotFoundError only for the
+    daily-returns store. Other stores still soft-fail (no real data path
+    needed for these tests — we just care about the warning emission)."""
+    def _fake_open(_bw_fund_id: str, store: str):
+        if store == "ds_fund_returns_daily.zarr":
+            raise FileNotFoundError("test: daily store intentionally missing")
+        raise FileNotFoundError(store)  # other stores also missing; OK
+
+    monkeypatch.setattr(_fund_data, "_open_fund_zarr", _fake_open)
+    monkeypatch.setattr(_fund_data, "_fund_identity", lambda _id: {})
+
+
+def test_warns_when_daily_returns_zarr_missing(caplog, monkeypatch):
+    """The headline P.4 fix: a missing daily store emits a WARN that
+    names the fund + the missing-file class so operators can grep logs."""
+    _make_open_zarr_that_only_misses_daily(monkeypatch)
+    with caplog.at_level(logging.WARNING, logger="riskmodels.snapshots._fund_data"):
+        _fund_data.get_data_for_f1("BW-FUND-DAILY-MISSING", enrich=False)
+    daily_warnings = [
+        r for r in caplog.records
+        if "ds_fund_returns_daily.zarr unavailable" in r.message
+    ]
+    assert len(daily_warnings) == 1
+    assert "BW-FUND-DAILY-MISSING" in daily_warnings[0].message
+    assert "FileNotFoundError" in daily_warnings[0].message
+    assert "monthly NAV granularity" in daily_warnings[0].message
+    assert daily_warnings[0].levelno == logging.WARNING
+
+
+def test_warning_message_mentions_fallback_path(caplog, monkeypatch):
+    """Operators need to know WHAT the fallback is — the message must
+    name 'monthly NAV' so they understand the chart still draws (just
+    coarser) rather than thinking it's a full data outage."""
+    _make_open_zarr_that_only_misses_daily(monkeypatch)
+    with caplog.at_level(logging.WARNING, logger="riskmodels.snapshots._fund_data"):
+        _fund_data.get_data_for_f1("BW-FUND-X", enrich=False)
+    msg = next(
+        r.message for r in caplog.records
+        if "ds_fund_returns_daily" in r.message
+    )
+    # Tells operator: chart still draws (just coarser), not "F1 is broken".
+    assert "monthly" in msg.lower()
+    assert "preferred" in msg.lower()  # signals "this isn't normal"
+
+
+def test_no_warning_when_daily_zarr_open_succeeds(caplog, monkeypatch):
+    """When the daily store opens cleanly the warning must NOT fire —
+    avoids producing noise on the happy path."""
+    # Build a minimal fake daily zarr that opens OK and provides the
+    # required keys with empty arrays — the loader will window+drop them
+    # and not change cum_nav, but the try block won't raise.
+    import numpy as np
+
+    class _FakeArr:
+        def __init__(self, data, attrs=None):
+            self._d = data
+            self.attrs = attrs or {}
+
+        def __getitem__(self, idx):
+            return self._d[idx]
+
+    class _FakeDailyZarr:
+        def __init__(self):
+            # Provide a minimal valid lag_basis with "report_date".
+            self._data = {
+                "lag_basis": _FakeArr(np.array(["report_date"], dtype=object)),
+                "teo": _FakeArr(
+                    np.array([], dtype=np.int64),
+                    attrs={"units": "days since 1970-01-01"},
+                ),
+                "gross_return": _FakeArr(np.zeros((0, 1), dtype=float)),
+                "l1_market": _FakeArr(np.zeros((0, 1), dtype=float)),
+                "l2_sector": _FakeArr(np.zeros((0, 1), dtype=float)),
+                "l3_subsector": _FakeArr(np.zeros((0, 1), dtype=float)),
+                "l3_residual": _FakeArr(np.zeros((0, 1), dtype=float)),
+            }
+
+        def __getitem__(self, k):
+            return self._data[k]
+
+    def _fake_open(_bw_fund_id: str, store: str):
+        if store == "ds_fund_returns_daily.zarr":
+            return _FakeDailyZarr()
+        raise FileNotFoundError(store)
+
+    monkeypatch.setattr(_fund_data, "_open_fund_zarr", _fake_open)
+    monkeypatch.setattr(_fund_data, "_fund_identity", lambda _id: {})
+
+    with caplog.at_level(logging.WARNING, logger="riskmodels.snapshots._fund_data"):
+        _fund_data.get_data_for_f1("BW-FUND-DAILY-PRESENT", enrich=False)
+    daily_warnings = [
+        r for r in caplog.records
+        if "ds_fund_returns_daily.zarr unavailable" in r.message
+    ]
+    assert daily_warnings == []

--- a/services/render-svc/render_svc/settings.py
+++ b/services/render-svc/render_svc/settings.py
@@ -6,8 +6,11 @@ dev / staging / prod without code changes. Defaults match production.
 
 from __future__ import annotations
 
+import logging
 import os
 from dataclasses import dataclass
+
+log = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -42,15 +45,45 @@ class Settings:
     zarr_root_uri: str
 
 
+_DEFAULT_BUCKET = "rm_api_data"
+_DEFAULT_ZARR_ROOT_URI = "gs://rm_api_data/eodhd"
+
+
 def load_from_env() -> Settings:
+    """Resolve runtime settings from env vars.
+
+    Logs a WARNING for each silent default actually used — operators
+    debugging "why is render-svc reading the wrong bucket" can see
+    in the startup logs whether the env var was set or whether the
+    default kicked in. Closes MASTER_BACKLOG P.6 + P.8 (the two
+    silent-default settings paths in this module).
+    """
+    bucket_env = os.environ.get("RENDER_SVC_BUCKET")
+    bucket = bucket_env or _DEFAULT_BUCKET
+    if not bucket_env:
+        log.warning(
+            "RENDER_SVC_BUCKET not set; using default bucket=%r. "
+            "Set the env var explicitly to silence this warning and "
+            "guarantee cache writes go where you intend.",
+            bucket,
+        )
+
+    zarr_env = os.environ.get("RENDER_SVC_ZARR_ROOT_URI")
+    zarr_root_uri = zarr_env or _DEFAULT_ZARR_ROOT_URI
+    if not zarr_env:
+        log.warning(
+            "RENDER_SVC_ZARR_ROOT_URI not set; using default zarr_root_uri=%r. "
+            "Set the env var explicitly to silence this warning and "
+            "confirm live_render compute targets the right zarr root.",
+            zarr_root_uri,
+        )
+
     return Settings(
-        bucket=os.environ.get("RENDER_SVC_BUCKET", "rm_api_data"),
+        bucket=bucket,
         prefix=os.environ.get("RENDER_SVC_PREFIX", "snapshots"),
         generated_utc_anchor=os.environ.get("RENDER_SVC_GENERATED_UTC") or None,
         log_level=os.environ.get("RENDER_SVC_LOG_LEVEL", "INFO"),
         persist_renders=os.environ.get("RENDER_SVC_PERSIST_RENDERS", "1") != "0",
         live_render=os.environ.get("RENDER_SVC_LIVE_RENDER", "0") == "1",
-        zarr_root_uri=os.environ.get(
-            "RENDER_SVC_ZARR_ROOT_URI", "gs://rm_api_data/eodhd"
-        ),
+        zarr_root_uri=zarr_root_uri,
     )

--- a/services/render-svc/tests/test_settings.py
+++ b/services/render-svc/tests/test_settings.py
@@ -1,0 +1,125 @@
+"""``load_from_env`` — silent-default visibility tests (MASTER_BACKLOG P.6 + P.8).
+
+When ``RENDER_SVC_BUCKET`` or ``RENDER_SVC_ZARR_ROOT_URI`` aren't set,
+the service used to silently fall back to ``rm_api_data`` / ``gs://rm_api_data/eodhd``
+with no operator-visible signal. The fix logs a WARNING for each default
+actually used, so a startup log line tells the operator exactly which
+env var is missing.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from render_svc.settings import load_from_env
+
+
+@pytest.fixture(autouse=True)
+def _clear_env(monkeypatch):
+    """Strip the relevant env vars so each test starts from a known state."""
+    for var in (
+        "RENDER_SVC_BUCKET",
+        "RENDER_SVC_ZARR_ROOT_URI",
+        "RENDER_SVC_PREFIX",
+        "RENDER_SVC_GENERATED_UTC",
+        "RENDER_SVC_LOG_LEVEL",
+        "RENDER_SVC_PERSIST_RENDERS",
+        "RENDER_SVC_LIVE_RENDER",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+# ---------------------------------------------------------------------------
+# P.8 — RENDER_SVC_BUCKET silent default
+# ---------------------------------------------------------------------------
+
+
+def test_warns_when_bucket_env_unset(caplog):
+    with caplog.at_level(logging.WARNING, logger="render_svc.settings"):
+        s = load_from_env()
+    assert s.bucket == "rm_api_data"
+    # Exactly one warning about the bucket default.
+    bucket_warnings = [r for r in caplog.records if "RENDER_SVC_BUCKET" in r.message]
+    assert len(bucket_warnings) == 1
+    assert bucket_warnings[0].levelno == logging.WARNING
+    assert "default bucket" in bucket_warnings[0].message
+    assert "'rm_api_data'" in bucket_warnings[0].message
+
+
+def test_no_warning_when_bucket_env_set(monkeypatch, caplog):
+    monkeypatch.setenv("RENDER_SVC_BUCKET", "explicit-test-bucket")
+    with caplog.at_level(logging.WARNING, logger="render_svc.settings"):
+        s = load_from_env()
+    assert s.bucket == "explicit-test-bucket"
+    bucket_warnings = [r for r in caplog.records if "RENDER_SVC_BUCKET" in r.message]
+    assert bucket_warnings == []
+
+
+def test_warns_even_when_explicitly_empty_string(caplog):
+    """Empty string env var is treated as unset — the operator likely
+    intended to set it but botched the value."""
+    import os
+    os.environ["RENDER_SVC_BUCKET"] = ""
+    try:
+        with caplog.at_level(logging.WARNING, logger="render_svc.settings"):
+            load_from_env()
+        bucket_warnings = [r for r in caplog.records if "RENDER_SVC_BUCKET" in r.message]
+        assert len(bucket_warnings) == 1
+    finally:
+        del os.environ["RENDER_SVC_BUCKET"]
+
+
+# ---------------------------------------------------------------------------
+# P.6 — RENDER_SVC_ZARR_ROOT_URI silent default
+# ---------------------------------------------------------------------------
+
+
+def test_warns_when_zarr_root_uri_env_unset(caplog):
+    with caplog.at_level(logging.WARNING, logger="render_svc.settings"):
+        s = load_from_env()
+    assert s.zarr_root_uri == "gs://rm_api_data/eodhd"
+    zarr_warnings = [
+        r for r in caplog.records if "RENDER_SVC_ZARR_ROOT_URI" in r.message
+    ]
+    assert len(zarr_warnings) == 1
+    assert zarr_warnings[0].levelno == logging.WARNING
+    assert "gs://rm_api_data/eodhd" in zarr_warnings[0].message
+
+
+def test_no_warning_when_zarr_root_uri_env_set(monkeypatch, caplog):
+    monkeypatch.setenv("RENDER_SVC_ZARR_ROOT_URI", "gs://test-research-bucket/zarrs")
+    with caplog.at_level(logging.WARNING, logger="render_svc.settings"):
+        s = load_from_env()
+    assert s.zarr_root_uri == "gs://test-research-bucket/zarrs"
+    zarr_warnings = [
+        r for r in caplog.records if "RENDER_SVC_ZARR_ROOT_URI" in r.message
+    ]
+    assert zarr_warnings == []
+
+
+# ---------------------------------------------------------------------------
+# Independence — each warning fires independently of the other
+# ---------------------------------------------------------------------------
+
+
+def test_both_warnings_fire_when_both_env_vars_unset(caplog):
+    """All-defaults case — both warnings fire so the operator sees the
+    complete picture in one startup log scan."""
+    with caplog.at_level(logging.WARNING, logger="render_svc.settings"):
+        load_from_env()
+    messages = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+    assert any("RENDER_SVC_BUCKET" in m for m in messages)
+    assert any("RENDER_SVC_ZARR_ROOT_URI" in m for m in messages)
+
+
+def test_only_one_warning_when_only_one_unset(monkeypatch, caplog):
+    """Mixed case — only the missing env var generates a warning."""
+    monkeypatch.setenv("RENDER_SVC_BUCKET", "explicit-bucket")
+    # RENDER_SVC_ZARR_ROOT_URI stays unset.
+    with caplog.at_level(logging.WARNING, logger="render_svc.settings"):
+        load_from_env()
+    messages = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+    assert not any("RENDER_SVC_BUCKET" in m for m in messages)
+    assert any("RENDER_SVC_ZARR_ROOT_URI" in m for m in messages)


### PR DESCRIPTION
## Summary

Three silent-default code paths surfaced by the back-end Q/A audit each return a degraded answer instead of erroring. None are bugs in isolation — the fallback shapes are correct. The bug is **invisibility**: operators have no log signal to distinguish *\"production is configured correctly and the fund's data is genuinely missing\"* from *\"an env var isn't wired and the service is reading the wrong bucket / zarr root / fund granularity\"*.

Three one-liner WARNs, plus 10 tests.

## The three closures

### P.4 — \`ds_fund_returns_daily.zarr\` missing → silent monthly downgrade

**Where:** \`sdk/riskmodels/snapshots/_fund_data.py\` (the daily-returns \`try/except\` block).

**Before:** \`except (FileNotFoundError, KeyError): pass\` — the F1 line chart silently falls back to ~12 monthly points instead of ~252 daily.

**After:** Same fallback behavior, but the WARN names the fund + the missing-file class + the granularity drop, so operators can grep render-svc logs:

\`\`\`
WARNING riskmodels.snapshots._fund_data:_fund_data.py:NNN
  ds_fund_returns_daily.zarr unavailable for BW-FUND-S000004563 (FileNotFoundError);
  F1 chart falls back to monthly NAV granularity. Daily store is the preferred
  source for the cumulative-return strip.
\`\`\`

### P.8 — \`RENDER_SVC_BUCKET\` silent default

**Where:** \`services/render-svc/render_svc/settings.py:47\`.

**Before:** Defaulted to \`\"rm_api_data\"\` silently. If prod uses a different bucket, renders cache to the wrong location and every call recomputes.

**After:** WARN at \`load_from_env()\` shows the operator which bucket is actually in use + why:

\`\`\`
WARNING render_svc.settings:settings.py:NN
  RENDER_SVC_BUCKET not set; using default bucket='rm_api_data'.
  Set the env var explicitly to silence this warning and guarantee cache writes go where you intend.
\`\`\`

### P.6 — \`RENDER_SVC_ZARR_ROOT_URI\` silent default

**Where:** Same file, line 53.

**Before:** Defaulted to \`\"gs://rm_api_data/eodhd\"\` silently. If a research branch intended a custom zarr root, the service silently loaded canonical prod data.

**After:** WARN names the default in use.

> **Note on the original survey:** P.6 originally claimed the silent default lived in \`zarr_context.py\`. Investigation showed \`zarr_context._default_zarr_root\` already **raises** when \`ERM3_ZARR_ROOT\` is unset (loud, not silent — no fix needed there). The actual silent default lives in render-svc \`settings.py\` for the \`RENDER_SVC_ZARR_ROOT_URI\` env. This PR fixes the real instance; backlog row will be updated.

## Why WARN (not INFO or ERROR)

- **INFO:** would be too quiet; missed in log dashboards filtered to WARN+
- **ERROR:** would page on-call; these are degraded-but-functional states, not outages
- **WARN:** right level — visible in standard log aggregation, doesn't trip alerts

## Test plan

- [x] **\`services/render-svc/tests/test_settings.py\` (+7 tests):** each env var unset / set / empty-string case; both warnings firing together when both unset; only-one firing when only one unset
- [x] **\`sdk/tests/test_fund_data_silent_downgrade_warnings.py\` (+3 tests):** daily-zarr-missing WARN (positive: emits with fund id + missing-file class + fallback hint; negative: no warning when daily zarr opens cleanly)
- [x] **Full SDK suite: 378 passed** (was 375, +3)
- [x] **render-svc suite: 88 passed** (was 81, +7)

## What's NOT in this PR

- No functional behavior change — every fallback still fires the same way
- No new env var requirements — operators can leave defaults; warnings just make the default usage visible
- No log-level changes — module loggers respect existing log config

## Stacked-PR check

Leaf — \`scripts/check-stacked-pr.sh\` confirms. Independent of RM_API #81 (TEO decoder); different code regions in \`_fund_data.py\` so no conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)