### PR TITLE
feat(chat): search_funds + get_fund_holdings tools — closes the FCNTX gap

### DIFF
--- a/lib/chat/system-prompt.ts
+++ b/lib/chat/system-prompt.ts
@@ -42,13 +42,15 @@ You **illuminate** how a portfolio behaves — what bets it is making, how large
 
 ## What you must NOT fabricate
 
-You have **no tool that returns a fund's, ETF's, or filer's holdings**. If a question requires knowing what a portfolio *contains* and the user has not given you the holdings:
+You have **no general tool that returns ETF or 13F-filer holdings**. **For mutual funds and ETFs filing N-PORT** (FCNTX, VTSAX, FXAIX, SPY, QQQ, XLK, etc.) **you DO have tools**: call \`search_funds\` to resolve a ticker or fund name to \`bw_fund_id\`, then \`get_fund_holdings\` to fetch the top-N current holdings + as_of date + AUM. Use them. Do not decline a fund-holdings question without trying.
 
-- **Decline honestly.** Say plainly: *"I don't have a live holdings feed for [fund/ETF/filer]."* Do **not** produce a holdings table. Do **not** list "approximate weights from recent filings." Do **not** say things like "Apple is around 10%, Microsoft 9%, …". **Even labeled-as-approximate fabrication is forbidden** — it's the same class of leak as inventing risk numbers, and it's the exact failure mode this product was built against.
+If a question requires knowing what a portfolio *contains* and the tools above don't cover it (e.g. a 13F filer's positions, a hedge fund's letter, "a typical 60/40 portfolio"):
+
+- **Decline honestly.** Say plainly: *"I don't have a live holdings feed for [filer/synthetic portfolio]."* Do **not** produce a holdings table. Do **not** list "approximate weights from recent filings." Do **not** say things like "Apple is around 10%, Microsoft 9%, …". **Even labeled-as-approximate fabrication is forbidden** — it's the same class of leak as inventing risk numbers, and it's the exact failure mode this product was built against.
 - **Offer the alternative the user can act on:** they can paste the tickers they care about (or run a snapshot on a portfolio) and you'll analyze the risk structure of *that*.
-- The same rule applies to "a typical large-cap growth fund" / "a generic 60/40 portfolio" / any synthetic stand-in — don't invent compositions. Ask the user to specify, or use only real, tool-fetched data. If you have a real tool that returns holdings, use it and report what it returns; otherwise, don't.
+- The same rule applies to "a typical large-cap growth fund" / "a generic 60/40 portfolio" / any synthetic stand-in — don't invent compositions. Ask the user to specify, or use only real, tool-fetched data.
 
-This is a hard rule, not a style preference. Approximating a portfolio's composition from memory and labeling it "approximate" is still fabrication.
+This is a hard rule, not a style preference. Approximating a portfolio's composition from memory and labeling it "approximate" is still fabrication. **But before declining, check whether \`search_funds\` + \`get_fund_holdings\` can resolve the request — for any 1940-Act fund that files N-PORT, they should.**
 
 ## Response shape — Aha first, then evidence
 
@@ -96,6 +98,7 @@ This matters: a serialized 8-call answer takes ≈ 8 × tool latency; a fan-out 
 - **Lead with the Aha, not the table** — see "Response shape" above. Per-position rows / full HR tables go inside a collapsible \`<details>\` block (or at the end under a "Details" heading); never at the top.
 - Always call tools before stating specific metrics, hedge ratios, or correlations for a ticker or portfolio. Never invent figures.
 - If the user gives a **company name** or ambiguous symbol, call search_tickers first, then fetch metrics.
+- If the user mentions a **mutual fund or ETF ticker** (FCNTX, VTSAX, SPY, QQQ, XLK, …), call \`search_funds\` first to resolve to \`bw_fund_id\`, then \`get_fund_holdings\` to fetch the actual top holdings. Treat the result the same as a user-pasted portfolio — real numbers, no fabrication.
 - If a **tool fails**, quote the error and suggestion from the tool result; do not guess numbers. Tell the user how to fix (e.g. try another ticker, top up balance).
 - Be concise: lead with numbers, then explain. When presenting HRs, name the ETF legs and frame them as what *would* neutralize each leg (e.g. "$0.62 of SPY per $1 of portfolio neutralizes the market leg"), not as a trade you're telling them to make.
 - If l3_res_er is high (>0.5), note that much risk is idiosyncratic (stock-specific, not fully hedgeable with sector/market ETFs).

--- a/lib/chat/tools.ts
+++ b/lib/chat/tools.ts
@@ -8,6 +8,8 @@ import type { ChatCompletionTool } from "openai/resources/chat/completions";
 import { TickerSchema, YearsSchema } from "@/lib/api/schemas";
 import { parseMacroFactorsSeriesQuery } from "@/lib/api/macro-factors-series-query";
 import { searchTickers } from "@/lib/dal/ticker-search";
+import { searchFunds, fetchFund } from "@/lib/dal/funds-engine";
+import { readFundHoldingsTopN } from "@/lib/dal/funds-zarr-reader";
 import { fetchMacroFactorSeriesRows } from "@/lib/dal/macro-factors";
 import {
   resolveSymbolByTicker,
@@ -88,6 +90,16 @@ const macroFactorsArgs = z.object({
 const searchTickersArgs = z.object({
   search: z.string().min(1, "Search query is required"),
   include_metadata: z.boolean().default(true),
+});
+
+const searchFundsArgs = z.object({
+  query: z.string().min(1, "Fund ticker or name required"),
+  limit: z.coerce.number().int().min(1).max(25).default(10),
+});
+
+const getFundHoldingsArgs = z.object({
+  bw_fund_id: z.string().min(1, "bw_fund_id required (call search_funds first)"),
+  limit: z.coerce.number().int().min(1).max(100).default(25),
 });
 
 const portfolioRiskArgs = z.object({
@@ -276,6 +288,62 @@ async function execMacroFactors(args: z.infer<typeof macroFactorsArgs>) {
 
 async function execSearchTickers(args: z.infer<typeof searchTickersArgs>) {
   return searchTickers(args.search, args.include_metadata);
+}
+
+async function execSearchFunds(args: z.infer<typeof searchFundsArgs>) {
+  const rows = await searchFunds({ q: args.query, limit: args.limit });
+  // Slim payload — the analyst only needs id + ticker + name + style + identity
+  // signals to decide which fund to drill into. Skip the AUM / lineage cruft.
+  return {
+    query: args.query,
+    n_results: rows.length,
+    funds: rows.map((r) => ({
+      bw_fund_id: r.bw_fund_id,
+      ticker: r.ticker,
+      fund_name: r.fund_name,
+      morningstar_category: r.morningstar_category,
+      equity_style_9box: r.equity_style_9box,
+      latest_report_date: r.latest_report_date,
+      latest_n_holdings: r.latest_n_holdings,
+    })),
+  };
+}
+
+async function execGetFundHoldings(args: z.infer<typeof getFundHoldingsArgs>) {
+  const [fund, holdings] = await Promise.all([
+    fetchFund(args.bw_fund_id),
+    readFundHoldingsTopN(args.bw_fund_id, args.limit),
+  ]);
+  if (!fund) {
+    return {
+      bw_fund_id: args.bw_fund_id,
+      error: "fund_not_found",
+      message: `No fund with bw_fund_id=${args.bw_fund_id}. Call search_funds first.`,
+    };
+  }
+  if (!holdings) {
+    return {
+      bw_fund_id: args.bw_fund_id,
+      ticker: fund.ticker,
+      fund_name: fund.fund_name,
+      error: "holdings_unavailable",
+      message:
+        "Fund metadata exists but the zarr holdings cube is empty for this fund (typically: not yet ingested or insufficient coverage). Don't fabricate; tell the user.",
+    };
+  }
+  return {
+    bw_fund_id: args.bw_fund_id,
+    ticker: fund.ticker,
+    fund_name: fund.fund_name,
+    morningstar_category: fund.morningstar_category,
+    equity_style_9box: fund.equity_style_9box,
+    as_of: holdings.teo,
+    aum_reported: holdings.aum_reported,
+    aum_erm3: holdings.aum_erm3,
+    n_holdings_returned: holdings.n_holdings_returned,
+    n_total_holdings: holdings.n_total_holdings,
+    holdings: holdings.holdings,
+  };
 }
 
 function sanitizeL3DecompositionResult(result: unknown): unknown {
@@ -567,6 +635,50 @@ export const CHAT_TOOLS_REGISTRY: ChatToolDef[] = [
     capabilityId: null,
     argSchema: searchTickersArgs,
     executor: async (a) => execSearchTickers(searchTickersArgs.parse(a)),
+  },
+  {
+    name: "search_funds",
+    openaiTool: fnTool(
+      "search_funds",
+      "Resolve a mutual-fund or ETF ticker / fund name to bw_fund_id (free lookup). Use this when the user mentions a mutual fund (FCNTX, VTSAX, FXAIX) or ETF (SPY, QQQ, XLK) — BEFORE calling get_fund_holdings. Returns up to 10 matching funds with ticker, fund_name, morningstar_category, equity_style_9box, latest_report_date.",
+      {
+        query: {
+          type: "string",
+          description: "Fund ticker (e.g. FCNTX) or partial fund name (e.g. Contrafund)",
+        },
+        limit: {
+          type: "integer",
+          description: "Max results, default 10, max 25",
+        },
+      },
+      ["query", "limit"],
+    ),
+    /** Free: same surface as the public /api/funds/search (no billing). */
+    capabilityId: null,
+    argSchema: searchFundsArgs,
+    executor: async (a) => execSearchFunds(searchFundsArgs.parse(a)),
+  },
+  {
+    name: "get_fund_holdings",
+    openaiTool: fnTool(
+      "get_fund_holdings",
+      "Top-N current holdings for a mutual fund or ETF at its latest report date (from the most recent N-PORT filing in the system). Use AFTER search_funds resolved a bw_fund_id. Returns per-holding bw_sym_id, market value, weight, plus fund identity (ticker, fund_name, category, style, as_of date, AUM).",
+      {
+        bw_fund_id: {
+          type: "string",
+          description: "BW fund identifier from search_funds",
+        },
+        limit: {
+          type: "integer",
+          description: "Max holdings to return, default 25, max 100",
+        },
+      },
+      ["bw_fund_id", "limit"],
+    ),
+    /** Same billing surface as public /api/funds/{bw_fund_id}/holdings. */
+    capabilityId: "fund-holdings",
+    argSchema: getFundHoldingsArgs,
+    executor: async (a) => execGetFundHoldings(getFundHoldingsArgs.parse(a)),
   },
   {
     name: "compute_portfolio_risk_index",


### PR DESCRIPTION
User reported: NVDA ticker analysis worked perfectly, but FCNTX (Fidelity Contrafund) was declined with "I don't have a live holdings feed for [fund]." Decline-to-fabricate was correct in isolation — but the chat agent's tool registry was missing a fund-holdings path entirely, despite the data + API existing.

## What changed

Two new tools in `lib/chat/tools.ts`:

| Tool | Billing | DAL |
|---|---|---|
| `search_funds(query, limit)` | free | `searchFunds()` — public funds discovery |
| `get_fund_holdings(bw_fund_id, limit)` | `fund-holdings` | `readFundHoldingsTopN()` + `fetchFund()` — N-PORT top-N |

System prompt updated to differentiate 1940-Act funds (use new tools) from 13F filers / synthetic stand-ins (still decline). Adds a Rules-section line telling the analyst to call `search_funds` first when a fund ticker is mentioned.

## Result

For any 1940-Act fund or ETF that files N-PORT and is in the system's funds_dag panel (FCNTX, VTSAX, FXAIX, SPY, QQQ, XLK, …), the analyst can now resolve the ticker, fetch the actual current top holdings, and analyze them. No fabrication, no decline-without-trying.

## Out of scope

- **13F filer holdings** (different filing type / separate Funds_DAG slice) — still declined; parallel session is working filer artifacts.
- **bw_sym_id → ticker resolution** in the holdings result — today returns `bw_sym_id`; analyst can call `search_tickers` to surface human-readable.

## Test plan

- [x] Typecheck on touched files clean (`lib/chat/tools.ts`, `lib/chat/system-prompt.ts`)
- [ ] Smoke test on staging: ask the analyst about FCNTX → expect a real top-holdings table from the latest N-PORT
- [ ] Smoke test: ask about an ETF (SPY, XLK) → should work the same way

🤖 Generated with [Claude Code](https://claude.com/claude-code)