### PR TITLE
feat(chat): search_filers + get_filer_holdings — completes holdings coverage

### DIFF
--- a/lib/chat/system-prompt.ts
+++ b/lib/chat/system-prompt.ts
@@ -42,15 +42,20 @@ You **illuminate** how a portfolio behaves — what bets it is making, how large
 
 ## What you must NOT fabricate
 
-You have **no general tool that returns ETF or 13F-filer holdings**. **For mutual funds and ETFs filing N-PORT** (FCNTX, VTSAX, FXAIX, SPY, QQQ, XLK, etc.) **you DO have tools**: call \`search_funds\` to resolve a ticker or fund name to \`bw_fund_id\`, then \`get_fund_holdings\` to fetch the top-N current holdings + as_of date + AUM. Use them. Do not decline a fund-holdings question without trying.
+You have **two tool families** that return real holdings — use them before declining:
 
-If a question requires knowing what a portfolio *contains* and the tools above don't cover it (e.g. a 13F filer's positions, a hedge fund's letter, "a typical 60/40 portfolio"):
+1. **Mutual funds + ETFs (1940-Act, N-PORT filings):** \`search_funds\` → \`get_fund_holdings\`. Covers FCNTX, VTSAX, FXAIX, SPY, QQQ, XLK, etc.
+2. **13F filers (institutional investors, 13F-HR filings):** \`search_filers\` → \`get_filer_holdings\`. Covers Berkshire Hathaway, Pershing Square, Bridgewater, Scion, Renaissance, Vanguard's 13F book, etc. **Filers DO NOT have tickers** — search by name / CIK / LEI.
 
-- **Decline honestly.** Say plainly: *"I don't have a live holdings feed for [filer/synthetic portfolio]."* Do **not** produce a holdings table. Do **not** list "approximate weights from recent filings." Do **not** say things like "Apple is around 10%, Microsoft 9%, …". **Even labeled-as-approximate fabrication is forbidden** — it's the same class of leak as inventing risk numbers, and it's the exact failure mode this product was built against.
+For both: resolve to a stable id first (free lookup), then fetch the top-N current holdings + as_of date + AUM. Treat the result the same as a user-pasted portfolio — real numbers, no fabrication.
+
+If a question requires knowing what a portfolio *contains* and **neither tool family covers it** (e.g. a hedge fund letter that's not in the 13F panel, "a typical 60/40 portfolio," "a generic large-cap growth composite"):
+
+- **Decline honestly.** Say plainly: *"I don't have a live holdings feed for [synthetic portfolio / off-panel entity]."* Do **not** produce a holdings table. Do **not** list "approximate weights from recent filings." Do **not** say things like "Apple is around 10%, Microsoft 9%, …". **Even labeled-as-approximate fabrication is forbidden** — it's the same class of leak as inventing risk numbers, and it's the exact failure mode this product was built against.
 - **Offer the alternative the user can act on:** they can paste the tickers they care about (or run a snapshot on a portfolio) and you'll analyze the risk structure of *that*.
-- The same rule applies to "a typical large-cap growth fund" / "a generic 60/40 portfolio" / any synthetic stand-in — don't invent compositions. Ask the user to specify, or use only real, tool-fetched data.
+- The same rule applies to any synthetic stand-in — don't invent compositions. Ask the user to specify, or use only real, tool-fetched data.
 
-This is a hard rule, not a style preference. Approximating a portfolio's composition from memory and labeling it "approximate" is still fabrication. **But before declining, check whether \`search_funds\` + \`get_fund_holdings\` can resolve the request — for any 1940-Act fund that files N-PORT, they should.**
+This is a hard rule, not a style preference. Approximating a portfolio's composition from memory and labeling it "approximate" is still fabrication. **But before declining, try both tool families first.**
 
 ## Response shape — Aha first, then evidence
 
@@ -99,6 +104,7 @@ This matters: a serialized 8-call answer takes ≈ 8 × tool latency; a fan-out 
 - Always call tools before stating specific metrics, hedge ratios, or correlations for a ticker or portfolio. Never invent figures.
 - If the user gives a **company name** or ambiguous symbol, call search_tickers first, then fetch metrics.
 - If the user mentions a **mutual fund or ETF ticker** (FCNTX, VTSAX, SPY, QQQ, XLK, …), call \`search_funds\` first to resolve to \`bw_fund_id\`, then \`get_fund_holdings\` to fetch the actual top holdings. Treat the result the same as a user-pasted portfolio — real numbers, no fabrication.
+- If the user mentions an **institutional investor / 13F filer by name** (Berkshire Hathaway, Pershing Square, Bridgewater, Scion, Renaissance, Vanguard's 13F book, …), call \`search_filers\` first to resolve to \`bw_filer_id\`, then \`get_filer_holdings\`. Filers don't have tickers — search by name / CIK / LEI.
 - If a **tool fails**, quote the error and suggestion from the tool result; do not guess numbers. Tell the user how to fix (e.g. try another ticker, top up balance).
 - Be concise: lead with numbers, then explain. When presenting HRs, name the ETF legs and frame them as what *would* neutralize each leg (e.g. "$0.62 of SPY per $1 of portfolio neutralizes the market leg"), not as a trade you're telling them to make.
 - If l3_res_er is high (>0.5), note that much risk is idiosyncratic (stock-specific, not fully hedgeable with sector/market ETFs).

--- a/lib/chat/tools.ts
+++ b/lib/chat/tools.ts
@@ -9,7 +9,11 @@ import { TickerSchema, YearsSchema } from "@/lib/api/schemas";
 import { parseMacroFactorsSeriesQuery } from "@/lib/api/macro-factors-series-query";
 import { searchTickers } from "@/lib/dal/ticker-search";
 import { searchFunds, fetchFund } from "@/lib/dal/funds-engine";
-import { readFundHoldingsTopN } from "@/lib/dal/funds-zarr-reader";
+import { searchFilers, fetchFiler } from "@/lib/dal/filers-engine";
+import {
+  readFundHoldingsTopN,
+  readFilerHoldingsTopN,
+} from "@/lib/dal/funds-zarr-reader";
 import { fetchMacroFactorSeriesRows } from "@/lib/dal/macro-factors";
 import {
   resolveSymbolByTicker,
@@ -99,6 +103,16 @@ const searchFundsArgs = z.object({
 
 const getFundHoldingsArgs = z.object({
   bw_fund_id: z.string().min(1, "bw_fund_id required (call search_funds first)"),
+  limit: z.coerce.number().int().min(1).max(100).default(25),
+});
+
+const searchFilersArgs = z.object({
+  query: z.string().min(1, "Filer name, CIK, or LEI required"),
+  limit: z.coerce.number().int().min(1).max(25).default(10),
+});
+
+const getFilerHoldingsArgs = z.object({
+  bw_filer_id: z.string().min(1, "bw_filer_id required (call search_filers first)"),
   limit: z.coerce.number().int().min(1).max(100).default(25),
 });
 
@@ -306,6 +320,65 @@ async function execSearchFunds(args: z.infer<typeof searchFundsArgs>) {
       latest_report_date: r.latest_report_date,
       latest_n_holdings: r.latest_n_holdings,
     })),
+  };
+}
+
+async function execSearchFilers(args: z.infer<typeof searchFilersArgs>) {
+  const rows = await searchFilers({ q: args.query, limit: args.limit });
+  return {
+    query: args.query,
+    n_results: rows.length,
+    filers: rows.map((r) => ({
+      bw_filer_id: r.bw_filer_id,
+      name: r.name,
+      cik: r.cik,
+      filer_type: r.filer_type,
+      filer_subtype: r.filer_subtype,
+      style_label: r.style_label,
+      aum_tier: r.aum_tier,
+      latest_report_date: r.latest_report_date,
+      latest_aum_usd: r.latest_aum_usd,
+      latest_n_holdings: r.latest_n_holdings,
+    })),
+  };
+}
+
+async function execGetFilerHoldings(args: z.infer<typeof getFilerHoldingsArgs>) {
+  const [filer, holdings] = await Promise.all([
+    fetchFiler(args.bw_filer_id),
+    readFilerHoldingsTopN(args.bw_filer_id, args.limit),
+  ]);
+  if (!filer) {
+    return {
+      bw_filer_id: args.bw_filer_id,
+      error: "filer_not_found",
+      message: `No filer with bw_filer_id=${args.bw_filer_id}. Call search_filers first.`,
+    };
+  }
+  if (!holdings) {
+    return {
+      bw_filer_id: args.bw_filer_id,
+      name: filer.name,
+      cik: filer.cik,
+      error: "holdings_unavailable",
+      message:
+        "Filer metadata exists but the zarr holdings cube is empty (typically: pre-13F era, not yet ingested, or insufficient coverage). Don't fabricate; tell the user.",
+    };
+  }
+  return {
+    bw_filer_id: args.bw_filer_id,
+    name: filer.name,
+    cik: filer.cik,
+    filer_type: filer.filer_type,
+    filer_subtype: filer.filer_subtype,
+    style_label: filer.style_label,
+    aum_tier: filer.aum_tier,
+    as_of: holdings.teo,
+    total_aum_usd: holdings.total_aum_usd,
+    aum_in_erm3: holdings.aum_in_erm3,
+    n_holdings_returned: holdings.n_holdings_returned,
+    n_total_holdings: holdings.n_total_holdings,
+    holdings: holdings.holdings,
   };
 }
 
@@ -679,6 +752,50 @@ export const CHAT_TOOLS_REGISTRY: ChatToolDef[] = [
     capabilityId: "fund-holdings",
     argSchema: getFundHoldingsArgs,
     executor: async (a) => execGetFundHoldings(getFundHoldingsArgs.parse(a)),
+  },
+  {
+    name: "search_filers",
+    openaiTool: fnTool(
+      "search_filers",
+      "Resolve a 13F filer's name (or CIK / LEI) to bw_filer_id (free lookup). Use this when the user mentions an institutional investor — Berkshire Hathaway, Pershing Square, Bridgewater, Scion, Renaissance, Vanguard's 13F filings, etc. — BEFORE calling get_filer_holdings. Returns up to 10 matching filers with bw_filer_id, name, CIK, filer_type, style_label, AUM, latest_report_date. NOTE: filers DO NOT have tickers; search is by name / CIK / LEI.",
+      {
+        query: {
+          type: "string",
+          description: "Filer name (e.g. Berkshire, Pershing Square), CIK, or LEI",
+        },
+        limit: {
+          type: "integer",
+          description: "Max results, default 10, max 25",
+        },
+      },
+      ["query", "limit"],
+    ),
+    /** Free: matches public /api/13f/filers/search (no billing). */
+    capabilityId: null,
+    argSchema: searchFilersArgs,
+    executor: async (a) => execSearchFilers(searchFilersArgs.parse(a)),
+  },
+  {
+    name: "get_filer_holdings",
+    openaiTool: fnTool(
+      "get_filer_holdings",
+      "Top-N current holdings for a 13F filer at its latest report date (from the most recent 13F-HR filing in the system). Use AFTER search_filers resolved a bw_filer_id. Returns per-holding security_id, market value, weight, plus filer identity (name, CIK, type, style, as_of, AUM).",
+      {
+        bw_filer_id: {
+          type: "string",
+          description: "BW filer identifier from search_filers",
+        },
+        limit: {
+          type: "integer",
+          description: "Max holdings to return, default 25, max 100",
+        },
+      },
+      ["bw_filer_id", "limit"],
+    ),
+    /** Same billing surface as public /api/13f/filers/{bw_filer_id}/holdings. */
+    capabilityId: "filer-holdings",
+    argSchema: getFilerHoldingsArgs,
+    executor: async (a) => execGetFilerHoldings(getFilerHoldingsArgs.parse(a)),
   },
   {
     name: "compute_portfolio_risk_index",


### PR DESCRIPTION
Symmetric to #83 — search_funds/get_fund_holdings already shipped, the analogous 13F-filer pair was missing. User flagged that filers were inappropriately marked 'parallel session lane' on my wire-up list; the chat-tool wire is its own concern.

| User says | Tool path |
|---|---|
| FCNTX / VTSAX / SPY (ticker) | search_funds → get_fund_holdings (#83) |
| Berkshire / Pershing (name) | search_filers → get_filer_holdings (this PR) |
| Synthetic / off-panel | Decline — anti-fabrication rule |

Typecheck clean on lib/chat/*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)