### PR TITLE
fix(tests): system-prompt test matches new tool-families framing (unblocks main CI)

### DIFF
--- a/tests/system-prompt.test.ts
+++ b/tests/system-prompt.test.ts
@@ -12,9 +12,18 @@ describe("buildSystemPrompt — contracted boundaries", () => {
   });
 
   it("encodes the no-fabricated-portfolio rule (TA.NMD.1)", () => {
-    // Header + the unambiguous decline-and-redirect instruction.
+    // Header + the unambiguous decline-and-redirect instruction. After
+    // PRs #83 (search_funds + get_fund_holdings) and #85 (search_filers
+    // + get_filer_holdings) landed, the prompt copy was rewritten from
+    // "no tool that returns a fund's, ETF's, or filer's holdings" to
+    // "two tool families that return real holdings — use them before
+    // declining." The decline-and-redirect rule still holds for the
+    // off-panel case; this test asserts both the new tool-families
+    // framing AND the unchanged hard-decline language.
     expect(prompt).toMatch(/What you must NOT fabricate/);
-    expect(prompt).toMatch(/no tool that returns a fund's, ETF's, or filer's holdings/i);
+    expect(prompt).toMatch(/two tool families/i);
+    expect(prompt).toMatch(/search_funds/);
+    expect(prompt).toMatch(/search_filers/);
     expect(prompt).toMatch(/Even labeled-as-approximate fabrication is forbidden/i);
     expect(prompt).toMatch(/Never fabricate portfolio composition/i);
   });


### PR DESCRIPTION
## Summary

Main CI broke when the chat session's PR #85 merged. PRs #83 and #85 rewrote \`lib/chat/system-prompt.ts\` from a \"no holdings tool\" framing to a \"two tool families\" framing, but the matching test in \`tests/system-prompt.test.ts\` still expected the old wording.

**Every PR cut off post-#85-main inherits the failure** — including in-flight observability PR #84, which is otherwise leaf + ready to merge.

## The diff

Update line 17 from:

\`\`\`ts
expect(prompt).toMatch(/no tool that returns a fund's, ETF's, or filer's holdings/i);
\`\`\`

to assertions matching the new framing:

\`\`\`ts
expect(prompt).toMatch(/two tool families/i);
expect(prompt).toMatch(/search_funds/);
expect(prompt).toMatch(/search_filers/);
\`\`\`

Preserves the original test's intent — the unchanged hard-decline language (\`Even labeled-as-approximate fabrication is forbidden\` + \`Never fabricate portfolio composition\`) still asserted.

## Test plan

- [x] \`npx vitest run tests/system-prompt.test.ts\` — 4/4 pass

## Stacked-PR check

Leaf. Independent of #84.

🤖 Generated with [Claude Code](https://claude.com/claude-code)