### PR TITLE
feat(residual-signal): /api/residual-signal endpoints (Phase D, D3)

### DIFF
--- a/app/api/residual-signal/[ticker]/route.ts
+++ b/app/api/residual-signal/[ticker]/route.ts
@@ -1,0 +1,114 @@
+/**
+ * GET /api/residual-signal/[ticker]
+ *
+ * Phase D residual mean-reversion factor for a single ticker: the latest
+ * signal reading plus a calendar-day history window (default 90d).
+ *
+ * The signal is the L3 orthogonal residual's 5-day mean-reversion factor —
+ * a combo-input building block for multi-signal alpha stacks, NOT a
+ * standalone strategy. Every response carries `capacity_note` with the
+ * explicit gross-Sharpe + market-impact capacity disclosure.
+ *
+ * @see lib/risk/residual-signal-service.ts
+ * @see BWMACRO/research/phase_b_minimum_experiment_results.md
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { withBilling, BillingContext } from "@/lib/agent/billing-middleware";
+import { getResidualSignalForTicker } from "@/lib/risk/residual-signal-service";
+import { getRiskMetadata } from "@/lib/dal/risk-metadata";
+import { addMetadataHeaders, buildMetadataBody } from "@/lib/dal/response-headers";
+import { ResidualSignalTickerRequestSchema } from "@/lib/api/schemas";
+import { getCorsHeaders } from "@/lib/cors";
+
+export const runtime = "nodejs";
+
+function classifyError(message: string): string {
+  const m = message.toLowerCase();
+  if (m.includes("zarr") || m.includes("gcs")) return "zarr_read_failed";
+  if (m.includes("timeout") || m.includes("aborted")) return "upstream_timeout";
+  if (m.includes("network") || m.includes("econnreset")) return "network_error";
+  return "internal_error";
+}
+
+export const GET = withBilling(
+  async (request: NextRequest, context: BillingContext) => {
+    const rawTicker = request.nextUrl.pathname.split("/").pop();
+    const origin = request.headers.get("origin");
+
+    const validation = ResidualSignalTickerRequestSchema.safeParse({
+      ticker: rawTicker,
+      days: request.nextUrl.searchParams.get("days") ?? undefined,
+    });
+    if (!validation.success) {
+      return NextResponse.json(
+        {
+          error: "Invalid request",
+          message: validation.error.issues[0]!.message,
+        },
+        { status: 400, headers: getCorsHeaders(origin) },
+      );
+    }
+
+    const { ticker, days } = validation.data;
+
+    try {
+      const fetchStart = performance.now();
+      const result = await getResidualSignalForTicker(ticker, days);
+
+      if (!result) {
+        return NextResponse.json(
+          {
+            error: "Not found",
+            message: `No residual signal for ticker ${ticker} (not in the active universe, or insufficient history).`,
+          },
+          { status: 404, headers: getCorsHeaders(origin) },
+        );
+      }
+
+      const metadata = await getRiskMetadata();
+      const fetchLatency = Math.round(performance.now() - fetchStart);
+
+      const response = NextResponse.json(
+        {
+          ...result,
+          _metadata: buildMetadataBody(metadata, {
+            data_source: "zarr",
+            range:
+              result.history.length > 0
+                ? [
+                    result.history[0]!.date,
+                    result.history[result.history.length - 1]!.date,
+                  ]
+                : undefined,
+          }),
+        },
+        {
+          headers: {
+            ...getCorsHeaders(origin),
+            "X-Data-Fetch-Latency-Ms": String(fetchLatency),
+          },
+        },
+      );
+      addMetadataHeaders(response, metadata);
+      return response;
+    } catch (e) {
+      const errMessage = e instanceof Error ? e.message : String(e);
+      const errClass = classifyError(errMessage);
+      console.error(
+        `[ResidualSignal] ${errClass} for ticker=${ticker} days=${days}:`,
+        errMessage,
+      );
+      return NextResponse.json(
+        {
+          error: "Internal Error",
+          error_class: errClass,
+          message: errMessage,
+          request_id: context.requestId,
+        },
+        { status: 500, headers: getCorsHeaders(origin) },
+      );
+    }
+  },
+  { capabilityId: "residual-signal" },
+);

--- a/app/api/residual-signal/decile/[n]/route.ts
+++ b/app/api/residual-signal/decile/[n]/route.ts
@@ -1,0 +1,83 @@
+/**
+ * GET /api/residual-signal/decile/[n]
+ *
+ * Phase D residual mean-reversion factor — current members of decile `n`
+ * (1 = most negative residual_z_5d / most "oversold", 10 = most positive /
+ * most "overbought"), sorted by residual_z_5d.
+ *
+ * Combo-input building block, not a standalone strategy — see `capacity_note`.
+ *
+ * @see lib/risk/residual-signal-service.ts
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { withBilling, BillingContext } from "@/lib/agent/billing-middleware";
+import { getResidualSignalDecile } from "@/lib/risk/residual-signal-service";
+import { getRiskMetadata } from "@/lib/dal/risk-metadata";
+import { addMetadataHeaders, buildMetadataBody } from "@/lib/dal/response-headers";
+import { getCorsHeaders } from "@/lib/cors";
+
+export const runtime = "nodejs";
+
+export const GET = withBilling(
+  async (request: NextRequest, context: BillingContext) => {
+    const rawN = request.nextUrl.pathname.split("/").pop();
+    const origin = request.headers.get("origin");
+
+    const n = Number(rawN);
+    if (!Number.isInteger(n) || n < 1 || n > 10) {
+      return NextResponse.json(
+        {
+          error: "Invalid request",
+          message: "decile must be an integer in [1, 10]",
+        },
+        { status: 400, headers: getCorsHeaders(origin) },
+      );
+    }
+
+    try {
+      const fetchStart = performance.now();
+      const result = await getResidualSignalDecile(n);
+
+      if (!result) {
+        return NextResponse.json(
+          { error: "Not found", message: "Residual signal store unavailable." },
+          { status: 404, headers: getCorsHeaders(origin) },
+        );
+      }
+
+      const metadata = await getRiskMetadata();
+      const fetchLatency = Math.round(performance.now() - fetchStart);
+
+      const response = NextResponse.json(
+        {
+          ...result,
+          _metadata: buildMetadataBody(metadata, {
+            data_source: "zarr",
+            range: [result.as_of_date, result.as_of_date],
+          }),
+        },
+        {
+          headers: {
+            ...getCorsHeaders(origin),
+            "X-Data-Fetch-Latency-Ms": String(fetchLatency),
+          },
+        },
+      );
+      addMetadataHeaders(response, metadata);
+      return response;
+    } catch (e) {
+      const errMessage = e instanceof Error ? e.message : String(e);
+      console.error(`[ResidualSignal/decile]`, errMessage);
+      return NextResponse.json(
+        {
+          error: "Internal Error",
+          message: errMessage,
+          request_id: context.requestId,
+        },
+        { status: 500, headers: getCorsHeaders(origin) },
+      );
+    }
+  },
+  { capabilityId: "residual-signal" },
+);

--- a/app/api/residual-signal/latest/route.ts
+++ b/app/api/residual-signal/latest/route.ts
@@ -1,0 +1,89 @@
+/**
+ * GET /api/residual-signal/latest
+ *
+ * Phase D residual mean-reversion factor — full active-universe cross-section
+ * at the latest teo, sorted by residual_z_5d ascending (most "oversold"
+ * first), paginated via ?limit (default 500, max 2000) and ?offset.
+ *
+ * Combo-input building block, not a standalone strategy — see `capacity_note`.
+ *
+ * @see lib/risk/residual-signal-service.ts
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { withBilling, BillingContext } from "@/lib/agent/billing-middleware";
+import { getResidualSignalLatest } from "@/lib/risk/residual-signal-service";
+import { getRiskMetadata } from "@/lib/dal/risk-metadata";
+import { addMetadataHeaders, buildMetadataBody } from "@/lib/dal/response-headers";
+import { ResidualSignalLatestRequestSchema } from "@/lib/api/schemas";
+import { getCorsHeaders } from "@/lib/cors";
+
+export const runtime = "nodejs";
+
+export const GET = withBilling(
+  async (request: NextRequest, context: BillingContext) => {
+    const { searchParams } = new URL(request.url);
+    const origin = request.headers.get("origin");
+
+    const validation = ResidualSignalLatestRequestSchema.safeParse({
+      limit: searchParams.get("limit") ?? undefined,
+      offset: searchParams.get("offset") ?? undefined,
+    });
+    if (!validation.success) {
+      return NextResponse.json(
+        {
+          error: "Invalid request",
+          message: validation.error.issues[0]!.message,
+        },
+        { status: 400, headers: getCorsHeaders(origin) },
+      );
+    }
+
+    const { limit, offset } = validation.data;
+
+    try {
+      const fetchStart = performance.now();
+      const result = await getResidualSignalLatest({ limit, offset });
+
+      if (!result) {
+        return NextResponse.json(
+          { error: "Not found", message: "Residual signal store unavailable." },
+          { status: 404, headers: getCorsHeaders(origin) },
+        );
+      }
+
+      const metadata = await getRiskMetadata();
+      const fetchLatency = Math.round(performance.now() - fetchStart);
+
+      const response = NextResponse.json(
+        {
+          ...result,
+          _metadata: buildMetadataBody(metadata, {
+            data_source: "zarr",
+            range: [result.as_of_date, result.as_of_date],
+          }),
+        },
+        {
+          headers: {
+            ...getCorsHeaders(origin),
+            "X-Data-Fetch-Latency-Ms": String(fetchLatency),
+          },
+        },
+      );
+      addMetadataHeaders(response, metadata);
+      return response;
+    } catch (e) {
+      const errMessage = e instanceof Error ? e.message : String(e);
+      console.error(`[ResidualSignal/latest]`, errMessage);
+      return NextResponse.json(
+        {
+          error: "Internal Error",
+          message: errMessage,
+          request_id: context.requestId,
+        },
+        { status: 500, headers: getCorsHeaders(origin) },
+      );
+    }
+  },
+  { capabilityId: "residual-signal" },
+);

--- a/lib/agent/capabilities.ts
+++ b/lib/agent/capabilities.ts
@@ -775,6 +775,47 @@ export const CAPABILITIES: Capability[] = [
     tags: ["risk", "decomposition", "lstar", "hedge"],
   },
   {
+    id: "residual-signal",
+    name: "Residual Mean-Reversion Signal",
+    description:
+      "L3 orthogonal-residual 5-day mean-reversion factor. A combo-input building block for multi-signal alpha stacks — NOT a standalone strategy. Returns residual_z_5d, decile_rank, signal_quality_quintile (subsector-tracking conditioning), industry_percentile and a residual autocorrelation diagnostic. Every response carries an explicit gross-Sharpe + market-impact capacity disclosure.",
+    endpoint: "/api/residual-signal",
+    method: "GET",
+    parameters: {
+      ticker: {
+        type: "string",
+        required: false,
+        description:
+          "Stock ticker for the per-ticker snapshot + history route (/api/residual-signal/{ticker}). Omit for the /latest and /decile routes.",
+      },
+      days: {
+        type: "integer",
+        required: false,
+        description: "Calendar-day lookback for the per-ticker history window.",
+        default: 90,
+      },
+    },
+    pricing: {
+      model: "per_request",
+      tier: "premium",
+      cost_usd: 0.02,
+      currency: "USD",
+      billing_code: "residual_signal_v1",
+    },
+    performance: {
+      avg_latency_ms: 140,
+      p95_latency_ms: 240,
+      availability_sla: 99.9,
+      rate_limit_per_minute: 60,
+    },
+    confidence: {
+      data_quality_score: 0.99,
+      update_frequency: "daily",
+      sources: ["erm3_models"],
+    },
+    tags: ["risk", "signal", "mean-reversion", "stat-arb", "factor"],
+  },
+  {
     id: "portfolio-returns",
     name: "Portfolio Returns",
     description: "Batch fetch returns for multiple tickers (portfolio analytics)",

--- a/lib/api/schemas.ts
+++ b/lib/api/schemas.ts
@@ -88,6 +88,37 @@ export const LstarRequestSchema = z.object({
 export type LstarRequest = z.infer<typeof LstarRequestSchema>;
 
 /**
+ * Schema for GET /api/residual-signal/[ticker] — Phase D residual
+ * mean-reversion factor. `days` is a calendar-day lookback for the history
+ * window.
+ */
+export const ResidualSignalTickerRequestSchema = z.object({
+  ticker: TickerSchema,
+  days: z.coerce
+    .number()
+    .int()
+    .min(1, "days must be >= 1")
+    .max(730, "days must be <= 730")
+    .default(90),
+});
+
+export type ResidualSignalTickerRequest = z.infer<
+  typeof ResidualSignalTickerRequestSchema
+>;
+
+/**
+ * Schema for GET /api/residual-signal/latest — paginated universe snapshot.
+ */
+export const ResidualSignalLatestRequestSchema = z.object({
+  limit: z.coerce.number().int().min(1).max(2000).default(500),
+  offset: z.coerce.number().int().min(0).default(0),
+});
+
+export type ResidualSignalLatestRequest = z.infer<
+  typeof ResidualSignalLatestRequestSchema
+>;
+
+/**
  * Schema for POST /api/decompose — simplified four-layer exposure + hedge map.
  * Returns market / sector / subsector / residual with each tradable layer's
  * hedge ETF and a `hedge` map of ETF → dollar ratio (negative of HR by convention).

--- a/lib/dal/zarr-reader.ts
+++ b/lib/dal/zarr-reader.ts
@@ -28,6 +28,7 @@ import {
   zarrHedgeBasename,
   zarrLinkBetasBasename,
   zarrRankingsBasename,
+  zarrResidualSignalBasename,
   zarrReturnsBasename,
 } from "@/lib/zarr-config";
 import { getCache, setCache, CACHE_TTL, generateCacheKey } from "@/lib/cache/redis";
@@ -1001,4 +1002,179 @@ export async function readSymbolRankSnapshot(
   });
 
   return { teo: teoStr, results };
+}
+
+// =====================================================================
+// Residual mean-reversion signal (Phase D)
+// =====================================================================
+//
+// `ds_erm3_residual_signal_{factorSetId}.zarr` is a flat (teo, symbol) store
+// with seven float32 variables — see erm3/core/residual_signal.py. Chunked
+// {teo: 500, symbol: 1000}. Carries a `ticker` string coord so tickers
+// resolve in-zarr without a Supabase round-trip.
+
+const RESIDUAL_SIGNAL_VARS = [
+  "residual_z_5d",
+  "signal_strength",
+  "decile_rank",
+  "industry_percentile",
+  "residual_autocorr_5d",
+  "l3_subsector_er",
+  "signal_quality_quintile",
+] as const;
+
+export interface ResidualSignalPoint {
+  date: string;
+  residual_z_5d: number | null;
+  signal_strength: number | null;
+  decile_rank: number | null;
+  industry_percentile: number | null;
+  residual_autocorr_5d: number | null;
+  l3_subsector_er: number | null;
+  signal_quality_quintile: number | null;
+}
+
+export interface ResidualSignalSeriesResult {
+  ticker: string;
+  points: ResidualSignalPoint[];
+  range: [string, string];
+}
+
+export interface ResidualSignalSnapshotRow {
+  ticker: string;
+  residual_z_5d: number | null;
+  signal_strength: number | null;
+  decile_rank: number | null;
+  industry_percentile: number | null;
+  residual_autocorr_5d: number | null;
+  l3_subsector_er: number | null;
+  signal_quality_quintile: number | null;
+}
+
+export interface ResidualSignalSnapshotResult {
+  teo: string | null;
+  rows: ResidualSignalSnapshotRow[];
+}
+
+/** Build idx→ticker from the zarr's `ticker` coord. */
+async function readTickerByIndex(grp: Group<Readable>): Promise<string[] | null> {
+  try {
+    const loc = grp.resolve("ticker");
+    const arr = await open.v2(loc, { kind: "array" });
+    const ch = await get(arr, null);
+    const d = ch?.data;
+    if (d instanceof UnicodeStringArray) {
+      return Array.from({ length: d.length }, (_, i) => String(d.get(i)).trim());
+    }
+    if (Array.isArray(d)) {
+      return d.map((x) => String(x).trim());
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Per-ticker residual-signal time series. Resolves the ticker against the
+ * store's own `ticker` coord (case-insensitive). Returns up to the
+ * [startDate, endDate] window — caller passes a 90d window for the API
+ * snapshot+history shape. Null if the store is unavailable or the ticker
+ * isn't in the universe.
+ */
+export async function readResidualSignalSeries(
+  ticker: string,
+  startDate?: string,
+  endDate?: string,
+): Promise<ResidualSignalSeriesResult | null> {
+  const grp = await openZarrGroup(zarrResidualSignalBasename());
+  if (!grp) return null;
+
+  const teos = await readTeoStrings(grp);
+  if (!teos?.length) return null;
+
+  const tickerMap = await readTickerIndexMap(grp);
+  if (!tickerMap?.size) return null;
+  const symIdx = tickerMap.get(ticker.trim().toUpperCase());
+  if (symIdx === undefined) return null;
+
+  const t0 = startDate ? lowerBound(teos, startDate) : 0;
+  const t1 = endDate ? upperBoundInclusive(teos, endDate) : teos.length;
+  if (t1 <= t0) {
+    return { ticker: ticker.toUpperCase(), points: [], range: ["", ""] };
+  }
+
+  const series = await Promise.all(
+    RESIDUAL_SIGNAL_VARS.map((v) =>
+      readFloatSeriesTeoSymbol(grp, v, t0, t1, symIdx),
+    ),
+  );
+
+  const points: ResidualSignalPoint[] = [];
+  for (let i = 0; i < t1 - t0; i++) {
+    const date = teos[t0 + i];
+    if (!date) continue;
+    points.push({
+      date,
+      residual_z_5d: series[0]?.[i] ?? null,
+      signal_strength: series[1]?.[i] ?? null,
+      decile_rank: series[2]?.[i] ?? null,
+      industry_percentile: series[3]?.[i] ?? null,
+      residual_autocorr_5d: series[4]?.[i] ?? null,
+      l3_subsector_er: series[5]?.[i] ?? null,
+      signal_quality_quintile: series[6]?.[i] ?? null,
+    });
+  }
+
+  return {
+    ticker: ticker.toUpperCase(),
+    points,
+    range: [teos[t0] ?? "", teos[t1 - 1] ?? ""],
+  };
+}
+
+/**
+ * Full active-universe residual-signal cross-section at the latest teo.
+ * Backs both /api/residual-signal/latest and /api/residual-signal/decile/{n}
+ * (the route filters by decile_rank). One chunk-row read per variable.
+ */
+export async function readResidualSignalLatest(): Promise<ResidualSignalSnapshotResult> {
+  const grp = await openZarrGroup(zarrResidualSignalBasename());
+  if (!grp) return { teo: null, rows: [] };
+
+  const teos = await readTeoStrings(grp);
+  if (!teos?.length) return { teo: null, rows: [] };
+  const teoIdx = teos.length - 1;
+  const teoStr = teos[teoIdx] ?? null;
+  if (!teoStr) return { teo: null, rows: [] };
+
+  const symMap = await readSymbolIndexMap(grp);
+  const tickerByIndex = await readTickerByIndex(grp);
+  if (!symMap?.size || !tickerByIndex?.length) return { teo: teoStr, rows: [] };
+  const nSymbol = symMap.size;
+
+  const rowsByVar = await Promise.all(
+    RESIDUAL_SIGNAL_VARS.map((v) => readFloatRowAtTeo(grp, v, teoIdx, nSymbol)),
+  );
+
+  const rows: ResidualSignalSnapshotRow[] = [];
+  for (let i = 0; i < nSymbol; i++) {
+    const z = rowsByVar[0]?.[i] ?? null;
+    // Skip symbols with no signal at this teo (inactive / insufficient history).
+    if (z == null) continue;
+    const ticker = tickerByIndex[i];
+    if (!ticker) continue;
+    rows.push({
+      ticker,
+      residual_z_5d: z,
+      signal_strength: rowsByVar[1]?.[i] ?? null,
+      decile_rank: rowsByVar[2]?.[i] ?? null,
+      industry_percentile: rowsByVar[3]?.[i] ?? null,
+      residual_autocorr_5d: rowsByVar[4]?.[i] ?? null,
+      l3_subsector_er: rowsByVar[5]?.[i] ?? null,
+      signal_quality_quintile: rowsByVar[6]?.[i] ?? null,
+    });
+  }
+
+  return { teo: teoStr, rows };
 }

--- a/lib/risk/residual-signal-service.ts
+++ b/lib/risk/residual-signal-service.ts
@@ -1,0 +1,158 @@
+/**
+ * Residual mean-reversion signal service (Phase D).
+ *
+ * Thin shaping layer over the zarr-reader. The signal is the L3 orthogonal
+ * residual's 5-day mean-reversion factor — see
+ * BWMACRO/research/phase_b_minimum_experiment_results.md.
+ *
+ * Product framing: a combo-input factor building block for multi-signal alpha
+ * stacks, NOT a standalone tradeable strategy. Every response carries an
+ * explicit gross-Sharpe + capacity disclosure. No buy/sell surface, no
+ * tradeable-alpha figure.
+ */
+
+import {
+  readResidualSignalSeries,
+  readResidualSignalLatest,
+  type ResidualSignalPoint,
+  type ResidualSignalSnapshotRow,
+} from "@/lib/dal/zarr-reader";
+
+/**
+ * Honest capacity disclosure attached to every residual-signal response.
+ * Phase B: gross Sharpe ~0.79 (decile L-S, H=5d) rising to ~1.28 in the
+ * top subsector-ER quintile; net of Kissell-Glantz market impact, standalone
+ * deployment caps near ~$1M book. Designed to be combined with other signals.
+ */
+export const RESIDUAL_SIGNAL_CAPACITY_NOTE =
+  "Informational factor for multi-signal alpha stacks; not investment advice. " +
+  "Gross Sharpe ~0.79 (decile long-short, 5-day horizon), ~1.28 within the " +
+  "high-subsector-ER quintile (signal_quality_quintile = 5). Net of " +
+  "market-impact costs, standalone deployment caps near ~$1M book size — " +
+  "intended as a combo input, not a standalone strategy.";
+
+export const RESIDUAL_SIGNAL_METHODOLOGY_LINK =
+  "https://riskmodels.app/docs/methodology#residual-mean-reversion-signal";
+
+export interface ResidualSignalReading {
+  residual_z_5d: number | null;
+  signal_strength: number | null;
+  decile_rank: number | null;
+  industry_percentile: number | null;
+  residual_autocorr_5d: number | null;
+  l3_subsector_er: number | null;
+  signal_quality_quintile: number | null;
+}
+
+export interface ResidualSignalTickerResult {
+  ticker: string;
+  as_of_date: string;
+  signal: ResidualSignalReading;
+  history: ResidualSignalPoint[];
+  capacity_note: string;
+  methodology_link: string;
+}
+
+export interface ResidualSignalUniverseResult {
+  as_of_date: string;
+  count: number;
+  total: number;
+  rows: ResidualSignalSnapshotRow[];
+  capacity_note: string;
+}
+
+export interface ResidualSignalDecileResult {
+  as_of_date: string;
+  decile: number;
+  count: number;
+  rows: ResidualSignalSnapshotRow[];
+  capacity_note: string;
+}
+
+function isoDaysAgo(days: number): string {
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() - days);
+  return d.toISOString().slice(0, 10);
+}
+
+/**
+ * Per-ticker snapshot + history. `days` is a calendar-day lookback for the
+ * history window (default 90). Returns null if the ticker isn't in the
+ * universe or the store is unavailable.
+ */
+export async function getResidualSignalForTicker(
+  ticker: string,
+  days = 90,
+): Promise<ResidualSignalTickerResult | null> {
+  const startDate = isoDaysAgo(days);
+  const series = await readResidualSignalSeries(ticker, startDate);
+  if (!series || series.points.length === 0) return null;
+
+  const latest = series.points[series.points.length - 1]!;
+  return {
+    ticker: series.ticker,
+    as_of_date: latest.date,
+    signal: {
+      residual_z_5d: latest.residual_z_5d,
+      signal_strength: latest.signal_strength,
+      decile_rank: latest.decile_rank,
+      industry_percentile: latest.industry_percentile,
+      residual_autocorr_5d: latest.residual_autocorr_5d,
+      l3_subsector_er: latest.l3_subsector_er,
+      signal_quality_quintile: latest.signal_quality_quintile,
+    },
+    history: series.points,
+    capacity_note: RESIDUAL_SIGNAL_CAPACITY_NOTE,
+    methodology_link: RESIDUAL_SIGNAL_METHODOLOGY_LINK,
+  };
+}
+
+/**
+ * Full active-universe cross-section at the latest teo, sorted by
+ * residual_z_5d ascending (most "oversold" first), paginated.
+ */
+export async function getResidualSignalLatest(
+  opts: { limit?: number; offset?: number } = {},
+): Promise<ResidualSignalUniverseResult | null> {
+  const snap = await readResidualSignalLatest();
+  if (!snap.teo) return null;
+
+  const sorted = [...snap.rows].sort(
+    (a, b) => (a.residual_z_5d ?? 0) - (b.residual_z_5d ?? 0),
+  );
+  const limit = Math.min(2000, Math.max(1, Math.floor(opts.limit ?? 500)));
+  const offset = Math.max(0, Math.floor(opts.offset ?? 0));
+  const page = sorted.slice(offset, offset + limit);
+
+  return {
+    as_of_date: snap.teo,
+    count: page.length,
+    total: sorted.length,
+    rows: page,
+    capacity_note: RESIDUAL_SIGNAL_CAPACITY_NOTE,
+  };
+}
+
+/**
+ * Current members of decile `n` (1 = most negative z / most oversold,
+ * 10 = most positive z / most overbought), sorted by residual_z_5d.
+ */
+export async function getResidualSignalDecile(
+  n: number,
+): Promise<ResidualSignalDecileResult | null> {
+  const snap = await readResidualSignalLatest();
+  if (!snap.teo) return null;
+
+  const decile = Math.min(10, Math.max(1, Math.floor(n)));
+  const rows = snap.rows
+    .filter((r) => r.decile_rank != null && Math.round(r.decile_rank) === decile)
+    .sort((a, b) => (a.residual_z_5d ?? 0) - (b.residual_z_5d ?? 0));
+
+  return {
+    as_of_date: snap.teo,
+    decile,
+    count: rows.length,
+    rows,
+    capacity_note: RESIDUAL_SIGNAL_CAPACITY_NOTE,
+  };
+}

--- a/lib/zarr-config.ts
+++ b/lib/zarr-config.ts
@@ -53,6 +53,17 @@ export function zarrRankingsBasename(factorSetId = getZarrFactorSetId()): string
 }
 
 /**
+ * Residual mean-reversion signal store (Phase D). Per-(teo, symbol) factor
+ * served at /api/residual-signal: residual_z_5d, signal_strength, decile_rank,
+ * industry_percentile, residual_autocorr_5d, l3_subsector_er,
+ * signal_quality_quintile. Carries a `ticker` string coord for in-zarr
+ * ticker resolution (no Supabase round-trip needed).
+ */
+export function zarrResidualSignalBasename(factorSetId = getZarrFactorSetId()): string {
+  return `ds_erm3_residual_signal_${factorSetId}.zarr`;
+}
+
+/**
  * ETF-to-ETF link betas (sector→market, subsector→market, subsector→sector).
  * Indexed (teo, symbol) over ~51 ETFs. The cascade hedge basket reads three
  * cells per ticker (sector ETF + subsector ETF at the latest teo).


### PR DESCRIPTION
## Summary
- Three GET routes serving the Phase D residual mean-reversion factor:
  - `/api/residual-signal/{ticker}` — latest snapshot + calendar-day history
  - `/api/residual-signal/latest` — paginated active-universe cross-section
  - `/api/residual-signal/decile/{n}` — current members of decile n
- `lib/dal/zarr-reader.ts`: `readResidualSignalSeries` + `readResidualSignalLatest` — tickers resolve in-zarr via the `ticker` coord (no Supabase round-trip).
- `lib/risk/residual-signal-service.ts`: shaping layer; every response carries an explicit gross-Sharpe + Kissell-Glantz capacity disclosure (`capacity_note`).
- `lib/zarr-config.ts`, `lib/api/schemas.ts`, `lib/agent/capabilities.ts`: basename, request schemas, billing capability ($0.02, premium).

Combo-input factor building block, not a standalone strategy. Reads `ds_erm3_residual_signal_*.zarr` (ERM3 PR #36). Endpoint returns a graceful 404 until that zarr is on GCS.

## Test plan
- [x] `tsc --noEmit` clean on all new/edited files
- [ ] Integration test against the live zarr once it's on GCS
- [ ] D4 follow-up: SDK methods, methodology doc, chat tool, OpenAPI spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)