### PR TITLE
feat(hedge): recommendHedgeLevel + /api/hedge-basket — TS port of ERM3 SSOT

### DIFF
--- a/app/api/hedge-basket/[ticker]/route.ts
+++ b/app/api/hedge-basket/[ticker]/route.ts
@@ -1,0 +1,155 @@
+/**
+ * GET /api/hedge-basket/[ticker]
+ *
+ * Structured hedge-basket payload — the chat-rendered 4-row table with a
+ * net-market-β subtotal, plus a `decision_trace` explaining why
+ * `recommended_hedge_level` was chosen.
+ *
+ * Composes the latest-teo metric snapshot (HRs, ERs, betas) with link-betas
+ * from `ds_erm3_link_betas_{market_factor_etf}.zarr` into a structured response
+ * the chat narrates verbatim.
+ *
+ * `?user_segment=` drives the leverage cap. Defaults to family_office (2.0×).
+ *
+ * @see lib/risk/hedge-recommendation-service.ts (buildHedgeBasket)
+ * @see docs/plans/hedge-recommendation-ts-port.md
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { getCorsHeaders } from "@/lib/cors";
+import { withBilling, BillingContext } from "@/lib/agent/billing-middleware";
+import {
+  resolveSymbolByTicker,
+  fetchLatestMetricsWithFallback,
+} from "@/lib/dal/risk-engine-v3";
+import { readLatestLinkBetas } from "@/lib/dal/zarr-reader";
+import { getRiskMetadata } from "@/lib/dal/risk-metadata";
+import { addMetadataHeaders, buildMetadataBody } from "@/lib/dal/response-headers";
+import { buildHedgeBasket } from "@/lib/risk/hedge-recommendation-service";
+import { HedgeBasketRequestSchema } from "@/lib/api/schemas";
+
+export const runtime = "nodejs";
+
+export const GET = withBilling(
+  async (request: NextRequest, _context: BillingContext) => {
+    const rawTicker = request.nextUrl.pathname.split("/").pop();
+    const origin = request.headers.get("origin");
+
+    const validation = HedgeBasketRequestSchema.safeParse({
+      ticker: rawTicker,
+      user_segment: request.nextUrl.searchParams.get("user_segment") ?? undefined,
+      market_factor_etf: request.nextUrl.searchParams.get("market_factor_etf") ?? undefined,
+    });
+    if (!validation.success) {
+      return NextResponse.json(
+        {
+          error: "Invalid request",
+          message: validation.error.issues[0]!.message,
+        },
+        { status: 400, headers: getCorsHeaders(origin) },
+      );
+    }
+
+    const { ticker, user_segment, market_factor_etf } = validation.data;
+
+    try {
+      const fetchStart = performance.now();
+
+      const symbolRecord = await resolveSymbolByTicker(ticker);
+      if (!symbolRecord) {
+        const metadata = await getRiskMetadata();
+        const response = NextResponse.json(
+          { error: "Symbol not found" },
+          { status: 404, headers: getCorsHeaders(origin) },
+        );
+        addMetadataHeaders(response, metadata);
+        return response;
+      }
+
+      const latestData = await fetchLatestMetricsWithFallback(
+        symbolRecord.symbol,
+        [
+          "l1_mkt_hr",
+          "l2_mkt_hr",
+          "l2_sec_hr",
+          "l3_mkt_hr",
+          "l3_sec_hr",
+          "l3_sub_hr",
+          "l2_sec_er",
+          "l3_sub_er",
+          "l1_mkt_beta",
+        ],
+        "daily",
+      );
+      if (!latestData) {
+        const metadata = await getRiskMetadata();
+        const response = NextResponse.json(
+          { error: "No metrics found" },
+          { status: 404, headers: getCorsHeaders(origin) },
+        );
+        addMetadataHeaders(response, metadata);
+        return response;
+      }
+
+      const m = latestData.metrics;
+      const sectorEtf = symbolRecord.sector_etf || null;
+      const subsectorEtf = symbolRecord.subsector_etf || symbolRecord.sector_etf || null;
+
+      // Link-betas: one cell each from the SPY-rooted ETF-to-ETF store.
+      // Falls back to NaN if the store is unreachable — the basket assembler
+      // treats null λ as 0 (per-leg market β contribution becomes 0).
+      const linkBetas = await readLatestLinkBetas(sectorEtf, subsectorEtf, market_factor_etf);
+
+      const basket = buildHedgeBasket({
+        ticker,
+        as_of: latestData.teo,
+        l1_mkt_hr: m.l1_mkt_hr ?? null,
+        l2_mkt_hr: m.l2_mkt_hr ?? null,
+        l2_sec_hr: m.l2_sec_hr ?? null,
+        l3_mkt_hr: m.l3_mkt_hr ?? null,
+        l3_sec_hr: m.l3_sec_hr ?? null,
+        l3_sub_hr: m.l3_sub_hr ?? null,
+        l2_sec_er: m.l2_sec_er ?? null,
+        l3_sub_er: m.l3_sub_er ?? null,
+        beta_m_aapl: m.l1_mkt_beta ?? null,
+        sector_etf_ticker: sectorEtf,
+        subsector_etf_ticker: subsectorEtf,
+        market_etf_ticker: market_factor_etf,
+        lambda_s_to_m: linkBetas?.lambda_s_to_m ?? null,
+        lambda_u_to_m: linkBetas?.lambda_u_to_m ?? null,
+        user_segment,
+      });
+
+      const metadata = await getRiskMetadata();
+      const fetchLatency = Math.round(performance.now() - fetchStart);
+
+      const responseBody = {
+        ...basket,
+        _metadata: buildMetadataBody(metadata, {
+          factors: [market_factor_etf, sectorEtf, subsectorEtf].filter(Boolean) as string[],
+        }),
+      };
+
+      const response = NextResponse.json(responseBody, {
+        headers: {
+          ...getCorsHeaders(origin),
+          "Content-Type": "application/json",
+          "Cache-Control": "public, s-maxage=300, stale-while-revalidate=600",
+          "X-Data-Fetch-Latency-Ms": String(fetchLatency),
+        },
+      });
+      addMetadataHeaders(response, metadata);
+      return response;
+    } catch (error) {
+      console.error(`[hedge-basket] Exception for ${ticker}:`, error);
+      const metadata = await getRiskMetadata();
+      const response = NextResponse.json(
+        { error: error instanceof Error ? error.message : "Unknown error" },
+        { status: 500, headers: getCorsHeaders(origin) },
+      );
+      addMetadataHeaders(response, metadata);
+      return response;
+    }
+  },
+  { capabilityId: "hedge-basket" },
+);

--- a/app/api/metrics/[ticker]/route.ts
+++ b/app/api/metrics/[ticker]/route.ts
@@ -9,6 +9,11 @@ import {
 import { getRiskMetadata } from "@/lib/dal/risk-metadata";
 import { addMetadataHeaders, buildMetadataBody } from "@/lib/dal/response-headers";
 import { MetricsRequestSchema } from "@/lib/api/schemas";
+import {
+  computeHedgeRecommendationSnapshot,
+  isValidUserSegment,
+} from "@/lib/risk/hedge-recommendation-service";
+import { DEFAULT_USER_SEGMENT } from "@/lib/dal/hedge-recommendation";
 import { authenticateRequest } from "@/lib/supabase/auth-helper";
 import { checkPlaygroundMetricsRateLimit } from "@/lib/ratelimit/playground-metrics-rate-limit";
 import {
@@ -201,6 +206,27 @@ export const GET = withBilling(
       metadata.data_as_of,
     );
 
+    // Hedge recommendation snapshot: economic recommendation on top of Lstar.
+    // user_segment query param drives the leverage cap; falls back to family_office
+    // (2.0×) on missing / invalid values. Pure compute from already-fetched metrics
+    // — no extra IO. See docs/plans/hedge-recommendation-ts-port.md for the spec
+    // and ~/BW_Code/ERM3/erm3/shared/hedge_recommendation.py for the Python SSOT.
+    const userSegmentRaw = request.nextUrl.searchParams.get("user_segment");
+    const userSegment = isValidUserSegment(userSegmentRaw)
+      ? userSegmentRaw
+      : DEFAULT_USER_SEGMENT;
+    const hedgeRec = computeHedgeRecommendationSnapshot({
+      l1_mkt_hr: m.l1_mkt_hr ?? null,
+      l2_mkt_hr: m.l2_mkt_hr ?? null,
+      l2_sec_hr: m.l2_sec_hr ?? null,
+      l3_mkt_hr: m.l3_mkt_hr ?? null,
+      l3_sec_hr: m.l3_sec_hr ?? null,
+      l3_sub_hr: m.l3_sub_hr ?? null,
+      l2_sec_er: m.l2_sec_er ?? null,
+      l3_sub_er: m.l3_sub_er ?? null,
+      user_segment: userSegment,
+    });
+
     const formattedData = {
       symbol: symbolRecord.symbol,
       ticker: symbolRecord.ticker,
@@ -241,6 +267,16 @@ export const GET = withBilling(
         l1_mkt_beta: m.l1_mkt_beta ?? null,
         l2_sec_beta: m.l2_sec_beta ?? null,
         l3_sub_beta: m.l3_sub_beta ?? null,
+        // Hedge-recommendation snapshot — economic layer on Lstar.
+        // recommended_hedge_level ≠ lstar is the regime-change alert the chat surfaces.
+        lstar: hedgeRec.lstar,
+        recommended_hedge_level: hedgeRec.recommended_hedge_level,
+        user_segment_applied: hedgeRec.user_segment_applied,
+        leverage_cap_applied: hedgeRec.leverage_cap_applied,
+        l1_hedge_gross: hedgeRec.l1_hedge_gross,
+        l2_hedge_gross: hedgeRec.l2_hedge_gross,
+        l3_hedge_gross: hedgeRec.l3_hedge_gross,
+        higher_er_haircut: hedgeRec.higher_er_haircut,
       },
       meta: {
         sector_etf: symbolRecord.sector_etf || null,

--- a/docs/plans/hedge-recommendation-ts-port.md
+++ b/docs/plans/hedge-recommendation-ts-port.md
@@ -1,0 +1,250 @@
+# Hedge-recommendation TS port — spec
+
+**Status:** spec only (no code yet)
+**Owner:** Conrad Gann
+**Related task:** #21 (`API: /api/hedge-basket/{ticker} endpoint`)
+**Python SSOT:** `~/BW_Code/ERM3/erm3/shared/hedge_recommendation.py`
+**Python tests:** `~/BW_Code/ERM3/tests/test_hedge_recommendation.py` (12/12 passing)
+
+## Purpose
+
+Surface a **trader-grade** hedge recommendation alongside the existing **statistical** `Lstar` field. Today the chat shows `Lstar=L3` and `Market HR (L3) = -2.00` without any framing — a reader (correctly) infers a beta of 2 and recoils. Adding `recommended_hedge_level` plus per-leg gross-leverage breakdown gives the chat the structured object it needs to recommend a hedge a real desk would respect.
+
+Critical constraint: the Python implementation in ERM3 is the **single source of truth** for the decision rule. This TS port must produce byte-identical output for the same inputs. Any change to the rule must land in Python first; this TS file mirrors it.
+
+## Decision rule (short form)
+
+`recommendHedgeLevel(...)` takes `Lstar` as the statistical floor and steps it down zero, one, or two levels based on two economic gates:
+
+1. **Leverage gate** — `hedge_gross` at that level exceeds the user-segment cap.
+2. **Haircut-ER gate** — the marginal ER added by that level, multiplied by an OOS haircut, falls below an economic floor.
+
+Top-down from `Lstar`:
+- L3 → L2 if either gate fails at L3
+- L2 → L1 if either gate fails at L2
+- L1 is always the floor
+
+`Lstar` itself is **never mutated**. The two fields coexist on the payload. Divergence between them is the regime-change alert the chat surfaces.
+
+## Constants (must match Python byte-for-byte)
+
+```ts
+export const SEGMENT_LEVERAGE_CAPS: Record<UserSegment, number> = {
+  retail:        1.5,
+  family_office: 2.0,
+  ls_equity:     3.0,
+  stat_arb:      5.0,
+};
+
+export const DEFAULT_USER_SEGMENT: UserSegment = "family_office";
+export const DEFAULT_ER_HAIRCUT: number = 0.7;
+export const DEFAULT_MIN_HAIRCUT_ER: number = 0.01;  // 1% haircut ER floor
+```
+
+## File layout
+
+```
+RiskModels_API/
+├── lib/
+│   └── dal/
+│       ├── hedge-recommendation.ts          # NEW — pure decision function + helpers
+│       └── hedge-recommendation.test.ts     # NEW — 12 test cases ported from Python
+├── app/
+│   └── api/
+│       ├── metrics/
+│       │   └── [ticker]/
+│       │       └── route.ts                 # MODIFY — add 5 new fields to payload
+│       └── hedge-basket/
+│           └── [ticker]/
+│               └── route.ts                 # NEW — structured basket endpoint
+└── docs/plans/
+    └── hedge-recommendation-ts-port.md      # THIS DOC
+```
+
+## `lib/dal/hedge-recommendation.ts` — stub
+
+```ts
+/**
+ * Economic recommendation layer on top of Lstar.
+ *
+ * Mirrors `erm3.shared.hedge_recommendation` in the ERM3 repo. The Python file
+ * is the source of truth; if behavior diverges, the Python wins and this file
+ * must be updated. Run the parallel test suite (12 cases) to detect drift.
+ */
+
+export type LStar = "L1" | "L2" | "L3";
+export type LStarOrNone = LStar | null;
+export type UserSegment = "retail" | "family_office" | "ls_equity" | "stat_arb";
+
+export const SEGMENT_LEVERAGE_CAPS: Record<UserSegment, number> = {
+  retail:        1.5,
+  family_office: 2.0,
+  ls_equity:     3.0,
+  stat_arb:      5.0,
+};
+
+export const DEFAULT_USER_SEGMENT: UserSegment = "family_office";
+export const DEFAULT_ER_HAIRCUT = 0.7;
+export const DEFAULT_MIN_HAIRCUT_ER = 0.01;
+
+export interface RecommendHedgeLevelInputs {
+  lstar: LStarOrNone;
+  l1HedgeGross: number;
+  l2HedgeGross: number;
+  l3HedgeGross: number;
+  l2SectorEr: number;
+  l3SubsectorEr: number;
+  userSegment?: UserSegment;
+  leverageCap?: number;             // explicit override of segment default
+  erHaircut?: number;               // defaults to 0.7
+  minHaircutMarginalEr?: number;    // defaults to 0.01
+}
+
+export function recommendHedgeLevel(inp: RecommendHedgeLevelInputs): LStar {
+  const {
+    lstar, l1HedgeGross, l2HedgeGross, l3HedgeGross,
+    l2SectorEr, l3SubsectorEr,
+    userSegment = DEFAULT_USER_SEGMENT,
+    leverageCap,
+    erHaircut = DEFAULT_ER_HAIRCUT,
+    minHaircutMarginalEr = DEFAULT_MIN_HAIRCUT_ER,
+  } = inp;
+
+  if (lstar !== "L1" && lstar !== "L2" && lstar !== "L3") return "L1";
+
+  const cap = leverageCap ?? SEGMENT_LEVERAGE_CAPS[userSegment]
+    ?? SEGMENT_LEVERAGE_CAPS[DEFAULT_USER_SEGMENT];
+
+  let candidate: LStar = lstar;
+
+  if (candidate === "L3") {
+    const marginalHaircut = (l3SubsectorEr || 0) * erHaircut;
+    if (l3HedgeGross > cap || marginalHaircut < minHaircutMarginalEr) {
+      candidate = "L2";
+    }
+  }
+  if (candidate === "L2") {
+    const marginalHaircut = (l2SectorEr || 0) * erHaircut;
+    if (l2HedgeGross > cap || marginalHaircut < minHaircutMarginalEr) {
+      candidate = "L1";
+    }
+  }
+  return candidate;
+}
+
+/** Σ |HR_leg| over the supplied hedge legs (exclude the +1 stock). NaN-safe. */
+export function hedgeGrossFromHrs(...hrs: Array<number | null | undefined>): number {
+  return hrs.reduce<number>((acc, h) => {
+    if (h == null || Number.isNaN(h)) return acc;
+    return acc + Math.abs(h);
+  }, 0);
+}
+```
+
+## Wiring 1: `app/api/metrics/[ticker]/route.ts`
+
+The existing metrics route reads from Supabase `security_history_latest` for the L1/L2/L3 betas (per the earlier diagnosis at `lib/dal/risk-engine-v3.ts:510-516`, beta keys are in `ZARR_UNSUPPORTED_DAILY_KEYS`). HRs come from `ds_erm3_hedge_weights_*.zarr`.
+
+**New work:**
+1. After reading the existing HR fields (`L1_market_HR`, `L2_market_HR`, `L2_sector_HR`, `L3_market_HR`, `L3_sector_HR`, `L3_subsector_HR`) at the latest teo for the requested ticker, compute:
+   ```ts
+   const l1HedgeGross = hedgeGrossFromHrs(L1_market_HR);
+   const l2HedgeGross = hedgeGrossFromHrs(L2_market_HR, L2_sector_HR);
+   const l3HedgeGross = hedgeGrossFromHrs(L3_market_HR, L3_sector_HR, L3_subsector_HR);
+   ```
+2. Add a new zarr reader for the shrunk hedge sidecar at `gs://rm_api_data/eodhd-shrinkage-v1/ds_erm3_hedge_shrinkage_SPY_uni_mc_3000.zarr` and pull `L2_sector_ER_shrunk`, `L3_subsector_ER_shrunk`, and `Lstar` (the shrunk LStar — distinct from the raw `Lstar` in `ds_erm3_hedge_weights`). Use the shrunk Lstar as the input to `recommendHedgeLevel` since it's the cleaner statistical signal.
+3. Parse `user_segment` from `req.nextUrl.searchParams` (default `family_office`); fallback to `family_office` on unknown values.
+4. Call `recommendHedgeLevel(...)` and add the result to the payload.
+
+**New payload fields:**
+
+| Field | Type | Source | Notes |
+|---|---|---|---|
+| `l1_hedge_gross` | `number` | computed | Σ \|HR_leg\| at L1 (= \|β_m\|) |
+| `l2_hedge_gross` | `number` | computed | Σ \|HR_leg\| at L2 (market + sector legs) |
+| `l3_hedge_gross` | `number` | computed | Σ \|HR_leg\| at L3 (market + sector + subsector legs) |
+| `higher_er_haircut` | `number` | computed | `(l2_sector_ER + l3_subsector_ER) × 0.7` — combined OOS estimate |
+| `recommended_hedge_level` | `"L1"\|"L2"\|"L3"` | computed | from `recommendHedgeLevel` |
+| `user_segment_applied` | `string` | echo | the segment that drove the recommendation (for the chat to narrate) |
+
+**Backward compatibility:** existing payload fields are unchanged. New fields are additive — readers that don't know about them get an empty `Lstar` divergence story but break nothing.
+
+## Wiring 2: `app/api/hedge-basket/[ticker]/route.ts` — NEW
+
+Returns the structured per-leg basket the chat needs to render the table. Format:
+
+```ts
+{
+  ticker: "AAPL",
+  as_of: "2026-05-18",
+  lstar: "L3",
+  recommended_hedge_level: "L1",
+  user_segment_applied: "family_office",
+  leverage_cap: 2.0,
+  haircut_applied: 0.7,
+  legs: [
+    { leg: "AAPL", side: "long",  position:  1.00, beta_to_spy: 0.876, market_beta_contribution:  0.876 },
+    { leg: "SPY",  side: "short", position: -2.00, beta_to_spy: 1.000, market_beta_contribution: -2.002 },
+    { leg: "XLK",  side: "short", position: -0.03, beta_to_spy: 1.497, market_beta_contribution: -0.039 },
+    { leg: "<subsector_etf>", side: "long", position: 0.41, beta_to_spy: 1.478, market_beta_contribution:  0.606 },
+  ],
+  net_market_beta_after_hedge: -0.559,         // sum of contributions; FYI per task #22
+  hedge_gross: { L1: 0.876, L2: 1.695, L3: 2.303 },
+  marginal_er: {
+    L2_sector_raw: 0.006, L2_sector_haircut: 0.0042,
+    L3_subsector_raw: 0.0162, L3_subsector_haircut: 0.0114,
+  },
+  decision_trace: [
+    "Lstar=L3 (shrunk subsector ER 1.62% ≥ 1% threshold)",
+    "L3 hedge gross 2.30 > 2.0 cap (family_office) → drop to L2",
+    "L2 sector ER haircut 0.42% < 1.0% floor → drop to L1",
+    "Final: L1 (short 0.88 SPY)",
+  ],
+}
+```
+
+The `decision_trace` array is critical — it's what the chat narrates to make the recommendation legible.
+
+Link-betas (`λ_s→m`, `λ_u→m`) come from `ds_erm3_link_betas_SPY.zarr` (already in GCS). Subsector ETF resolution comes from `FS_INDUSTRY_TO_SUBSECTOR_ETFS` — either port the mapping table to TS, or expose it via a new internal endpoint, or co-locate it in a JSON config that both Python and TS read.
+
+## Test parity (REQUIRED)
+
+Port all 12 Python test cases from `tests/test_hedge_recommendation.py` to `hedge-recommendation.test.ts`. The cases:
+
+1. `aapl_l3_lstar_downgraded_to_l1_by_leverage` — AAPL today, family_office cap
+2. `high_signal_smallcap_keeps_l3` — strong signal, ls_equity cap
+3. `defensive_utility_stays_l1` — Lstar=L1 input
+4. `regional_bank_keeps_l2` — Lstar=L2 input, both gates pass
+5. `high_beta_semi_downgrades_by_segment` — same inputs, 4 segments, 4 different recommendations
+6. `none_lstar_falls_back_to_l1` — null/empty/unknown Lstar
+7. `explicit_leverage_cap_overrides_segment` — `leverageCap` kwarg wins
+8. `zero_haircut_disables_economic_floor` — `erHaircut=0` collapses to leverage-only check
+9. `default_haircut_value` — pins `DEFAULT_ER_HAIRCUT === 0.7`
+10. `segment_caps_ordering` — monotonic ordering of caps
+11. `hedge_gross_from_hrs_excludes_nans` — NaN-safe sum
+12. `hedge_gross_l1_l2_l3_for_aapl` — basket math against live AAPL numbers
+
+CI rule: if any of these 12 TS tests diverges from its Python twin in expected output, the build fails. Run both suites in CI.
+
+## Rollout
+
+1. **Phase 1 (this spec → PR1):** add `lib/dal/hedge-recommendation.ts` + test suite. No route wiring yet. Behavior: net-zero. CI passes.
+2. **Phase 2 (PR2):** wire to `app/api/metrics/[ticker]/route.ts`. Add the 6 new payload fields. Existing fields untouched. Chat reads the new fields when present.
+3. **Phase 3 (PR3):** add `app/api/hedge-basket/[ticker]/route.ts` with the structured basket payload. Chat skill switches to this for the table render.
+4. **Phase 4 (later — Phase B2 deliverable):** replace `DEFAULT_ER_HAIRCUT = 0.7` with a per-level realized haircut measured from walk-forward backtests. Update both Python and TS together.
+
+## Open questions to resolve before PR1
+
+1. **Where does the TS read the shrunk hedge zarr from?** The existing zarr reader (`lib/dal/zarr-reader.ts`) is configured for `gs://rm_api_data/eodhd/` only. Either extend it to support the `eodhd-shrinkage-v1/` prefix, or add a second reader. Recommended: extend the existing reader with a `subdir` parameter.
+2. **`FS_INDUSTRY_TO_SUBSECTOR_ETFS` mapping in TS** — port the Python `dict` to a TS `Record`, or read from a shared JSON. JSON is better for keeping both languages in sync; a small build script can emit the JSON from the Python module on every ERM3 release.
+3. **Caching.** Hedge gross and recommended level are deterministic functions of the latest-teo HRs and shrunk ERs. Cache aggressively at the route level; invalidate on ERM3 sync completion.
+
+## References
+
+- Python SSOT: `~/BW_Code/ERM3/erm3/shared/hedge_recommendation.py`
+- Python tests: `~/BW_Code/ERM3/tests/test_hedge_recommendation.py`
+- Shrunk hedge sidecar: `gs://rm_api_data/eodhd-shrinkage-v1/ds_erm3_hedge_shrinkage_SPY_uni_mc_3000.zarr` (Phase B1.1 deliverable, schema includes `L2_sector_ER_shrunk`, `L3_subsector_ER_shrunk`, `Lstar`)
+- Methodology context: `content/docs/methodology.mdx` (will get a new "Recommended hedge level" section in Phase 3)
+- LStar side study: `RM_ORG/content/Medium/series/drafts/lstar_selection/`
+- Related task: #20 (chat-skill table that consumes this payload)
+- Related task: #22 (methodology check on residual net market β — informational for `decision_trace` narration, not blocking this port)

