### PR TITLE
feat(13f): filer concentration + holdings weight fix

### DIFF
--- a/OPENAPI_SPEC.yaml
+++ b/OPENAPI_SPEC.yaml
@@ -7668,6 +7668,62 @@ paths:
         "429":
           description: Rate limit exceeded.
 
+  /13f/filers/{bw_filer_id}/concentration:
+    get:
+      summary: 13F filer concentration summary
+      description: >
+        Quarter-end concentration panel from per-filer ds_portfolio.zarr.
+        Returns median and latest effective N, top-5 / top-10 weight share,
+        and weight HHI over an optional date window (same underlying series
+        as /portfolio, summarized for diligence).
+      operationId: getFilerConcentration
+      tags:
+        - 13F Filers
+      x-pricing:
+        capability_id: filer-concentration
+        tier: baseline
+        cost_usd: 0.005
+        billing_code: filer_concentration_v1
+      parameters:
+        - name: bw_filer_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: start_date
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date
+        - name: end_date
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date
+      responses:
+        "200":
+          description: Concentration summary (median + latest).
+          content:
+            application/json:
+              schema:
+                type: object
+        "402":
+          description: Insufficient prepaid balance.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InsufficientBalance"
+        "404":
+          description: Filer not found, or no concentration panel available.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "429":
+          description: Rate limit exceeded.
+
   /13f/filers/{bw_filer_id}/snapshot:
     get:
       summary: 13F filer composed snapshot (JSON)

--- a/app/api/13f/filers/[bw_filer_id]/concentration/route.ts
+++ b/app/api/13f/filers/[bw_filer_id]/concentration/route.ts
@@ -1,0 +1,88 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { withBilling, type BillingContext } from "@/lib/agent/billing-middleware";
+import { fetchFiler } from "@/lib/dal/filers-engine";
+import { readFilerConcentrationSummary } from "@/lib/dal/funds-zarr-reader";
+
+export const dynamic = "force-dynamic";
+
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * GET /api/13f/filers/{bw_filer_id}/concentration?start_date=&end_date=
+ *
+ * Quarter-end concentration panel from per-filer ds_portfolio.zarr on GCS.
+ * Returns median and latest effective N, top-5 / top-10 weight share, and
+ * weight HHI over the optional date window (same underlying series as
+ * /portfolio, summarized for §3-style diligence).
+ */
+export const GET = withBilling(
+  async (request: NextRequest, _context: BillingContext) => {
+    const segments = request.nextUrl.pathname.split("/");
+    const bwFilerId = segments[segments.length - 2];
+    if (!bwFilerId) {
+      return NextResponse.json(
+        { error: "bw_filer_id is required" },
+        { status: 400 },
+      );
+    }
+
+    const { searchParams } = request.nextUrl;
+    const startDate = searchParams.get("start_date") ?? undefined;
+    const endDate = searchParams.get("end_date") ?? undefined;
+    if (startDate && !ISO_DATE.test(startDate)) {
+      return NextResponse.json(
+        { error: "start_date must be YYYY-MM-DD" },
+        { status: 400 },
+      );
+    }
+    if (endDate && !ISO_DATE.test(endDate)) {
+      return NextResponse.json(
+        { error: "end_date must be YYYY-MM-DD" },
+        { status: 400 },
+      );
+    }
+    if (startDate && endDate && startDate > endDate) {
+      return NextResponse.json(
+        { error: "start_date must be <= end_date" },
+        { status: 400 },
+      );
+    }
+
+    const filer = await fetchFiler(bwFilerId);
+    if (!filer) {
+      return NextResponse.json({ error: "Filer not found" }, { status: 404 });
+    }
+
+    const summary = await readFilerConcentrationSummary(bwFilerId, {
+      startDate,
+      endDate,
+    });
+    if (!summary) {
+      return NextResponse.json(
+        {
+          error: "No concentration panel available for this filer",
+          bw_filer_id: bwFilerId,
+        },
+        { status: 404 },
+      );
+    }
+
+    const headers = new Headers({ "X-Data-As-Of": summary.end_teo });
+    if (filer.latest_filing_date) {
+      headers.set("X-Data-Filing-Date", filer.latest_filing_date);
+    }
+
+    return NextResponse.json(
+      {
+        bw_filer_id: bwFilerId,
+        cik: filer.cik,
+        name: filer.name,
+        filer_type: filer.filer_type,
+        aum_tier: filer.aum_tier,
+        ...summary,
+      },
+      { headers },
+    );
+  },
+  { capabilityId: "filer-concentration" },
+);

