### PR TITLE
feat(lstar): /api/lstar endpoint + methodology — recommended hedge level

### DIFF
--- a/OPENAPI_SPEC.yaml
+++ b/OPENAPI_SPEC.yaml
@@ -1263,6 +1263,99 @@ components:
           type: string
           example: security_history
 
+    LstarResponse:
+      type: object
+      description: >
+        Per-(ticker, date) recommended hedge level (L1/L2/L3) with the chosen level's dispatched hedge
+        ratios and total explained-return. Arrays are parallel by date index. Each L\* is a standalone
+        hedge solution (not stacked layers) — `market_hr`/`sector_hr`/`subsector_hr` come from the
+        chosen level's solver and are `null` where the chosen level doesn't use that ETF
+        (sector_hr is null when L\*=L1; subsector_hr is null when L\*∈{L1,L2}).
+      required:
+        - ticker
+        - dates
+        - lstar
+        - market_hr
+        - sector_hr
+        - subsector_hr
+        - total_er
+        - l2_sector_er
+        - l3_subsector_er
+        - threshold_used
+        - market_factor_etf
+        - universe
+        - data_source
+      properties:
+        ticker:
+          type: string
+        dates:
+          type: array
+          items:
+            type: string
+            format: date
+        lstar:
+          type: array
+          description: Recommended level per date. `null` where source ERs are unavailable.
+          items:
+            type: string
+            enum: [L1, L2, L3]
+            nullable: true
+        market_hr:
+          type: array
+          items:
+            type: number
+            format: float
+            nullable: true
+        sector_hr:
+          type: array
+          description: Hedge ratio for the sector ETF. `null` when `lstar` = `L1`.
+          items:
+            type: number
+            format: float
+            nullable: true
+        subsector_hr:
+          type: array
+          description: Hedge ratio for the subsector ETF. `null` when `lstar` ∈ {`L1`, `L2`}.
+          items:
+            type: number
+            format: float
+            nullable: true
+        total_er:
+          type: array
+          description: >
+            Sum of explained-return components at the chosen level (market + sector + subsector,
+            omitting residual).
+          items:
+            type: number
+            format: float
+            nullable: true
+        l2_sector_er:
+          type: array
+          description: Marginal sector ER at level L2 (input to the selection rule, exposed for audit).
+          items:
+            type: number
+            format: float
+            nullable: true
+        l3_subsector_er:
+          type: array
+          description: Marginal subsector ER at level L3 (input to the selection rule, exposed for audit).
+          items:
+            type: number
+            format: float
+            nullable: true
+        threshold_used:
+          type: number
+          format: float
+          example: 0.01
+          description: The marginal-ER threshold used to assign each date's level.
+        market_factor_etf:
+          type: string
+        universe:
+          type: string
+        data_source:
+          type: string
+          example: zarr
+
     FactorCorrelationRequest:
       type: object
       required:
@@ -3521,6 +3614,108 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/L3DecompositionResponse"
+        "401":
+          description: Missing or invalid Bearer token.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "402":
+          description: Insufficient balance.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InsufficientBalance"
+        "404":
+          description: Ticker not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "429":
+          description: Rate limit exceeded.
+          headers:
+            Retry-After:
+              schema: { type: integer }
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RateLimitExceeded"
+
+  /lstar:
+    get:
+      summary: Recommended hedge level (L*) per date with dispatched HRs
+      description: >
+        Per-(ticker, date) recommended hedge level — the simplest level whose marginal explained-return clears
+        the threshold:
+
+          • if `L3_subsector_ER ≥ θ` → `L3` (3-ETF hedge: market + sector + subsector)
+          • elif `L2_sector_ER ≥ θ` → `L2` (2-ETF hedge: market + sector)
+          • else                    → `L1` (1-ETF hedge: market only)
+
+        Default `θ = 0.01` (1%). The chat-facing default is server-authoritative; SDK callers can override
+        via `?threshold=`. Response carries the chosen level's market / sector / subsector hedge ratios
+        (nulls below the chosen level), the chosen level's total ER, and the raw `l2_sector_er` /
+        `l3_subsector_er` inputs for audit. See the side study at
+        `RM_ORG/content/Medium/series/drafts/lstar_selection/` for why 1% is the default.
+
+        **Billing:** $0.02 per request.
+      operationId: getLstar
+      tags: [Risk Metrics]
+      x-pricing:
+        capability_id: lstar
+        tier: premium
+        model: per_request
+        cost_usd: 0.02
+        currency: USD
+        billing_code: lstar_v1
+      parameters:
+        - name: ticker
+          in: query
+          required: true
+          schema: { type: string }
+          example: AAPL
+        - name: market_factor_etf
+          in: query
+          required: false
+          schema:
+            type: string
+            default: SPY
+          description: Market factor ETF passed through to the underlying L1/L2/L3 fields.
+        - name: years
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 15
+            default: 1
+          description: Calendar years of daily history.
+        - name: threshold
+          in: query
+          required: false
+          schema:
+            type: number
+            minimum: 0
+            maximum: 0.5
+            default: 0.01
+          description: >
+            Marginal-ER threshold for the L*/L1/L2/L3 selection rule. Default 0.01 (1%). Chat / agentic
+            surfaces should leave at the default; SDK callers may tune. Backtests across 275 tickers ×
+            11 sectors found no compelling reason for per-sector thresholds.
+      responses:
+        "200":
+          description: Per-date recommended level + dispatched hedge ratios.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/LstarResponse"
+        "400":
+          description: Invalid request.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         "401":
           description: Missing or invalid Bearer token.
           content:

