### PR TITLE
chore(observability): WARN when fund_fit.parquet path silently degrades — P.3

### DIFF
--- a/sdk/riskmodels/snapshots/_fund_data.py
+++ b/sdk/riskmodels/snapshots/_fund_data.py
@@ -1293,15 +1293,39 @@ def get_data_for_f1(
     # 5y endpoint delta) computed by Funds_DAG asset `fund_fit_parquet`.
     # Section III renders these in the fit card + drives the deterministic
     # narrative wording. Soft-fails when the parquet is absent or this
-    # fund has no row.
+    # fund has no row. WARN-on-silent-fallback per P.3 — missing
+    # fund_fit.parquet collapses the entire Section III fit card to None,
+    # which is a real degradation, not a normal absence. In prod
+    # (render-svc on Cloud Run), the typical cause is
+    # FUNDS_DAG_DATA_ROOT not being set, so `_funds_latest_path()` falls
+    # back to a sibling path that doesn't exist. Surface that loudly.
     fit_kw: dict[str, Any] = {}
     try:
         import pandas as _pd
         fit_path = _funds_latest_path().parent / "fund_fit.parquet"
-        if fit_path.exists():
+        if not fit_path.exists():
+            log.warning(
+                "fund_fit.parquet missing at %s for %s; Section III fit card "
+                "renders blank (fit_coverage / correlation_monthly / "
+                "delta_5y_pp etc. all None). Operational cause is usually "
+                "FUNDS_DAG_DATA_ROOT unset on render-svc Cloud Run, or "
+                "fund_fit.parquet not baked into the mounted root. See "
+                "BWMACRO master backlog P.3 / O.9.",
+                fit_path, bw_fund_id,
+            )
+        else:
             _fit_df = _pd.read_parquet(fit_path)
             _hit = _fit_df[_fit_df["bw_fund_id"] == bw_fund_id]
-            if len(_hit):
+            if not len(_hit):
+                log.warning(
+                    "fund_fit.parquet present at %s but contains no row for "
+                    "bw_fund_id=%s; Section III fit card renders blank for "
+                    "this fund only (other funds presumably fine). Likely "
+                    "the fund-fit asset run hasn't covered this id yet — "
+                    "cross-check against the asset's expected universe.",
+                    fit_path, bw_fund_id,
+                )
+            else:
                 _r = _hit.iloc[0]
                 def _opt(v: Any) -> Any:
                     if v is None or (isinstance(v, float) and not np.isfinite(v)):
@@ -1327,8 +1351,12 @@ def get_data_for_f1(
                     "fit_residual_vol":       _opt(_r.get("nav_residual_vol_5y")),
                     "fit_erm3_multifactor_r2": _opt(_r.get("erm3_multifactor_r2_5y")),
                 }
-    except Exception:
-        pass
+    except Exception as e:
+        log.warning(
+            "fund_fit.parquet read failed for %s: %s — Section III fit card "
+            "renders blank. Falling through silently to preserve f1 render.",
+            bw_fund_id, e,
+        )
 
     # ── Portfolio variance shares ───────────────────────────────────────
     # Headline `portfolio_metrics`, in order of preference (`_basis` records it):

--- a/sdk/tests/test_fund_data_fund_fit_warnings.py
+++ b/sdk/tests/test_fund_data_fund_fit_warnings.py
@@ -1,0 +1,180 @@
+"""``get_data_for_f1`` — fund_fit.parquet warning tests (MASTER_BACKLOG P.3).
+
+Three silent-downgrade paths when the ERM3 fit data is unavailable:
+
+  1. **file missing**       — entire fit card renders blank for every fund
+                              (typical Cloud Run cause: FUNDS_DAG_DATA_ROOT
+                              unset → fallback path doesn't resolve)
+  2. **fund not in parquet** — fit card renders blank for one fund only
+                              (typical cause: fund-fit asset hasn't covered
+                              this id yet)
+  3. **read fails**          — corrupt parquet or pyarrow error; same
+                              blank-fit-card visual result
+
+All three previously fell through to ``fit_kw = {}`` with no log signal.
+The fix WARNs at each path so operators can distinguish a deploy-config
+gap from a real data-coverage gap.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from riskmodels.snapshots import _fund_data
+
+
+def _stub_loader_internals(monkeypatch, *, funds_latest_path: Path) -> None:
+    """Make all zarr stores soft-fail + force _funds_latest_path to point
+    at a controlled tmp path. The tests only care about the fund_fit.parquet
+    path; everything else is a no-op."""
+    monkeypatch.setattr(
+        _fund_data,
+        "_open_fund_zarr",
+        lambda *_a, **_kw: (_ for _ in ()).throw(FileNotFoundError("test")),
+    )
+    monkeypatch.setattr(_fund_data, "_fund_identity", lambda _id: {})
+    monkeypatch.setattr(_fund_data, "_funds_latest_path", lambda: funds_latest_path)
+
+
+# ---------------------------------------------------------------------------
+# Path 1 — file missing entirely (the Cloud Run / FUNDS_DAG_DATA_ROOT case)
+# ---------------------------------------------------------------------------
+
+
+def test_warns_when_fund_fit_parquet_missing(caplog, tmp_path, monkeypatch):
+    """The headline P.3 fix: missing parquet → WARN that names the path
+    AND points to the operational cause (FUNDS_DAG_DATA_ROOT)."""
+    funds_latest = tmp_path / "funds_latest.json"  # parent dir exists; file doesn't matter
+    _stub_loader_internals(monkeypatch, funds_latest_path=funds_latest)
+
+    with caplog.at_level(logging.WARNING, logger="riskmodels.snapshots._fund_data"):
+        _fund_data.get_data_for_f1("BW-FUND-TEST", enrich=False)
+
+    fit_warnings = [
+        r for r in caplog.records
+        if "fund_fit.parquet missing" in r.message
+    ]
+    assert len(fit_warnings) == 1
+    msg = fit_warnings[0].message
+    assert "BW-FUND-TEST" in msg
+    assert "FUNDS_DAG_DATA_ROOT" in msg  # operator hint
+    assert "render-svc" in msg.lower()    # context for the operator
+    assert fit_warnings[0].levelno == logging.WARNING
+
+
+def test_warning_message_mentions_section_iii_consequence(caplog, tmp_path, monkeypatch):
+    """The WARN must name WHAT will visually break — operators reading
+    logs shouldn't have to know the Section III mapping by heart."""
+    _stub_loader_internals(monkeypatch, funds_latest_path=tmp_path / "funds_latest.json")
+
+    with caplog.at_level(logging.WARNING, logger="riskmodels.snapshots._fund_data"):
+        _fund_data.get_data_for_f1("BW-FUND-X", enrich=False)
+
+    msg = next(
+        r.message for r in caplog.records if "fund_fit.parquet missing" in r.message
+    )
+    assert "Section III" in msg
+    assert "blank" in msg.lower()
+
+
+# ---------------------------------------------------------------------------
+# Path 2 — file present but no row for this fund
+# ---------------------------------------------------------------------------
+
+
+def test_warns_when_fund_fit_parquet_lacks_fund_row(caplog, tmp_path, monkeypatch):
+    """Parquet exists but this fund isn't in it — different operator
+    triage (asset-coverage gap, not deploy-config gap). The WARN must
+    distinguish from the file-missing case."""
+    import pandas as pd
+
+    # Build a real empty parquet so the read path executes; the fund
+    # we query won't have a matching row.
+    parent = tmp_path
+    fit_path = parent / "fund_fit.parquet"
+    pd.DataFrame({"bw_fund_id": ["BW-FUND-OTHER"]}).to_parquet(fit_path)
+
+    funds_latest = parent / "funds_latest.json"
+    _stub_loader_internals(monkeypatch, funds_latest_path=funds_latest)
+
+    with caplog.at_level(logging.WARNING, logger="riskmodels.snapshots._fund_data"):
+        _fund_data.get_data_for_f1("BW-FUND-MISSING", enrich=False)
+
+    coverage_warnings = [
+        r for r in caplog.records
+        if "contains no row" in r.message
+    ]
+    assert len(coverage_warnings) == 1
+    msg = coverage_warnings[0].message
+    assert "BW-FUND-MISSING" in msg
+    # The "no row" message should distinguish from the file-missing one
+    # by mentioning that other funds are presumably fine.
+    assert "this fund only" in msg
+    assert "asset" in msg.lower()
+
+
+# ---------------------------------------------------------------------------
+# Path 3 — read failure (corrupt parquet, missing pyarrow, etc.)
+# ---------------------------------------------------------------------------
+
+
+def test_warns_when_fund_fit_parquet_read_fails(caplog, tmp_path, monkeypatch):
+    """Any unexpected exception during the parquet read path WARNs and
+    falls through — preserves the f1 render even when fit data is broken."""
+    parent = tmp_path
+    fit_path = parent / "fund_fit.parquet"
+    # Write garbage so pandas raises on read.
+    fit_path.write_bytes(b"not a parquet file")
+
+    _stub_loader_internals(monkeypatch, funds_latest_path=parent / "funds_latest.json")
+
+    with caplog.at_level(logging.WARNING, logger="riskmodels.snapshots._fund_data"):
+        # Should NOT raise — the WARN-and-fall-through preserves the render.
+        _fund_data.get_data_for_f1("BW-FUND-CORRUPT", enrich=False)
+
+    read_warnings = [
+        r for r in caplog.records
+        if "fund_fit.parquet read failed" in r.message
+    ]
+    assert len(read_warnings) == 1
+    msg = read_warnings[0].message
+    assert "BW-FUND-CORRUPT" in msg
+    # The WARN must mention that the render continues so operators don't
+    # over-react to the warning.
+    assert "preserve" in msg.lower() or "falling through" in msg.lower()
+
+
+# ---------------------------------------------------------------------------
+# Negative — no warning when fit data resolves correctly
+# ---------------------------------------------------------------------------
+
+
+def test_no_warning_when_fund_fit_parquet_has_fund_row(caplog, tmp_path, monkeypatch):
+    """Happy path: parquet exists and has a row for this fund → no
+    WARN, fit_kw populated. Confirms the warnings are gated on actual
+    fallback firing, not noisy at every render."""
+    import pandas as pd
+
+    parent = tmp_path
+    fit_path = parent / "fund_fit.parquet"
+    # Minimal row with the bw_fund_id we query.
+    pd.DataFrame({
+        "bw_fund_id": ["BW-FUND-COVERED"],
+        "weight_coverage_mean": [0.973],
+        "correlation_monthly": [0.98],
+    }).to_parquet(fit_path)
+
+    funds_latest = parent / "funds_latest.json"
+    _stub_loader_internals(monkeypatch, funds_latest_path=funds_latest)
+
+    with caplog.at_level(logging.WARNING, logger="riskmodels.snapshots._fund_data"):
+        fd = _fund_data.get_data_for_f1("BW-FUND-COVERED", enrich=False)
+
+    fit_warnings = [
+        r for r in caplog.records
+        if "fund_fit" in r.message
+    ]
+    assert fit_warnings == []
+    # And the fit data made it onto FundData.
+    assert fd.fit_correlation_monthly == 0.98


### PR DESCRIPTION
## Summary

Closes the **code-side of MASTER_BACKLOG P.3** — the last P-section item from the back-end Q/A audit. The operational half (wire \`FUNDS_DAG_DATA_ROOT\` on Cloud Run + bake \`fund_fit.parquet\` to a GCS-mounted root) stays operator-side and is tracked under O.9; this PR provides the visibility that confirms whether that wiring took effect once it's done.

## The three silent paths now emit distinct WARNs

| Path | Visual consequence | Operator triage | WARN distinguishes by |
|---|---|---|---|
| File missing | Section III blank for EVERY fund | Cloud Run env (FUNDS_DAG_DATA_ROOT) | mentions \`FUNDS_DAG_DATA_ROOT\` + cross-refs P.3 / O.9 |
| Row missing | Section III blank for ONE fund | Asset-coverage gap | mentions \`this fund only\` + asset universe |
| Read fails | Section III blank + render preserved | Corrupt parquet or pyarrow issue | mentions \`preserve\` / \`falling through\` |

Each WARN names the \`bw_fund_id\` so operators can grep render-svc logs.

## Test plan

- [x] **+5 tests** in \`sdk/tests/test_fund_data_fund_fit_warnings.py\`:
  - File missing → WARN names \`bw_fund_id\` + \`FUNDS_DAG_DATA_ROOT\` hint
  - WARN names Section III + blank visual consequence
  - No-row case → DIFFERENT WARN distinguishes from file-missing
  - Read failure → WARN + render preserved (no exception propagates)
  - Happy path: no warning when fit data resolves correctly
- [x] **Full SDK suite: 404 passed** (was 399, +5)

## Stacked-PR check

Leaf — independent of every other open PR. Safe to squash-merge anytime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)