--- a/lib/agent/capabilities.ts
+++ b/lib/agent/capabilities.ts
@@ -1926,6 +1926,53 @@ export const CAPABILITIES: Capability[] = [
     tags: ["13f", "filers", "history", "time-series"],
   },
   {
+    id: "filer-concentration",
+    name: "13F Filer Concentration Summary",
+    description:
+      "Quarter-end concentration panel from per-filer ds_portfolio.zarr on GCS. " +
+      "Returns median and latest effective N, top-5 / top-10 weight share, and weight HHI " +
+      "over an optional ?start_date / ?end_date window.",
+    endpoint: "/api/13f/filers/{bw_filer_id}/concentration",
+    method: "GET",
+    parameters: {
+      bw_filer_id: {
+        type: "string",
+        required: true,
+        description:
+          "Funds_DAG canonical filer id (format: BW-FILER-CIK{cik}).",
+      },
+      start_date: {
+        type: "string",
+        required: false,
+        description: "Inclusive lower bound, YYYY-MM-DD.",
+      },
+      end_date: {
+        type: "string",
+        required: false,
+        description: "Inclusive upper bound, YYYY-MM-DD.",
+      },
+    },
+    pricing: {
+      model: "per_request",
+      tier: "baseline",
+      cost_usd: 0.005,
+      currency: "USD",
+      billing_code: "filer_concentration_v1",
+    },
+    performance: {
+      avg_latency_ms: 200,
+      p95_latency_ms: 500,
+      availability_sla: 99.9,
+      rate_limit_per_minute: 60,
+    },
+    confidence: {
+      data_quality_score: 0.9,
+      update_frequency: "quarterly",
+      sources: ["bw_filer_id/{id}/ds_portfolio.zarr", "filers"],
+    },
+    tags: ["13f", "filers", "concentration"],
+  },
+  {
     id: "filer-snapshot-json",
     name: "13F Filer Snapshot (JSON)",
     description:

--- a/lib/dal/funds-zarr-reader.ts
+++ b/lib/dal/funds-zarr-reader.ts
@@ -1007,7 +1007,14 @@ export async function readFilerHoldingsTopN(
   ]);
   if (!adjMv) return null;
 
-  const denom = totalAumUsd != null && totalAumUsd > 0 ? totalAumUsd : null;
+  let denom = totalAumUsd != null && totalAumUsd > 0 ? totalAumUsd : null;
+  if (denom == null) {
+    let sumAdj = 0;
+    for (const v of adjMv) {
+      if (v != null && v > 0) sumAdj += v;
+    }
+    denom = sumAdj > 0 ? sumAdj : null;
+  }
   const holdings: FilerHolding[] = [];
   for (let i = 0; i < adjMv.length; i++) {
     const v = adjMv[i];
@@ -1046,7 +1053,9 @@ export interface FilerPortfolioRow {
   weight_sum: number | null;
   n_holdings_active: number | null;
   effective_n: number | null;
+  top5_weight_sum: number | null;
   top10_weight_sum: number | null;
+  weight_hhi: number | null;
   // AUM
   total_aum_usd: number | null;
   aum_in_erm3: number | null;
@@ -1070,7 +1079,9 @@ const FILER_PORTFOLIO_VARS = [
   "weight_sum",
   "n_holdings_active",
   "effective_n",
+  "top5_weight_sum",
   "top10_weight_sum",
+  "weight_hhi",
   "total_aum_usd",
   "aum_in_erm3",
   "n_holdings_in_erm3",
@@ -1128,6 +1139,72 @@ export async function readFilerPortfolioSeries(
     rows.push(row as unknown as FilerPortfolioRow);
   }
   return rows;
+}
+
+function medianFinite(values: Array<number | null>): number | null {
+  const nums = values.filter(
+    (v): v is number => v != null && Number.isFinite(v),
+  );
+  if (nums.length === 0) return null;
+  nums.sort((a, b) => a - b);
+  const mid = Math.floor(nums.length / 2);
+  if (nums.length % 2 === 1) return nums[mid]!;
+  return (nums[mid - 1]! + nums[mid]!) / 2;
+}
+
+export interface FilerConcentrationLatest {
+  teo: string;
+  effective_n: number | null;
+  top5_weight_sum: number | null;
+  top10_weight_sum: number | null;
+  weight_hhi: number | null;
+  n_holdings_active: number | null;
+}
+
+export interface FilerConcentrationSummary {
+  n_periods: number;
+  start_teo: string;
+  end_teo: string;
+  latest: FilerConcentrationLatest;
+  median: {
+    effective_n: number | null;
+    top5_weight_sum: number | null;
+    top10_weight_sum: number | null;
+    weight_hhi: number | null;
+  };
+}
+
+/**
+ * Median + latest quarter-end concentration from ``ds_portfolio.zarr``.
+ * Null when the filer has no portfolio panel in the date window.
+ */
+export async function readFilerConcentrationSummary(
+  bwFilerId: string,
+  options: FundPortfolioOptions = {},
+): Promise<FilerConcentrationSummary | null> {
+  const rows = await readFilerPortfolioSeries(bwFilerId, options);
+  if (rows.length === 0) return null;
+
+  const latest = rows[rows.length - 1]!;
+  return {
+    n_periods: rows.length,
+    start_teo: rows[0]!.teo,
+    end_teo: latest.teo,
+    latest: {
+      teo: latest.teo,
+      effective_n: latest.effective_n,
+      top5_weight_sum: latest.top5_weight_sum,
+      top10_weight_sum: latest.top10_weight_sum,
+      weight_hhi: latest.weight_hhi,
+      n_holdings_active: latest.n_holdings_active,
+    },
+    median: {
+      effective_n: medianFinite(rows.map((r) => r.effective_n)),
+      top5_weight_sum: medianFinite(rows.map((r) => r.top5_weight_sum)),
+      top10_weight_sum: medianFinite(rows.map((r) => r.top10_weight_sum)),
+      weight_hhi: medianFinite(rows.map((r) => r.weight_hhi)),
+    },
+  };
 }
 
 const FILER_RETURNS_VARS = [

--- a/mcp/data/capabilities.json
+++ b/mcp/data/capabilities.json
@@ -1009,6 +1009,20 @@
     "tags": ["13f", "filer", "return-attribution", "portfolio-surface", "funds"]
   },
   {
+    "id": "filer-concentration",
+    "name": "13F Filer Concentration Summary",
+    "description": "Quarter-end concentration panel from per-filer ds_portfolio.zarr (median + latest effective N, top-5 / top-10 weight share, weight HHI). Optional ?start_date / ?end_date window.",
+    "endpoint": "/api/13f/filers/{bw_filer_id}/concentration",
+    "method": "GET",
+    "parameters": {
+      "bw_filer_id": { "type": "string", "required": true, "description": "Funds_DAG canonical 13F filer id (BW-FILER-CIK{cik})." },
+      "start_date": { "type": "string", "required": false, "description": "YYYY-MM-DD lower bound on report_date." },
+      "end_date": { "type": "string", "required": false, "description": "YYYY-MM-DD upper bound on report_date." }
+    },
+    "pricing": { "model": "per_request", "cost_usd": 0.005, "currency": "USD", "billing_code": "filer_concentration_v1" },
+    "tags": ["13f", "filer", "concentration", "portfolio-surface"]
+  },
+  {
     "id": "filer-snapshot-json",
     "name": "13F Filer Snapshot (JSON)",
     "description": "Composed JSON snapshot for a single 13F filer. Bundles registry + latest metrics + top-25 holdings + portfolio history + cohort context. Cohort axis = filer_type × aum_tier (vs equity_style_9box on the fund side). No NAV section (filers have no NAV by construction); hedge section gated on D.8.10 Phase 3. Matching server-rendered PDF is /api/13f/filers/{bw_filer_id}/snapshot.pdf. MASTER_BACKLOG D.8.8 / D.8.9.",

--- a/mcp/data/openapi.json
+++ b/mcp/data/openapi.json
@@ -11695,6 +11695,85 @@
         }
       }
     },