--- a/app/api/lstar/route.ts
+++ b/app/api/lstar/route.ts
@@ -1,0 +1,138 @@
+import { NextRequest, NextResponse } from "next/server";
+import { withBilling, BillingContext } from "@/lib/agent/billing-middleware";
+import { getLstarService } from "@/lib/risk/lstar-service";
+import { getRiskMetadata } from "@/lib/dal/risk-metadata";
+import { addMetadataHeaders, buildMetadataBody } from "@/lib/dal/response-headers";
+import { LstarRequestSchema } from "@/lib/api/schemas";
+import { getCorsHeaders } from "@/lib/cors";
+import { parseFormat, formatResponse } from "@/lib/api/format-response";
+
+export const runtime = "nodejs";
+
+function classifyLstarError(message: string): string {
+  const m = message.toLowerCase();
+  if (m.includes("zarr") || m.includes("gcs")) return "zarr_read_failed";
+  if (m.includes("registry") || m.includes("metric_key")) return "registry_resolve_failed";
+  if (m.includes("supabase") || m.includes("postgres")) return "supabase_query_failed";
+  if (m.includes("timeout") || m.includes("aborted")) return "upstream_timeout";
+  if (m.includes("network") || m.includes("econnreset")) return "network_error";
+  return "internal_error";
+}
+
+/**
+ * GET /api/lstar
+ *
+ * Per-(ticker, date) recommended hedge-level series with the chosen level's
+ * dispatched hedge ratios. The selection rule:
+ *
+ *   if L3_subsector_ER >= θ → L3 (3-ETF hedge)
+ *   elif L2_sector_ER  >= θ → L2 (2-ETF hedge)
+ *   else                   → L1 (market hedge only)
+ *
+ * θ defaults to 1% (chat-safe). SDK callers can override via `?threshold=`.
+ *
+ * Response carries the lstar string per date, the chosen level's market /
+ * sector / subsector HRs (nulls below the chosen level), and the raw ER
+ * inputs (`l2_sector_er`, `l3_subsector_er`) so callers can audit or apply
+ * their own threshold without a second request.
+ */
+export const GET = withBilling(
+  async (request: NextRequest, context: BillingContext) => {
+    const { searchParams } = new URL(request.url);
+    const origin = request.headers.get("origin");
+
+    const validation = LstarRequestSchema.safeParse({
+      ticker: searchParams.get("ticker"),
+      market_factor_etf: searchParams.get("market_factor_etf") || "SPY",
+      years: searchParams.get("years") || "1",
+      threshold: searchParams.get("threshold"),
+    });
+
+    if (!validation.success) {
+      return NextResponse.json(
+        {
+          error: "Invalid request",
+          message: validation.error.issues[0]!.message,
+        },
+        { status: 400, headers: getCorsHeaders(origin) },
+      );
+    }
+
+    const { ticker, market_factor_etf, years, threshold } = validation.data;
+
+    try {
+      const fetchStart = performance.now();
+      const service = getLstarService();
+      const result = await service.getLstar(ticker, market_factor_etf, {
+        years,
+        threshold,
+      });
+
+      if (!result) {
+        return NextResponse.json({ error: "Not found" }, { status: 404 });
+      }
+
+      const metadata = await getRiskMetadata();
+      const fetchLatency = Math.round(performance.now() - fetchStart);
+
+      const format = parseFormat(searchParams, request.headers.get("accept"));
+      if (format !== "json") {
+        const resultAny = result as unknown as Record<string, unknown>;
+        const dates = resultAny.dates as string[];
+        const csvRows = dates.map((date: string, i: number) => {
+          const row: Record<string, unknown> = { ticker: result.ticker, date };
+          for (const [key, val] of Object.entries(resultAny)) {
+            if (key === "ticker" || key === "dates") continue;
+            if (Array.isArray(val)) row[key] = (val as unknown[])[i];
+          }
+          return row;
+        });
+        return formatResponse({
+          rows: csvRows,
+          format,
+          filename: `${result.ticker}_lstar.csv`,
+          extraHeaders: getCorsHeaders(origin) as Record<string, string>,
+        });
+      }
+
+      const d = result.dates;
+      const histRange: [string, string] | undefined =
+        d.length > 0 ? [d[0]!, d[d.length - 1]!] : undefined;
+
+      const response = NextResponse.json(
+        {
+          ...result,
+          _metadata: buildMetadataBody(metadata, {
+            data_source: "zarr",
+            range: histRange,
+          }),
+        },
+        {
+          headers: {
+            ...getCorsHeaders(origin),
+            "X-Data-Fetch-Latency-Ms": String(fetchLatency),
+          },
+        },
+      );
+      addMetadataHeaders(response, metadata);
+      return response;
+    } catch (e) {
+      const errMessage = e instanceof Error ? e.message : String(e);
+      const errClass = classifyLstarError(errMessage);
+      console.error(
+        `[Lstar] ${errClass} for ticker=${ticker} years=${years} threshold=${threshold}:`,
+        errMessage,
+      );
+      return NextResponse.json(
+        {
+          error: "Internal Error",
+          error_class: errClass,
+          message: errMessage,
+          request_id: context.requestId,
+        },
+        { status: 500, headers: getCorsHeaders(origin) },
+      );
+    }
+  },
+  { capabilityId: "lstar" },
+);