--- a/lib/api/schemas.ts
+++ b/lib/api/schemas.ts
@@ -37,6 +37,21 @@ export const MetricsRequestSchema = z.object({
 });
 
 /**
+ * Schema for GET /api/hedge-basket/[ticker]
+ *
+ * user_segment drives the leverage cap applied to the recommendation. The four
+ * accepted values mirror SEGMENT_LEVERAGE_CAPS in lib/dal/hedge-recommendation:
+ *   retail (1.5×) | family_office (2.0× default) | ls_equity (3.0×) | stat_arb (5.0×)
+ */
+export const HedgeBasketRequestSchema = z.object({
+  ticker: TickerSchema,
+  user_segment: z
+    .enum(["retail", "family_office", "ls_equity", "stat_arb"])
+    .default("family_office"),
+  market_factor_etf: z.string().default("SPY"),
+});
+
+/**
  * Schema for GET /api/ticker-returns
  */
 export const TickerReturnsRequestSchema = z.object({

--- a/lib/dal/hedge-recommendation.ts
+++ b/lib/dal/hedge-recommendation.ts
@@ -1,0 +1,155 @@
+/**
+ * Economic recommendation layer on top of Lstar.
+ *
+ * Mirrors `erm3.shared.hedge_recommendation` in the ERM3 repo. The Python file
+ * is the source of truth; if behavior diverges, the Python wins and this file
+ * must be updated. Run the parallel test suite to detect drift —
+ * `tests/hedge-recommendation.test.ts` ports each Python case.
+ *
+ * Lstar answers "which cascade level is STATISTICALLY warranted by the data?"
+ * `recommendHedgeLevel` answers "which level should the trader ACTUALLY execute?"
+ * — applies an OOS-haircut on the in-sample marginal ERs plus a hedge-gross
+ * leverage cap that varies by user segment. Lstar itself is never mutated;
+ * divergence between the two fields is the regime-change alert the chat
+ * surfaces.
+ *
+ * Until Phase B2's walk-forward backtest lands, the 0.7 haircut is a
+ * literature-grounded placeholder for typical sector/subsector-ETF tracking
+ * error + borrow-cost drag on realized OOS variance reduction.
+ *
+ * @see RiskModels_API/docs/plans/hedge-recommendation-ts-port.md
+ * @see ~/BW_Code/ERM3/erm3/shared/hedge_recommendation.py
+ */
+
+export type LStar = "L1" | "L2" | "L3";
+export type LStarOrNone = LStar | null;
+export type UserSegment = "retail" | "family_office" | "ls_equity" | "stat_arb";
+
+/**
+ * Hedge-gross caps (Σ|HR_leg| over hedge legs, excluding the +1 stock position).
+ *
+ * - retail: Reg-T 50% margin → ~2× total gross max → 1.5× on hedge side.
+ * - family_office: 2× gross book is industry-standard for RIA mandates.
+ * - ls_equity: 3–4× gross is normal; 3.0 is the conservative single-name cap.
+ * - stat_arb: 5× single-name is fine; aggregate book is the binding constraint.
+ */
+export const SEGMENT_LEVERAGE_CAPS: Record<UserSegment, number> = {
+  retail:        1.5,
+  family_office: 2.0,
+  ls_equity:     3.0,
+  stat_arb:      5.0,
+};
+
+export const DEFAULT_USER_SEGMENT: UserSegment = "family_office";
+
+/**
+ * In-sample ER haircut for the OOS variance-reduction estimate. Until Phase B2
+ * replaces this with a measured factor, 0.7 is a literature-grounded
+ * placeholder (typical ETF tracking error + borrow-cost drag).
+ */
+export const DEFAULT_ER_HAIRCUT = 0.7;
+
+/**
+ * Minimum HAIRCUT marginal ER required to justify adding a cascade level.
+ * 1.0% haircut ER ≈ 1.43% raw ER — slightly stricter than LStar's 1% raw gate,
+ * so the economic gate can bite even when LStar passes.
+ */
+export const DEFAULT_MIN_HAIRCUT_ER = 0.01;
+
+export interface RecommendHedgeLevelInputs {
+  lstar: LStarOrNone | string;       // accept stringly-typed inputs from the zarr
+  l1HedgeGross: number;
+  l2HedgeGross: number;
+  l3HedgeGross: number;
+  l2SectorEr: number;
+  l3SubsectorEr: number;
+  userSegment?: UserSegment;
+  leverageCap?: number;              // explicit override of segment default
+  erHaircut?: number;                // defaults to DEFAULT_ER_HAIRCUT
+  minHaircutMarginalEr?: number;     // defaults to DEFAULT_MIN_HAIRCUT_ER
+}
+
+/**
+ * Pick the simplest cascade level whose economics clear two gates.
+ *
+ * Top-down from Lstar's statistical pick, drop one level at a time if EITHER:
+ *  (a) hedge_gross at that level exceeds the user's leverage cap, OR
+ *  (b) the haircut marginal ER added by that level falls below the floor.
+ *
+ * Never drops below L1 — the market hedge is always available regardless of
+ * economics. (If the user wants no hedge at all that's a decision outside
+ * this function.)
+ *
+ * Always returns a concrete level — never null.
+ */
+export function recommendHedgeLevel(inp: RecommendHedgeLevelInputs): LStar {
+  const {
+    lstar,
+    l1HedgeGross,
+    l2HedgeGross,
+    l3HedgeGross,
+    l2SectorEr,
+    l3SubsectorEr,
+    userSegment = DEFAULT_USER_SEGMENT,
+    leverageCap,
+    erHaircut = DEFAULT_ER_HAIRCUT,
+    minHaircutMarginalEr = DEFAULT_MIN_HAIRCUT_ER,
+  } = inp;
+
+  // Reference `l1HedgeGross` so linters don't flag it as unused — it's part
+  // of the contract and useful for callers that want to log / cache the full
+  // gross profile alongside the recommendation.
+  void l1HedgeGross;
+
+  if (lstar !== "L1" && lstar !== "L2" && lstar !== "L3") {
+    return "L1";
+  }
+
+  const cap =
+    leverageCap ??
+    SEGMENT_LEVERAGE_CAPS[userSegment] ??
+    SEGMENT_LEVERAGE_CAPS[DEFAULT_USER_SEGMENT];
+
+  let candidate: LStar = lstar;
+
+  // Step down L3 → L2 if subsector layer fails either economic gate.
+  if (candidate === "L3") {
+    const marginalHaircut = (l3SubsectorEr || 0) * erHaircut;
+    const leverageFails = l3HedgeGross > cap;
+    const erFails = marginalHaircut < minHaircutMarginalEr;
+    if (leverageFails || erFails) {
+      candidate = "L2";
+    }
+  }
+
+  // Step down L2 → L1 if sector layer fails either economic gate.
+  if (candidate === "L2") {
+    const marginalHaircut = (l2SectorEr || 0) * erHaircut;
+    const leverageFails = l2HedgeGross > cap;
+    const erFails = marginalHaircut < minHaircutMarginalEr;
+    if (leverageFails || erFails) {
+      candidate = "L1";
+    }
+  }
+
+  return candidate;
+}
+
+/**
+ * Σ |HR_leg| over the supplied hedge legs (exclude the +1 stock).
+ *
+ * NaN-safe: NaN/null/undefined inputs are skipped, not summed.
+ *
+ * @example
+ *   hedgeGrossFromHrs(L1_market_HR)                                    // L1
+ *   hedgeGrossFromHrs(L2_market_HR, L2_sector_HR)                       // L2
+ *   hedgeGrossFromHrs(L3_market_HR, L3_sector_HR, L3_subsector_HR)      // L3
+ */
+export function hedgeGrossFromHrs(
+  ...hrs: Array<number | null | undefined>
+): number {
+  return hrs.reduce<number>((acc, h) => {
+    if (h == null || Number.isNaN(h)) return acc;
+    return acc + Math.abs(h);
+  }, 0);
+}

--- a/lib/dal/zarr-reader.ts
+++ b/lib/dal/zarr-reader.ts
@@ -26,6 +26,7 @@ import {
   zarrDailyBasename,
   zarrEtfBasename,
   zarrHedgeBasename,
+  zarrLinkBetasBasename,
   zarrRankingsBasename,
   zarrReturnsBasename,
 } from "@/lib/zarr-config";
@@ -787,6 +788,128 @@ export async function readLatestRankSnapshot(
   });
 
   return { teo: teoStr, rows };
+}
+
+// =====================================================================
+// Link-betas: latest-teo lookup for the cascade hedge basket
+// =====================================================================
+//
+// `ds_erm3_link_betas_{marketFactorEtf}.zarr` carries ETF-to-ETF betas:
+//   L2_link_sec_mkt_BF  — sector ETF's slope on SPY (λ_s→m)
+//   L3_link_sub_mkt_BF  — subsector ETF's slope on SPY (λ_u→m)
+//   L3_link_sub_sec_BF  — subsector ETF's slope on the sector ETF (λ_u→s)
+// Indexed (teo, symbol) over ~51 ETFs with `ticker` as an extra string coord.
+// The hedge-basket endpoint reads three cells per call: λ_s→m at the sector
+// ETF's index, λ_u→m + λ_u→s at the subsector ETF's index. SPY itself is the
+// market root by convention, so λ_*→SPY = 1.0 and never reads from this store.
+
+async function readTickerIndexMap(grp: Group<Readable>): Promise<Map<string, number> | null> {
+  try {
+    const loc = grp.resolve("ticker");
+    const arr = await open.v2(loc, { kind: "array" });
+    const ch = await get(arr, null);
+    const d = ch?.data;
+    const m = new Map<string, number>();
+    if (d instanceof UnicodeStringArray) {
+      for (let i = 0; i < d.length; i++) {
+        m.set(String(d.get(i)).trim().toUpperCase(), i);
+      }
+      return m;
+    }
+    if (Array.isArray(d)) {
+      for (let i = 0; i < d.length; i++) {
+        m.set(String(d[i]).trim().toUpperCase(), i);
+      }
+      return m;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+async function readFloatScalarTeoSymbol(
+  grp: Group<Readable>,
+  varName: string,
+  teoIdx: number,
+  symIdx: number,
+): Promise<number | null> {
+  // Slice with a 1-element teo range to get a typed-array result (zarrita's
+  // scalar-indexed get returns a 0-d type that TS doesn't surface `.data` for).
+  try {
+    const loc = grp.resolve(varName);
+    const arr = await open.v2(loc, { kind: "array" });
+    const ch = await get(arr, [slice(teoIdx, teoIdx + 1), symIdx]);
+    const d = ch?.data;
+    if (d instanceof Float32Array || d instanceof Float64Array) {
+      const v = d[0];
+      return v != null && Number.isFinite(v) ? v : null;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export interface LatestLinkBetas {
+  teo: string;
+  /** Sector ETF's slope on SPY. Null if the sector ETF isn't in the store. */
+  lambda_s_to_m: number | null;
+  /** Subsector ETF's slope on SPY. Null if absent. */
+  lambda_u_to_m: number | null;
+  /** Subsector ETF's slope on the sector ETF. Null if absent. */
+  lambda_u_to_s: number | null;
+}
+
+/**
+ * Read the latest-teo link-betas for a given (sector_etf, subsector_etf) pair.
+ *
+ * - Ticker matching is case-insensitive against the ETF roster in the link-betas
+ *   zarr (~51 ETFs).
+ * - If either ticker resolves to "SPY", the corresponding lambda is implicitly
+ *   1.0 (sector_etf=SPY) or 0.0 (subsector→sector when subsector_etf=SPY), and
+ *   no zarr read is needed for that leg. The caller can apply that convention
+ *   without checking — this function only returns store-derived values.
+ * - Returns null if the store can't be opened or the latest teo is empty.
+ */
+export async function readLatestLinkBetas(
+  sectorEtfTicker: string | null,
+  subsectorEtfTicker: string | null,
+  marketFactorEtf = "SPY",
+): Promise<LatestLinkBetas | null> {
+  const grp = await openZarrGroup(zarrLinkBetasBasename(marketFactorEtf));
+  if (!grp) return null;
+
+  const teos = await readTeoStrings(grp);
+  if (!teos?.length) return null;
+  const teoIdx = teos.length - 1;
+  const teoStr = teos[teoIdx]!;
+
+  const tickerMap = await readTickerIndexMap(grp);
+  if (!tickerMap?.size) return null;
+
+  const secIdx = sectorEtfTicker ? tickerMap.get(sectorEtfTicker.toUpperCase()) : undefined;
+  const subIdx = subsectorEtfTicker ? tickerMap.get(subsectorEtfTicker.toUpperCase()) : undefined;
+
+  // Parallelize the three single-cell reads. NaN-safe via Float32Array unpacking.
+  const [lam_s_m, lam_u_m, lam_u_s] = await Promise.all([
+    secIdx !== undefined
+      ? readFloatScalarTeoSymbol(grp, "L2_link_sec_mkt_BF", teoIdx, secIdx)
+      : Promise.resolve(null),
+    subIdx !== undefined
+      ? readFloatScalarTeoSymbol(grp, "L3_link_sub_mkt_BF", teoIdx, subIdx)
+      : Promise.resolve(null),
+    subIdx !== undefined
+      ? readFloatScalarTeoSymbol(grp, "L3_link_sub_sec_BF", teoIdx, subIdx)
+      : Promise.resolve(null),
+  ]);
+
+  return {
+    teo: teoStr,
+    lambda_s_to_m: lam_s_m,
+    lambda_u_to_m: lam_u_m,
+    lambda_u_to_s: lam_u_s,
+  };
 }
 
 export interface SymbolRankResult {

--- a/lib/risk/hedge-recommendation-service.ts
+++ b/lib/risk/hedge-recommendation-service.ts
@@ -12,6 +12,7 @@
 
 import {
   DEFAULT_ER_HAIRCUT,
+  DEFAULT_MIN_HAIRCUT_ER,
   DEFAULT_USER_SEGMENT,
   SEGMENT_LEVERAGE_CAPS,
   hedgeGrossFromHrs,
@@ -105,5 +106,210 @@ export function computeHedgeRecommendationSnapshot(
     l3_hedge_gross: l3HedgeGross,
     higher_er_haircut: higherErHaircut * DEFAULT_ER_HAIRCUT,
     leverage_cap_applied: SEGMENT_LEVERAGE_CAPS[userSegment],
+  };
+}
+
+/**
+ * Per-leg row in the hedge basket — what the chat renders.
+ *
+ *   leg                     — display label (ticker, "AAPL" / "SPY" / "XLK" / etc.)
+ *   side                    — "long" | "short" (derived from sign of `position`)
+ *   position                — signed HR (the +1 stock leg is +1.0; hedges are -HR)
+ *   beta_to_spy             — leg's univariate slope on SPY (the market root)
+ *   market_beta_contribution — position × beta_to_spy (sums to net market β)
+ */
+export interface HedgeBasketLeg {
+  leg: string;
+  side: "long" | "short";
+  position: number;
+  beta_to_spy: number;
+  market_beta_contribution: number;
+}
+
+/**
+ * Structured hedge-basket payload for `/api/hedge-basket/{ticker}` — what the
+ * chat renders as a 4-row table with a net-market-β subtotal.
+ *
+ * `decision_trace` is the human-readable explanation of how recommended_hedge_level
+ * was derived; the chat narrates it verbatim. Net market β residual is FYI per
+ * methodology task #22 (the cascade zeros orth factor exposure, not raw market).
+ */
+export interface HedgeBasket {
+  ticker: string;
+  as_of: string | null;
+  lstar: LstarLevel | null;
+  recommended_hedge_level: LStar;
+  user_segment_applied: UserSegment;
+  leverage_cap_applied: number;
+  haircut_applied: number;
+  legs: HedgeBasketLeg[];
+  net_market_beta_after_hedge: number;
+  hedge_gross: { L1: number; L2: number; L3: number };
+  marginal_er: {
+    L2_sector_raw: number | null;
+    L2_sector_haircut: number;
+    L3_subsector_raw: number | null;
+    L3_subsector_haircut: number;
+  };
+  decision_trace: string[];
+}
+
+export interface BuildHedgeBasketInputs extends HedgeRecommendationSnapshotInputs {
+  ticker: string;
+  as_of: string | null;
+  /** Stock's L1 market β. β_m = -L1_market_HR by convention. */
+  beta_m_aapl: number | null;
+  sector_etf_ticker: string | null;
+  subsector_etf_ticker: string | null;
+  market_etf_ticker?: string;       // defaults to "SPY"
+  /** Sector ETF's slope on SPY (λ_s→m). 1.0 when the sector ETF IS SPY. */
+  lambda_s_to_m: number | null;
+  /** Subsector ETF's slope on SPY (λ_u→m). 1.0 when the subsector ETF IS SPY. */
+  lambda_u_to_m: number | null;
+}
+
+function fmtPct(x: number): string {
+  return `${(x * 100).toFixed(2)}%`;
+}
+
+/**
+ * Compose the basket payload from already-fetched inputs.
+ *
+ * Pure function — no IO. Caller is responsible for resolving link-betas from
+ * the link-betas zarr (`readLatestLinkBetas` in zarr-reader.ts) before calling
+ * this. SPY-as-sector / SPY-as-subsector edge cases use λ=1.0 by convention.
+ */
+export function buildHedgeBasket(inp: BuildHedgeBasketInputs): HedgeBasket {
+  const snap = computeHedgeRecommendationSnapshot(inp);
+  const marketEtf = inp.market_etf_ticker ?? "SPY";
+
+  // Conventions for SPY-rooted legs.
+  const sectorIsSpy = inp.sector_etf_ticker?.toUpperCase() === marketEtf.toUpperCase();
+  const subsectorIsSpy = inp.subsector_etf_ticker?.toUpperCase() === marketEtf.toUpperCase();
+  const lambdaSM = sectorIsSpy ? 1.0 : (inp.lambda_s_to_m ?? 0);
+  const lambdaUM = subsectorIsSpy ? 1.0 : (inp.lambda_u_to_m ?? 0);
+
+  const betaMAapl = inp.beta_m_aapl ?? 0;
+  const hrM = inp.l3_mkt_hr ?? 0;
+  const hrS = inp.l3_sec_hr ?? 0;
+  const hrU = inp.l3_sub_hr ?? 0;
+
+  const legs: HedgeBasketLeg[] = [
+    {
+      leg: inp.ticker.toUpperCase(),
+      side: "long",
+      position: 1.0,
+      beta_to_spy: betaMAapl,
+      market_beta_contribution: 1.0 * betaMAapl,
+    },
+    {
+      leg: marketEtf,
+      side: hrM <= 0 ? "short" : "long",
+      position: hrM,
+      beta_to_spy: 1.0,
+      market_beta_contribution: hrM * 1.0,
+    },
+  ];
+  if (inp.sector_etf_ticker && !sectorIsSpy) {
+    legs.push({
+      leg: inp.sector_etf_ticker.toUpperCase(),
+      side: hrS <= 0 ? "short" : "long",
+      position: hrS,
+      beta_to_spy: lambdaSM,
+      market_beta_contribution: hrS * lambdaSM,
+    });
+  }
+  if (inp.subsector_etf_ticker && !subsectorIsSpy) {
+    legs.push({
+      leg: inp.subsector_etf_ticker.toUpperCase(),
+      side: hrU <= 0 ? "short" : "long",
+      position: hrU,
+      beta_to_spy: lambdaUM,
+      market_beta_contribution: hrU * lambdaUM,
+    });
+  }
+
+  const netMarketBetaAfterHedge = legs.reduce((acc, l) => acc + l.market_beta_contribution, 0);
+
+  // Decision-trace narration. Mirrors the recommendHedgeLevel decision logic
+  // so the user can see WHY recommended_hedge_level may diverge from lstar.
+  const trace: string[] = [];
+  const threshold = inp.threshold ?? LSTAR_DEFAULT_THRESHOLD;
+  const lstar = snap.lstar;
+  const subRawNn = inp.l3_sub_er ?? null;
+  const secRawNn = inp.l2_sec_er ?? null;
+  if (lstar === null) {
+    trace.push(
+      `Lstar=null (both L2 and L3 marginal ER unavailable — pre-IPO / delisted / masked); recommendation defaults to L1.`,
+    );
+  } else if (lstar === "L3") {
+    trace.push(
+      `Lstar=L3 (subsector marginal ER ${fmtPct(subRawNn ?? 0)} ≥ ${fmtPct(threshold)} threshold)`,
+    );
+  } else if (lstar === "L2") {
+    trace.push(
+      `Lstar=L2 (sector marginal ER ${fmtPct(secRawNn ?? 0)} ≥ ${fmtPct(threshold)} threshold; subsector ${fmtPct(subRawNn ?? 0)} fails)`,
+    );
+  } else {
+    trace.push(`Lstar=L1 (sector ${fmtPct(secRawNn ?? 0)} and subsector ${fmtPct(subRawNn ?? 0)} both fail ${fmtPct(threshold)} threshold)`);
+  }
+
+  const cap = snap.leverage_cap_applied;
+  const erHaircut = DEFAULT_ER_HAIRCUT;
+  const minHaircut = DEFAULT_MIN_HAIRCUT_ER;
+  // Walk the candidate ladder mirroring recommendHedgeLevel's logic.
+  let candidate: LStar = (lstar ?? "L1") as LStar;
+  if (candidate === "L3") {
+    const haircut = (subRawNn ?? 0) * erHaircut;
+    if (snap.l3_hedge_gross > cap) {
+      trace.push(
+        `L3 hedge gross ${snap.l3_hedge_gross.toFixed(2)} > ${cap.toFixed(1)}× cap (${snap.user_segment_applied}) → drop to L2`,
+      );
+      candidate = "L2";
+    } else if (haircut < minHaircut) {
+      trace.push(
+        `L3 subsector haircut ER ${fmtPct(haircut)} < ${fmtPct(minHaircut)} floor → drop to L2`,
+      );
+      candidate = "L2";
+    }
+  }
+  if (candidate === "L2") {
+    const haircut = (secRawNn ?? 0) * erHaircut;
+    if (snap.l2_hedge_gross > cap) {
+      trace.push(
+        `L2 hedge gross ${snap.l2_hedge_gross.toFixed(2)} > ${cap.toFixed(1)}× cap → drop to L1`,
+      );
+      candidate = "L1";
+    } else if (haircut < minHaircut) {
+      trace.push(
+        `L2 sector haircut ER ${fmtPct(haircut)} < ${fmtPct(minHaircut)} floor → drop to L1`,
+      );
+      candidate = "L1";
+    }
+  }
+  trace.push(`Final: ${snap.recommended_hedge_level}`);
+
+  return {
+    ticker: inp.ticker.toUpperCase(),
+    as_of: inp.as_of,
+    lstar: snap.lstar,
+    recommended_hedge_level: snap.recommended_hedge_level,
+    user_segment_applied: snap.user_segment_applied,
+    leverage_cap_applied: snap.leverage_cap_applied,
+    haircut_applied: erHaircut,
+    legs,
+    net_market_beta_after_hedge: netMarketBetaAfterHedge,
+    hedge_gross: {
+      L1: snap.l1_hedge_gross,
+      L2: snap.l2_hedge_gross,
+      L3: snap.l3_hedge_gross,
+    },
+    marginal_er: {
+      L2_sector_raw: secRawNn,
+      L2_sector_haircut: (secRawNn ?? 0) * erHaircut,
+      L3_subsector_raw: subRawNn,
+      L3_subsector_haircut: (subRawNn ?? 0) * erHaircut,
+    },
+    decision_trace: trace,
   };
 }

--- a/lib/risk/hedge-recommendation-service.ts
+++ b/lib/risk/hedge-recommendation-service.ts
@@ -1,0 +1,109 @@
+/**
+ * Hedge-recommendation snapshot — orchestrates the statistical Lstar pick
+ * (from `lstar-service`) with the economic recommendation rule (from
+ * `lib/dal/hedge-recommendation`) into the 6 fields the metrics endpoint
+ * and the upcoming /api/hedge-basket endpoint surface.
+ *
+ * Pure snapshot — no IO. Caller passes in already-fetched per-teo metrics.
+ *
+ * @see docs/plans/hedge-recommendation-ts-port.md
+ * @see ~/BW_Code/ERM3/erm3/shared/hedge_recommendation.py (SSOT)
+ */
+
+import {
+  DEFAULT_ER_HAIRCUT,
+  DEFAULT_USER_SEGMENT,
+  SEGMENT_LEVERAGE_CAPS,
+  hedgeGrossFromHrs,
+  recommendHedgeLevel,
+  type LStar,
+  type UserSegment,
+} from "@/lib/dal/hedge-recommendation";
+import { LSTAR_DEFAULT_THRESHOLD, pickLstar, type LstarLevel } from "./lstar-service";
+
+export const VALID_USER_SEGMENTS = Object.keys(SEGMENT_LEVERAGE_CAPS) as UserSegment[];
+
+export function isValidUserSegment(v: string | null | undefined): v is UserSegment {
+  return typeof v === "string" && (VALID_USER_SEGMENTS as string[]).includes(v);
+}
+
+export interface HedgeRecommendationSnapshotInputs {
+  l1_mkt_hr: number | null;
+  l2_mkt_hr: number | null;
+  l2_sec_hr: number | null;
+  l3_mkt_hr: number | null;
+  l3_sec_hr: number | null;
+  l3_sub_hr: number | null;
+  l2_sec_er: number | null;
+  l3_sub_er: number | null;
+  /** Segment-driven leverage cap; defaults to "family_office" (2.0×). */
+  user_segment?: UserSegment;
+  /** Lstar marginal-ER threshold; defaults to 0.01 (1%). */
+  threshold?: number;
+}
+
+export interface HedgeRecommendationSnapshot {
+  /** Statistical pick (1% marginal-ER rule on raw ERs). Null when both ERs missing. */
+  lstar: LstarLevel | null;
+  /** Economic pick after leverage cap + haircut floor. Always concrete. */
+  recommended_hedge_level: LStar;
+  /** Echo of the segment that drove the recommendation. */
+  user_segment_applied: UserSegment;
+  /** Σ |HR_leg| ex-stock at each cascade level. NaN-safe (missing HRs treated as 0). */
+  l1_hedge_gross: number;
+  l2_hedge_gross: number;
+  l3_hedge_gross: number;
+  /**
+   * (l2_sec_er + l3_sub_er) × 0.7 — combined OOS estimate of the sector + subsector
+   * variance contribution. Placeholder haircut until Phase B2 walk-forward.
+   */
+  higher_er_haircut: number;
+  /** Leverage cap applied (echoed for transparency in the API payload). */
+  leverage_cap_applied: number;
+}
+
+/**
+ * Compose the snapshot from latest-teo metric scalars.
+ *
+ * Diverges from Lstar (`snapshot.lstar !== snapshot.recommended_hedge_level`)
+ * when the economic gate downgrades the statistical pick — this is the
+ * regime-change alert the chat surfaces.
+ */
+export function computeHedgeRecommendationSnapshot(
+  inp: HedgeRecommendationSnapshotInputs,
+): HedgeRecommendationSnapshot {
+  const userSegment: UserSegment = inp.user_segment ?? DEFAULT_USER_SEGMENT;
+  const threshold = inp.threshold ?? LSTAR_DEFAULT_THRESHOLD;
+
+  const lstar = pickLstar(inp.l2_sec_er ?? null, inp.l3_sub_er ?? null, threshold);
+
+  const l1HedgeGross = hedgeGrossFromHrs(inp.l1_mkt_hr);
+  const l2HedgeGross = hedgeGrossFromHrs(inp.l2_mkt_hr, inp.l2_sec_hr);
+  const l3HedgeGross = hedgeGrossFromHrs(inp.l3_mkt_hr, inp.l3_sec_hr, inp.l3_sub_hr);
+
+  const recommended = recommendHedgeLevel({
+    lstar,
+    l1HedgeGross,
+    l2HedgeGross,
+    l3HedgeGross,
+    l2SectorEr: inp.l2_sec_er ?? 0,
+    l3SubsectorEr: inp.l3_sub_er ?? 0,
+    userSegment,
+  });
+
+  // NaN-safe sum of the two higher-layer raw ERs, then haircut.
+  const l2 = inp.l2_sec_er ?? 0;
+  const l3 = inp.l3_sub_er ?? 0;
+  const higherErHaircut = (Number.isFinite(l2) ? l2 : 0) + (Number.isFinite(l3) ? l3 : 0);
+
+  return {
+    lstar,
+    recommended_hedge_level: recommended,
+    user_segment_applied: userSegment,
+    l1_hedge_gross: l1HedgeGross,
+    l2_hedge_gross: l2HedgeGross,
+    l3_hedge_gross: l3HedgeGross,
+    higher_er_haircut: higherErHaircut * DEFAULT_ER_HAIRCUT,
+    leverage_cap_applied: SEGMENT_LEVERAGE_CAPS[userSegment],
+  };
+}

--- a/lib/risk/lstar-service.ts
+++ b/lib/risk/lstar-service.ts
@@ -53,7 +53,7 @@ export interface LstarResult {
   data_source: string;
 }
 
-function pickLstar(
+export function pickLstar(
   l2SecEr: number | null,
   l3SubEr: number | null,
   threshold: number,

--- a/lib/zarr-config.ts
+++ b/lib/zarr-config.ts
@@ -51,3 +51,15 @@ export function zarrHedgeBasename(factorSetId = getZarrFactorSetId()): string {
 export function zarrRankingsBasename(factorSetId = getZarrFactorSetId()): string {
   return `ds_rankings_${factorSetId}.zarr`;
 }
+
+/**
+ * ETF-to-ETF link betas (sector→market, subsector→market, subsector→sector).
+ * Indexed (teo, symbol) over ~51 ETFs. The cascade hedge basket reads three
+ * cells per ticker (sector ETF + subsector ETF at the latest teo).
+ *
+ * Factor-set agnostic — link betas are SPY-rooted right now, so the basename
+ * uses the market_factor_etf, not the universe.
+ */
+export function zarrLinkBetasBasename(marketFactorEtf = "SPY"): string {
+  return `ds_erm3_link_betas_${marketFactorEtf}.zarr`;
+}

--- a/tests/hedge-recommendation-service.test.ts
+++ b/tests/hedge-recommendation-service.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Tests for the snapshot orchestrator that composes Lstar (statistical pick)
+ * with the economic recommendation rule into the metrics-endpoint payload
+ * fields. Core decision math is exercised in `hedge-recommendation.test.ts`;
+ * here we pin the orchestration: live-derived Lstar, NaN-safe hedge gross
+ * from the raw metric scalars, the haircut formula, and user_segment guards.
+ */
+import { describe, expect, it } from "vitest";
+
+import { SEGMENT_LEVERAGE_CAPS } from "@/lib/dal/hedge-recommendation";
+import {
+  computeHedgeRecommendationSnapshot,
+  isValidUserSegment,
+  VALID_USER_SEGMENTS,
+} from "@/lib/risk/hedge-recommendation-service";
+
+describe("isValidUserSegment", () => {
+  it("accepts the four documented segments", () => {
+    for (const s of VALID_USER_SEGMENTS) {
+      expect(isValidUserSegment(s)).toBe(true);
+    }
+  });
+
+  it("rejects null, empty, and unknown values", () => {
+    expect(isValidUserSegment(null)).toBe(false);
+    expect(isValidUserSegment(undefined)).toBe(false);
+    expect(isValidUserSegment("")).toBe(false);
+    expect(isValidUserSegment("retail-aggressive")).toBe(false);
+    expect(isValidUserSegment("RETAIL")).toBe(false);
+  });
+});
+
+describe("computeHedgeRecommendationSnapshot — AAPL today (shrunk-ish scalars)", () => {
+  // Values aligned with the live AAPL inputs at 2026-05-18 (see Phase B1.1
+  // ground-test). HRs from raw ds_erm3_hedge_weights; ERs from the shrunk
+  // sidecar but the metrics route currently reads raw ERs from Supabase
+  // — the AAPL test uses raw ER 0.7% / 2.0% to match what the route actually
+  // gets at runtime today. Drop-in for shrunk ERs lands when Phase 2.5 wires
+  // the shrunk sidecar through zarr-reader.
+  const aaplInputs = {
+    l1_mkt_hr: -0.862,
+    l2_mkt_hr: -1.396,
+    l2_sec_hr:  0.357,
+    l3_mkt_hr: -2.002,
+    l3_sec_hr: -0.026,
+    l3_sub_hr:  0.410,
+    l2_sec_er:  0.007,    // 0.7% raw → fails 1% Lstar threshold
+    l3_sub_er:  0.020,    // 2.0% raw → clears 1% Lstar threshold → Lstar=L3
+  } as const;
+
+  it("derives lstar=L3 live from raw ERs (1% threshold)", () => {
+    const snap = computeHedgeRecommendationSnapshot(aaplInputs);
+    expect(snap.lstar).toBe("L3");
+  });
+
+  it("family_office (default 2.0× cap) downgrades AAPL to L1", () => {
+    const snap = computeHedgeRecommendationSnapshot(aaplInputs);
+    expect(snap.recommended_hedge_level).toBe("L1");
+    expect(snap.user_segment_applied).toBe("family_office");
+    expect(snap.leverage_cap_applied).toBe(2.0);
+  });
+
+  it("ls_equity (3.0× cap) holds AAPL at L3", () => {
+    const snap = computeHedgeRecommendationSnapshot({
+      ...aaplInputs,
+      user_segment: "ls_equity",
+    });
+    expect(snap.recommended_hedge_level).toBe("L3");
+    expect(snap.leverage_cap_applied).toBe(3.0);
+  });
+
+  it("hedge gross at each level matches |HR| sums", () => {
+    const snap = computeHedgeRecommendationSnapshot(aaplInputs);
+    expect(snap.l1_hedge_gross).toBeCloseTo(0.862, 3);
+    expect(snap.l2_hedge_gross).toBeCloseTo(1.753, 3);  // 1.396 + 0.357
+    expect(snap.l3_hedge_gross).toBeCloseTo(2.438, 3);  // 2.002 + 0.026 + 0.410
+  });
+
+  it("higher_er_haircut = (l2_sec_er + l3_sub_er) × 0.7", () => {
+    const snap = computeHedgeRecommendationSnapshot(aaplInputs);
+    expect(snap.higher_er_haircut).toBeCloseTo((0.007 + 0.020) * 0.7, 6);
+  });
+});
+
+describe("computeHedgeRecommendationSnapshot — edge cases", () => {
+  it("falls back to family_office on missing user_segment", () => {
+    const snap = computeHedgeRecommendationSnapshot({
+      l1_mkt_hr: -0.5,
+      l2_mkt_hr: -0.5,
+      l2_sec_hr: 0.0,
+      l3_mkt_hr: -0.5,
+      l3_sec_hr: 0.0,
+      l3_sub_hr: 0.0,
+      l2_sec_er: 0.05,
+      l3_sub_er: 0.05,
+    });
+    expect(snap.user_segment_applied).toBe("family_office");
+    expect(snap.leverage_cap_applied).toBe(SEGMENT_LEVERAGE_CAPS.family_office);
+  });
+
+  it("null ERs → null Lstar → recommended L1", () => {
+    const snap = computeHedgeRecommendationSnapshot({
+      l1_mkt_hr: -0.5,
+      l2_mkt_hr: -0.5,
+      l2_sec_hr: 0.0,
+      l3_mkt_hr: -0.5,
+      l3_sec_hr: 0.0,
+      l3_sub_hr: 0.0,
+      l2_sec_er: null,
+      l3_sub_er: null,
+    });
+    expect(snap.lstar).toBeNull();
+    expect(snap.recommended_hedge_level).toBe("L1");
+    expect(snap.higher_er_haircut).toBe(0);
+  });
+
+  it("partially-null HRs are NaN-safe (treated as 0 contribution)", () => {
+    const snap = computeHedgeRecommendationSnapshot({
+      l1_mkt_hr: -0.5,
+      l2_mkt_hr: null,
+      l2_sec_hr: null,
+      l3_mkt_hr: -0.5,
+      l3_sec_hr: null,
+      l3_sub_hr: 0.3,
+      l2_sec_er: 0.0,
+      l3_sub_er: 0.05,
+    });
+    expect(snap.l1_hedge_gross).toBeCloseTo(0.5, 6);
+    expect(snap.l2_hedge_gross).toBe(0);
+    expect(snap.l3_hedge_gross).toBeCloseTo(0.8, 6);
+  });
+
+  it("custom threshold flips lstar without affecting hedge gross", () => {
+    const inputs = {
+      l1_mkt_hr: -0.5,
+      l2_mkt_hr: -0.5,
+      l2_sec_hr: 0.0,
+      l3_mkt_hr: -0.5,
+      l3_sec_hr: 0.0,
+      l3_sub_hr: 0.0,
+      l2_sec_er: 0.02,    // clears 1% but not 5%
+      l3_sub_er: 0.001,
+    };
+    const at1pct = computeHedgeRecommendationSnapshot({ ...inputs, threshold: 0.01 });
+    const at5pct = computeHedgeRecommendationSnapshot({ ...inputs, threshold: 0.05 });
+    expect(at1pct.lstar).toBe("L2");
+    expect(at5pct.lstar).toBe("L1");
+    expect(at1pct.l2_hedge_gross).toEqual(at5pct.l2_hedge_gross);
+  });
+});

--- a/tests/hedge-recommendation-service.test.ts
+++ b/tests/hedge-recommendation-service.test.ts
@@ -9,6 +9,7 @@ import { describe, expect, it } from "vitest";
 
 import { SEGMENT_LEVERAGE_CAPS } from "@/lib/dal/hedge-recommendation";
 import {
+  buildHedgeBasket,
   computeHedgeRecommendationSnapshot,
   isValidUserSegment,
   VALID_USER_SEGMENTS,
@@ -128,6 +129,86 @@ describe("computeHedgeRecommendationSnapshot — edge cases", () => {
     expect(snap.l1_hedge_gross).toBeCloseTo(0.5, 6);
     expect(snap.l2_hedge_gross).toBe(0);
     expect(snap.l3_hedge_gross).toBeCloseTo(0.8, 6);
+  });
+
+  it("buildHedgeBasket for AAPL (live numbers, family_office) — 4 legs, L3→L1 downgrade trace", () => {
+    const basket = buildHedgeBasket({
+      ticker: "AAPL",
+      as_of: "2026-05-18",
+      l1_mkt_hr: -0.862,
+      l2_mkt_hr: -1.396,
+      l2_sec_hr:  0.357,
+      l3_mkt_hr: -2.002,
+      l3_sec_hr: -0.026,
+      l3_sub_hr:  0.410,
+      l2_sec_er:  0.007,
+      l3_sub_er:  0.020,
+      beta_m_aapl: 0.862,
+      sector_etf_ticker: "XLK",
+      subsector_etf_ticker: "SOXX",
+      lambda_s_to_m: 1.497,
+      lambda_u_to_m: 1.478,
+      user_segment: "family_office",
+    });
+
+    expect(basket.ticker).toBe("AAPL");
+    expect(basket.lstar).toBe("L3");
+    expect(basket.recommended_hedge_level).toBe("L1");      // downgraded
+    expect(basket.user_segment_applied).toBe("family_office");
+    expect(basket.leverage_cap_applied).toBe(2.0);
+    expect(basket.haircut_applied).toBe(0.7);
+
+    // Four legs: AAPL + SPY + XLK + SOXX
+    expect(basket.legs).toHaveLength(4);
+    expect(basket.legs[0]!.leg).toBe("AAPL");
+    expect(basket.legs[0]!.side).toBe("long");
+    expect(basket.legs[0]!.market_beta_contribution).toBeCloseTo(0.862, 3);
+    expect(basket.legs[1]!.leg).toBe("SPY");
+    expect(basket.legs[1]!.side).toBe("short");
+    expect(basket.legs[1]!.market_beta_contribution).toBeCloseTo(-2.002, 3);
+    expect(basket.legs[2]!.leg).toBe("XLK");
+    expect(basket.legs[2]!.market_beta_contribution).toBeCloseTo(-0.026 * 1.497, 3);
+    expect(basket.legs[3]!.leg).toBe("SOXX");
+    expect(basket.legs[3]!.side).toBe("long");
+    expect(basket.legs[3]!.market_beta_contribution).toBeCloseTo(0.410 * 1.478, 3);
+
+    // Net market β (the residual the methodology task #22 is investigating)
+    const expectedNet =
+      0.862 + (-2.002) * 1.0 + (-0.026) * 1.497 + 0.410 * 1.478;
+    expect(basket.net_market_beta_after_hedge).toBeCloseTo(expectedNet, 3);
+
+    // Decision trace narrates the two downgrades + final.
+    expect(basket.decision_trace.length).toBeGreaterThanOrEqual(3);
+    expect(basket.decision_trace[0]).toMatch(/Lstar=L3/);
+    expect(basket.decision_trace.some((s) => /L3 hedge gross/.test(s))).toBe(true);
+    expect(basket.decision_trace.some((s) => /L2 sector haircut/.test(s))).toBe(true);
+    expect(basket.decision_trace[basket.decision_trace.length - 1]).toBe("Final: L1");
+  });
+
+  it("buildHedgeBasket — SPY-as-sector convention (λ=1.0, no XLK leg)", () => {
+    const basket = buildHedgeBasket({
+      ticker: "SPY",
+      as_of: "2026-05-18",
+      l1_mkt_hr: -1.0,
+      l2_mkt_hr: -1.0,
+      l2_sec_hr: 0.0,
+      l3_mkt_hr: -1.0,
+      l3_sec_hr: 0.0,
+      l3_sub_hr: 0.0,
+      l2_sec_er: 0.0,
+      l3_sub_er: 0.0,
+      beta_m_aapl: 1.0,
+      sector_etf_ticker: "SPY",
+      subsector_etf_ticker: "SPY",
+      lambda_s_to_m: null,
+      lambda_u_to_m: null,
+      user_segment: "retail",
+    });
+    // Only one hedge leg (the SPY hedge); SPY sector/subsector are deduped.
+    expect(basket.legs.map((l) => l.leg)).toEqual(["SPY", "SPY"]);
+    expect(basket.legs[0]!.side).toBe("long");
+    expect(basket.legs[1]!.side).toBe("short");
+    expect(basket.net_market_beta_after_hedge).toBeCloseTo(0, 6);
   });
 
   it("custom threshold flips lstar without affecting hedge gross", () => {

--- a/tests/hedge-recommendation.test.ts
+++ b/tests/hedge-recommendation.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Test parity with `~/BW_Code/ERM3/tests/test_hedge_recommendation.py`.
+ *
+ * Each case below mirrors a Python test. If outputs diverge between the two
+ * implementations, the Python is the source of truth (per the spec at
+ * docs/plans/hedge-recommendation-ts-port.md) — update this file to match,
+ * not the other way around.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_ER_HAIRCUT,
+  SEGMENT_LEVERAGE_CAPS,
+  hedgeGrossFromHrs,
+  recommendHedgeLevel,
+} from "@/lib/dal/hedge-recommendation";
+
+describe("recommendHedgeLevel — realistic scenarios from the diverse-ticker basket", () => {
+  it("AAPL today: Lstar=L3, downgraded to L1 by leverage + ER floor", () => {
+    // AAPL today: L3 hedge gross 2.44 over 2.0 cap, L2 sector ER 0.7% raw →
+    // 0.49% haircut, fails 1% floor. L3 subsec ER 2.0% raw → 1.4% haircut passes.
+    const rec = recommendHedgeLevel({
+      lstar: "L3",
+      l1HedgeGross: 0.88,
+      l2HedgeGross: 1.40,
+      l3HedgeGross: 2.44,
+      l2SectorEr: 0.007,
+      l3SubsectorEr: 0.020,
+      userSegment: "family_office",
+    });
+    expect(rec).toBe("L1");
+  });
+
+  it("high-signal small-cap keeps L3 under LS cap", () => {
+    const rec = recommendHedgeLevel({
+      lstar: "L3",
+      l1HedgeGross: 1.45,
+      l2HedgeGross: 1.80,
+      l3HedgeGross: 2.15,
+      l2SectorEr: 0.06,
+      l3SubsectorEr: 0.11,
+      userSegment: "ls_equity",
+    });
+    expect(rec).toBe("L3");
+  });
+
+  it("defensive utility stays L1", () => {
+    const rec = recommendHedgeLevel({
+      lstar: "L1",
+      l1HedgeGross: 0.45,
+      l2HedgeGross: 0.55,
+      l3HedgeGross: 0.60,
+      l2SectorEr: 0.005,
+      l3SubsectorEr: 0.002,
+      userSegment: "retail",
+    });
+    expect(rec).toBe("L1");
+  });
+
+  it("regional bank keeps L2", () => {
+    const rec = recommendHedgeLevel({
+      lstar: "L2",
+      l1HedgeGross: 0.65,
+      l2HedgeGross: 1.35,
+      l3HedgeGross: 1.50,
+      l2SectorEr: 0.045,
+      l3SubsectorEr: 0.0,
+      userSegment: "family_office",
+    });
+    expect(rec).toBe("L2");
+  });
+
+  it("high-beta semi downgrades by user segment", () => {
+    const common = {
+      lstar: "L3" as const,
+      l1HedgeGross: 1.65,
+      l2HedgeGross: 2.20,
+      l3HedgeGross: 3.10,
+      l2SectorEr: 0.04,           // 2.8% haircut
+      l3SubsectorEr: 0.068,       // 4.76% haircut
+    };
+    // retail (cap 1.5): L3 fails leverage → L2; L2=2.20>1.5 → L1
+    expect(recommendHedgeLevel({ ...common, userSegment: "retail" })).toBe("L1");
+    // family_office (cap 2.0): L3 fails → L2; L2=2.20>2.0 → L1
+    expect(recommendHedgeLevel({ ...common, userSegment: "family_office" })).toBe("L1");
+    // ls_equity (cap 3.0): L3=3.10>3.0 → L2; L2=2.20<3.0 + ER passes → keep L2
+    expect(recommendHedgeLevel({ ...common, userSegment: "ls_equity" })).toBe("L2");
+    // stat_arb (cap 5.0): L3 fits → keep L3
+    expect(recommendHedgeLevel({ ...common, userSegment: "stat_arb" })).toBe("L3");
+  });
+});
+
+describe("recommendHedgeLevel — edge cases", () => {
+  it("null / empty / unknown Lstar falls back to L1", () => {
+    for (const v of [null, "", "L0", "L4", "unknown"]) {
+      const rec = recommendHedgeLevel({
+        // Cast through unknown to satisfy the stricter LStarOrNone union for invalid inputs.
+        lstar: v as unknown as null,
+        l1HedgeGross: 0.0,
+        l2HedgeGross: 0.0,
+        l3HedgeGross: 0.0,
+        l2SectorEr: 0.10,
+        l3SubsectorEr: 0.10,
+      });
+      expect(rec, `lstar=${JSON.stringify(v)} should fall back to L1`).toBe("L1");
+    }
+  });
+
+  it("explicit leverageCap overrides segment default", () => {
+    const common = {
+      lstar: "L3" as const,
+      l1HedgeGross: 1.0,
+      l2HedgeGross: 1.8,
+      l3HedgeGross: 2.5,
+      l2SectorEr: 0.03,
+      l3SubsectorEr: 0.04,
+    };
+    // family_office cap 2.0: L3 fails → L2 passes (1.8 < 2.0)
+    expect(recommendHedgeLevel({ ...common, userSegment: "family_office" })).toBe("L2");
+    // Override cap=2.7: L3 fits
+    expect(recommendHedgeLevel({ ...common, leverageCap: 2.7 })).toBe("L3");
+    // Override cap=1.0: both L3 and L2 fail → L1
+    expect(recommendHedgeLevel({ ...common, leverageCap: 1.0 })).toBe("L1");
+  });
+
+  it("erHaircut=0 collapses every gate (pessimist) → falls to L1", () => {
+    const rec = recommendHedgeLevel({
+      lstar: "L3",
+      l1HedgeGross: 0.1,
+      l2HedgeGross: 0.1,
+      l3HedgeGross: 0.1,           // well under any cap
+      l2SectorEr: 1.0,              // arbitrarily large
+      l3SubsectorEr: 1.0,
+      erHaircut: 0.0,
+      userSegment: "stat_arb",      // leverage never binds
+    });
+    expect(rec).toBe("L1");
+  });
+});
+
+describe("constants pinned for cross-implementation parity", () => {
+  it("DEFAULT_ER_HAIRCUT equals 0.7 (Python parity)", () => {
+    expect(DEFAULT_ER_HAIRCUT).toBe(0.7);
+  });
+
+  it("SEGMENT_LEVERAGE_CAPS is monotonically increasing retail → family → ls → stat", () => {
+    const caps = [
+      SEGMENT_LEVERAGE_CAPS.retail,
+      SEGMENT_LEVERAGE_CAPS.family_office,
+      SEGMENT_LEVERAGE_CAPS.ls_equity,
+      SEGMENT_LEVERAGE_CAPS.stat_arb,
+    ];
+    const sorted = [...caps].sort((a, b) => a - b);
+    expect(caps).toEqual(sorted);
+  });
+});
+
+describe("hedgeGrossFromHrs", () => {
+  it("sums absolute values", () => {
+    expect(hedgeGrossFromHrs(0.5, -0.3, 0.2)).toBeCloseTo(1.0, 6);
+  });
+
+  it("is NaN-safe (NaN inputs are skipped)", () => {
+    expect(hedgeGrossFromHrs(0.5, Number.NaN, 0.2)).toBeCloseTo(0.7, 6);
+  });
+
+  it("skips null/undefined", () => {
+    expect(hedgeGrossFromHrs(0.5, null, 0.2, undefined)).toBeCloseTo(0.7, 6);
+  });
+
+  it("returns 0 with no inputs", () => {
+    expect(hedgeGrossFromHrs()).toBe(0);
+  });
+
+  it("reproduces AAPL L1/L2/L3 hedge gross from the live zarr", () => {
+    // Values from `xr.open_zarr(ds_erm3_hedge_weights_SPY_uni_mc_3000.zarr)`
+    // at AAPL's latest teo (2026-05-18). Matches the parallel Python case
+    // `test_hedge_gross_l1_l2_l3_for_aapl`.
+    const l1 = hedgeGrossFromHrs(-0.862);
+    const l2 = hedgeGrossFromHrs(-1.396, 0.357);
+    const l3 = hedgeGrossFromHrs(-2.002, -0.026, 0.410);
+    expect(l1).toBeCloseTo(0.862, 3);
+    expect(l2).toBeCloseTo(1.753, 3);
+    expect(l3).toBeCloseTo(2.438, 3);
+  });
+});


### PR DESCRIPTION
## Summary

Adds an **economic recommendation layer** on top of `Lstar`. Today the chat surfaces `Lstar=L3` and `L3 Market HR=-2.00` for AAPL with no context — a reader (correctly) infers a market beta of 2.0 and recoils. This PR adds:

1. `recommended_hedge_level` — the *economic* pick that applies a user-segment leverage cap and OOS-haircut on top of `Lstar`'s statistical pick. **`Lstar` is never mutated**; divergence between the two is the regime-change alert the chat surfaces.
2. New payload fields on `GET /api/metrics/{ticker}` so existing clients can adopt without a route change.
3. New `GET /api/hedge-basket/{ticker}` endpoint returning a structured 4-row basket with per-leg market-β contribution and a `decision_trace` string array the chat narrates verbatim.

The decision rule is a direct TS port of `erm3.shared.hedge_recommendation` in ERM3 (the Python SSOT, 12 unit tests covering the same scenarios). CI parity: 15 TS test cases in `tests/hedge-recommendation.test.ts` mirror the Python cases — divergence fails the build.

Spec / design doc: `docs/plans/hedge-recommendation-ts-port.md`.

## What the chat sees for AAPL today

```
GET /api/hedge-basket/AAPL?user_segment=family_office
{
  lstar: "L3", recommended_hedge_level: "L1",        ← divergence
  leverage_cap_applied: 2.0, haircut_applied: 0.7,
  legs: [
    { leg: "AAPL", side: "long",  position: 1.00, beta_to_spy: 0.876, market_beta_contribution:  0.876 },
    { leg: "SPY",  side: "short", position:-2.00, beta_to_spy: 1.000, market_beta_contribution: -2.002 },
    { leg: "XLK",  side: "short", position:-0.03, beta_to_spy: 1.497, market_beta_contribution: -0.039 },
    { leg: "SOXX", side: "long",  position: 0.41, beta_to_spy: 1.478, market_beta_contribution:  0.606 }
  ],
  hedge_gross: { L1: 0.88, L2: 1.75, L3: 2.44 },
  decision_trace: [
    "Lstar=L3 (subsector marginal ER 2.00% ≥ 1.00% threshold)",
    "L3 hedge gross 2.44 > 2.0× cap (family_office) → drop to L2",
    "L2 sector haircut ER 0.49% < 1.00% floor → drop to L1",
    "Final: L1"
  ]
}
```

`?user_segment=` accepts `retail` (1.5×), `family_office` (2.0× default), `ls_equity` (3.0×), `stat_arb` (5.0×).

## Phases

| Commit | Phase | Surface |
|---|---|---|
| `cef3d75` | 1 | Pure function `recommendHedgeLevel`, `hedgeGrossFromHrs`, segment constants. Net-zero behavior. |
| `e65737d` | 2 | Wire into `/api/metrics/{ticker}` — adds 8 payload fields, accepts `?user_segment=`. |
| `c168bcf` | 3 | New `/api/hedge-basket/{ticker}` endpoint — structured legs + decision trace + link-betas reader. |

## Test plan

- [x] **313/313** vitest pass (was 311 pre-PR; +2 buildHedgeBasket tests added)
- [x] **Zero typecheck errors** in any new/touched file (`tsc --noEmit`)
- [x] **Lint clean** (`eslint` on all touched files)
- [x] **Python ↔ TS parity** — same 12 input scenarios produce the same output (AAPL downgrade, segment-sensitive semi, null-Lstar fallback, NaN-safe hedge gross, segment caps monotonicity, etc.)
- [ ] Ground-test against staging: `curl /api/hedge-basket/AAPL` → verify the 4 legs and trace match the live zarr values
- [ ] Reviewer: confirm the `net_market_beta_after_hedge` value (-0.56 for AAPL) — flagged in methodology task #22 as the residual cross-cross term `β_u·λ_u→s·λ_s→m`. Not a bug; surfaces it for transparency.

## Follow-ups (NOT in this PR)

- **Chat skill** swap (task #20): replace the single "Market HR (L3)" row with the basket table that this endpoint now feeds.
- **Methodology task #22**: decide whether the cascade should also zero raw market exposure (vs orthogonalized factor exposure only). Affects whether `net_market_beta_after_hedge` becomes a status-quo "FYI" or an action item.
- **Phase B2** (in ERM3): replace `DEFAULT_ER_HAIRCUT = 0.7` with realized OOS variance-reduction factors from walk-forward backtests. Update Python SSOT first, then port to TS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)