+    "/13f/filers/{bw_filer_id}/concentration": {
+      "get": {
+        "summary": "13F filer concentration summary",
+        "description": "Quarter-end concentration panel from per-filer ds_portfolio.zarr. Returns median and latest effective N, top-5 / top-10 weight share, and weight HHI over an optional date window (same underlying series as /portfolio, summarized for diligence).\n",
+        "operationId": "getFilerConcentration",
+        "tags": [
+          "13F Filers"
+        ],
+        "x-pricing": {
+          "capability_id": "filer-concentration",
+          "tier": "baseline",
+          "cost_usd": 0.005,
+          "billing_code": "filer_concentration_v1"
+        },
+        "parameters": [
+          {
+            "name": "bw_filer_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "start_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          },
+          {
+            "name": "end_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Concentration summary (median + latest).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Insufficient prepaid balance.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InsufficientBalance"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Filer not found, or no concentration panel available.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded."
+          }
+        }
+      }
+    },
     "/13f/filers/{bw_filer_id}/snapshot": {
       "get": {
         "summary": "13F filer composed snapshot (JSON)",


### PR DESCRIPTION
## Summary
- Adds `GET /api/13f/filers/{bw_filer_id}/concentration` (median + latest effective N, top-5/10, HHI from `ds_portfolio.zarr`).
- Fixes holdings `weight: null` when filer `ds_ph` lacks `total_aum_usd` by normalizing on summed `adj_mv`.
- Registers `filer-concentration` in capabilities + OpenAPI (Part 2 Medium publish slice).

## Test plan
- [ ] Vercel preview build green
- [ ] `GET /api/13f/filers/BW-FILER-CIK0001067983/concentration` → 200 after deploy
- [ ] `GET /api/13f/filers/BW-FILER-CIK0001067983/holdings` → non-null weights on top names
- [ ] Smoke Part 2 cohort (5 filers): holdings, portfolio, snapshot, concentration


Made with [Cursor](https://cursor.com)