--- a/content/docs/methodology.mdx
+++ b/content/docs/methodology.mdx
@@ -380,6 +380,51 @@ This +0.408% is pure stock-specific return — idiosyncratic alpha after neutral
 
 ---
 
+## Choosing a Level: The L\* Rule
+
+### The Problem
+
+L1, L2, and L3 are not stacked layers — each is a **standalone hedge solution** with its own market/sector/subsector ratios. By construction, total explained risk is monotonic in level: $ER^{L3} \geq ER^{L2} \geq ER^{L1}$. So "always pick L3" looks optimal.
+
+In practice it isn't. For mega-cap names where the subsector ETF effectively *is* the stock (AAPL ≈ XLK ≈ semiconductors), the L3 subsector hedge ratio gets unstable. The orthogonalization machinery does its job correctly, but the marginal explained-return from the third ETF can be under 1% — and the L3 hedge ratios that absorb a near-zero variance contribution flicker noisily month to month.
+
+### The Rule
+
+**L\* (L-star)** picks the simplest level whose marginal explained-return clears a threshold $\theta$:
+
+$$
+L^{*} =
+\begin{cases}
+L_3 & \text{if } ER^{L3}_{\text{subsector}} \geq \theta \\
+L_2 & \text{else if } ER^{L2}_{\text{sector}} \geq \theta \\
+L_1 & \text{otherwise}
+\end{cases}
+$$
+
+The decision is made per (ticker, month). $ER^{L2}_{\text{sector}}$ and $ER^{L3}_{\text{subsector}}$ are the orthogonalized incremental contributions at each level (defined in the variance decomposition above), so the rule is checking whether the next ETF earns its keep.
+
+### The Default: 1%
+
+The chat-facing default is $\theta = 0.01$ (1%). SDK callers can override.
+
+We chose 1% via a side study across 275 tickers (top 25 by market cap in each of 11 GICS sectors) over a 60-month window. Three variants were compared: $\theta = 1\%$ with monthly point-read inputs vs 3-month vs 12-month trailing-mean inputs. The monthly point-read won or tied in 10 of 11 sectors on forward 12-month realized explained-return, and the 12-month smoothing degraded results by up to 176 bps in Energy and Financials (where regime changes punish lagged decisions). Per-sector thresholds offered ≤ 25 bps of improvement in four sectors — not enough to trade away operational simplicity.
+
+The full study is at [`RM_ORG/content/Medium/series/drafts/lstar_selection/`](https://github.com/) (raw CSV, reproducible script, write-up).
+
+### Implications for the Hedge
+
+When L\* picks a lower level, the hedge is **smaller and simpler**, not a subset of the L3 hedge. The L\*=L2 instruction is "trade SPY + your sector ETF, in the ratios L2's solver emitted." It is not "use L3's ratios and zero out subsector." Each L\*'s ratios are internally consistent within that level's regression.
+
+When L\*=L1 — usually idiosyncratic-heavy names like Tesla or Netflix — neither the sector ETF nor the subsector ETF clears the bar. The model is telling you the residual is most of the story; sector hedging would just trade noise.
+
+### When Lower Levels Win
+
+A useful diagnostic: if a name spends most of its history at L1, the stock's risk decomposition is dominated by idiosyncrasy. Sector and subsector ETFs aren't useful tools for it. If a name oscillates between L2 and L3, the subsector ETF is borderline-useful — a quant PM might prefer L3 for completeness, but the chat-facing recommendation will alternate as the marginal explained-return crosses the 1% line.
+
+If a name parks at L3 indefinitely (typical for liquid mid-caps in well-defined subsectors — AMD in semis, MAR in hotels), the full three-ETF hedge is doing real work and the recommendation stays there.
+
+---
+
 ## Why This Matters for Trading
 
 ### Direct Hedging

--- a/lib/agent/capabilities.ts
+++ b/lib/agent/capabilities.ts
@@ -684,6 +684,59 @@ export const CAPABILITIES: Capability[] = [
     tags: ["risk", "decomposition", "l3"],
   },
   {
+    id: "lstar",
+    name: "Lstar Recommended Hedge Level",
+    description:
+      "Per-(ticker, date) recommended hedge level (L1/L2/L3) with the chosen level's dispatched hedge ratios. Selection rule picks the simplest level whose marginal explained-return clears the threshold (default 1%); routes mega-caps with noisy subsector hedges down to L2.",
+    endpoint: "/api/lstar",
+    method: "GET",
+    parameters: {
+      ticker: {
+        type: "string",
+        required: true,
+        description: "Stock ticker symbol",
+      },
+      market_factor_etf: {
+        type: "string",
+        required: false,
+        description: "Market factor ETF",
+        default: "SPY",
+      },
+      years: {
+        type: "integer",
+        required: false,
+        description: "Calendar years of daily history",
+        default: 1,
+      },
+      threshold: {
+        type: "number",
+        required: false,
+        description:
+          "Marginal-ER threshold for level selection. Chat / agentic surfaces should leave at the 1% default; SDK callers may override.",
+        default: 0.01,
+      },
+    },
+    pricing: {
+      model: "per_request",
+      tier: "premium",
+      cost_usd: 0.02,
+      currency: "USD",
+      billing_code: "lstar_v1",
+    },
+    performance: {
+      avg_latency_ms: 130,
+      p95_latency_ms: 220,
+      availability_sla: 99.9,
+      rate_limit_per_minute: 60,
+    },
+    confidence: {
+      data_quality_score: 0.99,
+      update_frequency: "daily",
+      sources: ["erm3_models", "security_history"],
+    },
+    tags: ["risk", "decomposition", "lstar", "hedge"],
+  },
+  {
     id: "portfolio-returns",
     name: "Portfolio Returns",
     description: "Batch fetch returns for multiple tickers (portfolio analytics)",

--- a/lib/agent/cost-estimator.ts
+++ b/lib/agent/cost-estimator.ts
@@ -46,6 +46,7 @@ const ENDPOINT_TO_CAPABILITY: Record<string, string> = {
   "metrics": "metrics-snapshot",
   "metrics-snapshot": "metrics-snapshot",
   "l3-decomposition": "l3-decomposition",
+  lstar: "lstar",
   "portfolio-returns": "portfolio-returns",
   "portfolio-risk-index": "portfolio-risk-index",
   "macro-factors": "macro-factor-series",

--- a/lib/api-response.ts
+++ b/lib/api-response.ts
@@ -112,6 +112,7 @@ export const PRICING = {
   RETURNS: 0.005,
   ETF_RETURNS: 0.005,
   L3_DECOMPOSITION: 0.02,
+  LSTAR: 0.02,
   BATCH_ANALYZE_PER_POSITION: 0.005,
   BATCH_ANALYZE_MIN: 0.01,
   TICKERS: 0.001,
@@ -138,6 +139,8 @@ export function estimateCost(
       return PRICING.ETF_RETURNS;
     case "l3-decomposition":
       return PRICING.L3_DECOMPOSITION;
+    case "lstar":
+      return PRICING.LSTAR;
     case "batch-analyze":
       return Math.max(
         PRICING.BATCH_ANALYZE_MIN,

--- a/lib/api/schemas.ts
+++ b/lib/api/schemas.ts
@@ -55,6 +55,24 @@ export const L3DecompositionRequestSchema = z.object({
 });
 
 /**
+ * Schema for GET /api/lstar — per-(ticker, date) recommended hedge level.
+ * `threshold` is accepted for SDK callers; chat / agentic surfaces should
+ * leave it at the 1% default and treat the response as server-authoritative.
+ */
+export const LstarRequestSchema = z.object({
+  ticker: TickerSchema,
+  market_factor_etf: z.string().default("SPY"),
+  years: YearsSchema,
+  threshold: z.coerce
+    .number()
+    .min(0, "threshold must be >= 0")
+    .max(0.5, "threshold must be <= 0.5 (50%)")
+    .default(0.01),
+});
+
+export type LstarRequest = z.infer<typeof LstarRequestSchema>;
+
+/**
  * Schema for POST /api/decompose — simplified four-layer exposure + hedge map.
  * Returns market / sector / subsector / residual with each tradable layer's
  * hedge ETF and a `hedge` map of ETF → dollar ratio (negative of HR by convention).

--- a/lib/risk/lstar-service.ts
+++ b/lib/risk/lstar-service.ts
@@ -1,0 +1,220 @@
+/**
+ * Lstar (L*) Selection Service
+ *
+ * Per-(ticker, teo) hedge-level recommendation. The simplest level whose
+ * marginal explained-return (ER) clears a threshold:
+ *
+ *   if L3_subsector_ER >= θ → L3 (3-ETF hedge: market + sector + subsector)
+ *   elif L2_sector_ER  >= θ → L2 (2-ETF hedge: market + sector)
+ *   else                   → L1 (1-ETF hedge: market only)
+ *
+ * Default θ = 1%. The chat-default route hardcodes this; SDK callers can pass
+ * an override.
+ *
+ * Lstar is materialized in the ERM3 hedge-weights zarr as a convenience for
+ * direct zarr consumers, but the API computes live from the L2/L3 ER inputs
+ * already exposed by the V3 DAL. Live derivation lets callers tune θ without
+ * waiting for an ERM3 rebuild.
+ *
+ * Background: see RM_ORG/content/Medium/series/drafts/lstar_selection/article.md
+ * for the side study that locked the 1% / 1m default.
+ */
+
+import {
+  resolveSymbolByTicker,
+  fetchHistory,
+  pivotHistory,
+  type V3MetricKey,
+} from "@/lib/dal/risk-engine-v3";
+
+export const LSTAR_DEFAULT_THRESHOLD = 0.01;
+
+export type LstarLevel = "L1" | "L2" | "L3";
+
+export interface LstarResult {
+  ticker: string;
+  dates: string[];
+  /** Recommended level per date, null where source ERs are unavailable. */
+  lstar: (LstarLevel | null)[];
+  /** Hedge ratio for the market ETF, drawn from the chosen level's solver. */
+  market_hr: (number | null)[];
+  /** Hedge ratio for the sector ETF; null when Lstar = L1. */
+  sector_hr: (number | null)[];
+  /** Hedge ratio for the subsector ETF; null when Lstar ∈ {L1, L2}. */
+  subsector_hr: (number | null)[];
+  /** Total explained-return at the chosen level (market + sector + subsector). */
+  total_er: (number | null)[];
+  /** Raw inputs to the selection rule, surfaced for audit / SDK override. */
+  l2_sector_er: (number | null)[];
+  l3_subsector_er: (number | null)[];
+  threshold_used: number;
+  market_factor_etf: string;
+  universe: string;
+  data_source: string;
+}
+
+function pickLstar(
+  l2SecEr: number | null,
+  l3SubEr: number | null,
+  threshold: number,
+): LstarLevel | null {
+  // Both inputs null → can't decide (pre-IPO, delisted, masked).
+  if (l2SecEr == null && l3SubEr == null) return null;
+  // The selection rule is order-sensitive — check L3 first (highest granularity
+  // that meets the bar), then L2, default L1. NaN-safe via null coalescing.
+  if (l3SubEr != null && l3SubEr >= threshold) return "L3";
+  if (l2SecEr != null && l2SecEr >= threshold) return "L2";
+  return "L1";
+}
+
+export class LstarService {
+  /**
+   * Resolve Lstar + dispatched hedge ratios for a ticker across a daily window.
+   *
+   * @param ticker          Stock ticker (e.g. "AAPL")
+   * @param marketFactorEtf Market factor ETF (default "SPY")
+   * @param options.years   Calendar years of history (default 1)
+   * @param options.threshold  Marginal-ER threshold; default 1%
+   */
+  async getLstar(
+    ticker: string,
+    marketFactorEtf: string = "SPY",
+    options?: { years?: number; threshold?: number },
+  ): Promise<LstarResult | null> {
+    const upperTicker = ticker.toUpperCase();
+    const years = options?.years ?? 1;
+    const threshold = options?.threshold ?? LSTAR_DEFAULT_THRESHOLD;
+
+    const symbolRecord = await resolveSymbolByTicker(upperTicker);
+    if (!symbolRecord) return null;
+
+    const startDate = new Date();
+    startDate.setFullYear(startDate.getFullYear() - years);
+    const startDateStr = startDate.toISOString().split("T")[0]!;
+
+    const keys: V3MetricKey[] = [
+      "l1_mkt_hr",
+      "l2_mkt_hr",
+      "l2_sec_hr",
+      "l3_mkt_hr",
+      "l3_sec_hr",
+      "l3_sub_hr",
+      "l1_mkt_er",
+      "l2_mkt_er",
+      "l2_sec_er",
+      "l3_mkt_er",
+      "l3_sec_er",
+      "l3_sub_er",
+    ];
+
+    const rows = await fetchHistory(symbolRecord.symbol, keys, {
+      periodicity: "daily",
+      startDate: startDateStr,
+      orderBy: "asc",
+    });
+
+    if (rows.length === 0) {
+      return this.emptyResult(upperTicker, marketFactorEtf, threshold);
+    }
+
+    const pivoted = pivotHistory(rows);
+    if (pivoted.length === 0) {
+      return this.emptyResult(upperTicker, marketFactorEtf, threshold);
+    }
+
+    const dates = pivoted.map((p) => p.teo);
+    const lstar: (LstarLevel | null)[] = [];
+    const market_hr: (number | null)[] = [];
+    const sector_hr: (number | null)[] = [];
+    const subsector_hr: (number | null)[] = [];
+    const total_er: (number | null)[] = [];
+    const l2_sector_er: (number | null)[] = [];
+    const l3_subsector_er: (number | null)[] = [];
+
+    for (const p of pivoted) {
+      const l2s = (p.l2_sec_er as number | null) ?? null;
+      const l3ss = (p.l3_sub_er as number | null) ?? null;
+      const chosen = pickLstar(l2s, l3ss, threshold);
+      lstar.push(chosen);
+      l2_sector_er.push(l2s);
+      l3_subsector_er.push(l3ss);
+
+      // Dispatch hedges and total ER to the chosen level. Each L* is a
+      // self-contained hedge solution — we use its own market/sector/subsector
+      // HRs as emitted by the ERM3 solver, not a stitched-across-levels sum.
+      if (chosen === "L3") {
+        market_hr.push((p.l3_mkt_hr as number | null) ?? null);
+        sector_hr.push((p.l3_sec_hr as number | null) ?? null);
+        subsector_hr.push((p.l3_sub_hr as number | null) ?? null);
+        const m = (p.l3_mkt_er as number | null) ?? 0;
+        const s = (p.l3_sec_er as number | null) ?? 0;
+        const ss = l3ss ?? 0;
+        total_er.push(m + s + ss);
+      } else if (chosen === "L2") {
+        market_hr.push((p.l2_mkt_hr as number | null) ?? null);
+        sector_hr.push((p.l2_sec_hr as number | null) ?? null);
+        subsector_hr.push(null);
+        const m = (p.l2_mkt_er as number | null) ?? 0;
+        const s = l2s ?? 0;
+        total_er.push(m + s);
+      } else if (chosen === "L1") {
+        market_hr.push((p.l1_mkt_hr as number | null) ?? null);
+        sector_hr.push(null);
+        subsector_hr.push(null);
+        const m = (p.l1_mkt_er as number | null) ?? null;
+        total_er.push(m);
+      } else {
+        market_hr.push(null);
+        sector_hr.push(null);
+        subsector_hr.push(null);
+        total_er.push(null);
+      }
+    }
+
+    return {
+      ticker: upperTicker,
+      dates,
+      lstar,
+      market_hr,
+      sector_hr,
+      subsector_hr,
+      total_er,
+      l2_sector_er,
+      l3_subsector_er,
+      threshold_used: threshold,
+      market_factor_etf: marketFactorEtf,
+      universe: "US_EQUITY",
+      data_source: "zarr",
+    };
+  }
+
+  private emptyResult(
+    ticker: string,
+    marketFactorEtf: string,
+    threshold: number,
+  ): LstarResult {
+    return {
+      ticker,
+      dates: [],
+      lstar: [],
+      market_hr: [],
+      sector_hr: [],
+      subsector_hr: [],
+      total_er: [],
+      l2_sector_er: [],
+      l3_subsector_er: [],
+      threshold_used: threshold,
+      market_factor_etf: marketFactorEtf,
+      universe: "US_EQUITY",
+      data_source: "zarr",
+    };
+  }
+}
+
+let _instance: LstarService | null = null;
+export function getLstarService(): LstarService {
+  if (!_instance) {
+    _instance = new LstarService();
+  }
+  return _instance;
+}

--- a/mcp/data/openapi.json
+++ b/mcp/data/openapi.json
@@ -1368,6 +1368,119 @@
           }
         }
       },
+      "LstarResponse": {
+        "type": "object",
+        "description": "Per-(ticker, date) recommended hedge level (L1/L2/L3) with the chosen level's dispatched hedge ratios and total explained-return. Arrays are parallel by date index. Each L\\* is a standalone hedge solution (not stacked layers) — `market_hr`/`sector_hr`/`subsector_hr` come from the chosen level's solver and are `null` where the chosen level doesn't use that ETF (sector_hr is null when L\\*=L1; subsector_hr is null when L\\*∈{L1,L2}).\n",
+        "required": [
+          "ticker",
+          "dates",
+          "lstar",
+          "market_hr",
+          "sector_hr",
+          "subsector_hr",
+          "total_er",
+          "l2_sector_er",
+          "l3_subsector_er",
+          "threshold_used",
+          "market_factor_etf",
+          "universe",
+          "data_source"
+        ],
+        "properties": {
+          "ticker": {
+            "type": "string"
+          },
+          "dates": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "date"
+            }
+          },
+          "lstar": {
+            "type": "array",
+            "description": "Recommended level per date. `null` where source ERs are unavailable.",
+            "items": {
+              "type": "string",
+              "enum": [
+                "L1",
+                "L2",
+                "L3"
+              ],
+              "nullable": true
+            }
+          },
+          "market_hr": {
+            "type": "array",
+            "items": {
+              "type": "number",
+              "format": "float",
+              "nullable": true
+            }
+          },
+          "sector_hr": {
+            "type": "array",
+            "description": "Hedge ratio for the sector ETF. `null` when `lstar` = `L1`.",
+            "items": {
+              "type": "number",
+              "format": "float",
+              "nullable": true
+            }
+          },
+          "subsector_hr": {
+            "type": "array",
+            "description": "Hedge ratio for the subsector ETF. `null` when `lstar` ∈ {`L1`, `L2`}.",
+            "items": {
+              "type": "number",
+              "format": "float",
+              "nullable": true
+            }
+          },
+          "total_er": {
+            "type": "array",
+            "description": "Sum of explained-return components at the chosen level (market + sector + subsector, omitting residual).\n",
+            "items": {
+              "type": "number",
+              "format": "float",
+              "nullable": true
+            }
+          },
+          "l2_sector_er": {
+            "type": "array",
+            "description": "Marginal sector ER at level L2 (input to the selection rule, exposed for audit).",
+            "items": {
+              "type": "number",
+              "format": "float",
+              "nullable": true
+            }
+          },
+          "l3_subsector_er": {
+            "type": "array",
+            "description": "Marginal subsector ER at level L3 (input to the selection rule, exposed for audit).",
+            "items": {
+              "type": "number",
+              "format": "float",
+              "nullable": true
+            }
+          },
+          "threshold_used": {
+            "type": "number",
+            "format": "float",
+            "example": 0.01,
+            "description": "The marginal-ER threshold used to assign each date's level."
+          },
+          "market_factor_etf": {
+            "type": "string"
+          },
+          "universe": {
+            "type": "string"
+          },
+          "data_source": {
+            "type": "string",
+            "example": "zarr"
+          }
+        }
+      },
       "FactorCorrelationRequest": {
         "type": "object",
         "required": [
@@ -5055,6 +5168,138 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/L3DecompositionResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid Bearer token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Insufficient balance.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InsufficientBalance"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Ticker not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded.",
+            "headers": {
+              "Retry-After": {
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RateLimitExceeded"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/lstar": {
+      "get": {
+        "summary": "Recommended hedge level (L*) per date with dispatched HRs",
+        "description": "Per-(ticker, date) recommended hedge level — the simplest level whose marginal explained-return clears the threshold:\n\n  • if `L3_subsector_ER ≥ θ` → `L3` (3-ETF hedge: market + sector + subsector)\n  • elif `L2_sector_ER ≥ θ` → `L2` (2-ETF hedge: market + sector)\n  • else                    → `L1` (1-ETF hedge: market only)\n\nDefault `θ = 0.01` (1%). The chat-facing default is server-authoritative; SDK callers can override via `?threshold=`. Response carries the chosen level's market / sector / subsector hedge ratios (nulls below the chosen level), the chosen level's total ER, and the raw `l2_sector_er` / `l3_subsector_er` inputs for audit. See the side study at `RM_ORG/content/Medium/series/drafts/lstar_selection/` for why 1% is the default.\n**Billing:** $0.02 per request.\n",
+        "operationId": "getLstar",
+        "tags": [
+          "Risk Metrics"
+        ],
+        "x-pricing": {
+          "capability_id": "lstar",
+          "tier": "premium",
+          "model": "per_request",
+          "cost_usd": 0.02,
+          "currency": "USD",
+          "billing_code": "lstar_v1"
+        },
+        "parameters": [
+          {
+            "name": "ticker",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "AAPL"
+          },
+          {
+            "name": "market_factor_etf",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "SPY"
+            },
+            "description": "Market factor ETF passed through to the underlying L1/L2/L3 fields."
+          },
+          {
+            "name": "years",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 15,
+              "default": 1
+            },
+            "description": "Calendar years of daily history."
+          },
+          {
+            "name": "threshold",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 0.5,
+              "default": 0.01
+            },
+            "description": "Marginal-ER threshold for the L*/L1/L2/L3 selection rule. Default 0.01 (1%). Chat / agentic surfaces should leave at the default; SDK callers may tune. Backtests across 275 tickers × 11 sectors found no compelling reason for per-sector thresholds.\n"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Per-date recommended level + dispatched hedge ratios.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LstarResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }


### PR DESCRIPTION
## Summary
- New REST endpoint `GET /api/lstar?ticker=<T>` returning a per-(ticker, date) recommended hedge level (L1/L2/L3) with the chosen level's dispatched HRs (market/sector/subsector) and total ER
- Dedicated service computes Lstar **live** from L2/L3 ER inputs already served by the V3 DAL — no dependency on the companion ERM3 PR landing first
- Default threshold 0.01 (1%); SDK callers can override via `?threshold=`
- Public methodology doc gets a new "Choosing a Level: The L\* Rule" section

## Why
For mega-caps where the subsector ETF effectively *is* the stock (AAPL ≈ semiconductors), L3 hedge ratios get unstable while their marginal explained-return stays near zero. Chat / agent surfaces don't have the judgment to pick a level — they need a server-authoritative answer. Lstar gives them one.

## Threshold defense
275-ticker × 11-sector × 60-month side study (full writeup at `RM_ORG/content/Medium/series/drafts/lstar_selection/`):
- 1m point-read at 1% wins or ties 12m smoothing in 10/11 sectors on forward 12m realized ER
- 12m smoothing degrades by up to **176 bps in Energy**, **154 bps in Financials**
- 3m smoothing offers ≤25 bps improvement in 4 sectors — not worth tuning
- 1% threshold sits in a sane place: AAPL gets demoted to L1 ~19% of months (noise rejection), TSLA spends ~66% of months at L2, XOM is 100% L2, AMD is 100% L3

## Companion PRs
- **ERM3** [#24](https://github.com/BlueWaterCorp/ERM3/pull/24) — materializes Lstar + ER cube in the hedge_weights zarr (additive; not a blocker for this PR since service computes live)
- **RM_ORG** — Medium article + reproducible study (separate PR; methodology doc here links to it)

## What ships
| File | Change |
|---|---|
| `app/api/lstar/route.ts` | New REST endpoint, billing + CORS + CSV format support, mirrors `/l3-decomposition` |
| `lib/risk/lstar-service.ts` | New service; computes Lstar from `l2_sec_er` + `l3_sub_er`, dispatches HRs server-side |
| `lib/api/schemas.ts` | New `LstarRequestSchema` with threshold validation (0–0.5 range, default 0.01) |
| `lib/agent/capabilities.ts` | Capability registration for agent discovery |
| `lib/agent/cost-estimator.ts`, `lib/api-response.ts` | Billing wiring (\$0.02/request) |
| `OPENAPI_SPEC.yaml` + `mcp/data/openapi.json` | Public spec + `LstarResponse` schema |
| `content/docs/methodology.mdx` | New "Choosing a Level: The L\* Rule" section, public methodology |

## Test plan
- [ ] `GET /api/lstar?ticker=AAPL&years=1` → 200, `lstar` array length matches `dates`, latest entry should be `L3` (subsector ER ~1.99% > 1%)
- [ ] `GET /api/lstar?ticker=TSLA&years=5` → mostly `L2` entries
- [ ] `GET /api/lstar?ticker=XOM&years=5` → 100% `L2` entries
- [ ] `GET /api/lstar?ticker=AMD&years=5` → 100% `L3` entries
- [ ] `?threshold=0.02` → strictly fewer L3 picks, more L1
- [ ] `?threshold=0.005` → strictly more L3 picks
- [ ] Invalid threshold `?threshold=1.5` → 400 with validation message
- [ ] Unknown ticker → 404
- [ ] `Accept: text/csv` → CSV with per-date rows
- [ ] OpenAPI: `npm run check:openapi` (or equivalent) passes
- [ ] Methodology doc renders correctly (KaTeX block for the rule)

🤖 Generated with [Claude Code](https://claude.com/claude-code)