### PR TITLE
feat(residual-signal): SDK + docs + chat tool + OpenAPI (Phase D, D4)

### DIFF
--- a/OPENAPI_SPEC.yaml
+++ b/OPENAPI_SPEC.yaml
@@ -1263,6 +1263,55 @@ components:
           type: string
           example: security_history
 
+    ResidualSignalReading:
+      type: object
+      description: >
+        One residual mean-reversion reading. In /residual-signal/{ticker} this
+        is both the latest `signal` object and each `history` item; history
+        items additionally carry `date`.
+      properties:
+        date:
+          type: string
+          format: date
+          description: Trading day (present on history items; omitted on the latest `signal`).
+        residual_z_5d:
+          type: number
+          nullable: true
+          description: 5-day cumulative L3 residual return, z-scored by 60-day residual vol. Negative = oversold.
+        signal_strength:
+          type: number
+          nullable: true
+          description: Absolute value of residual_z_5d.
+        decile_rank:
+          type: integer
+          nullable: true
+          description: 1-10 cross-sectional decile of residual_z_5d (1 = most oversold).
+        industry_percentile:
+          type: number
+          nullable: true
+          description: 0-1 percentile of residual_z_5d within the stock's EODHD industry cohort.
+        residual_autocorr_5d:
+          type: number
+          nullable: true
+          description: Trailing-252d lag-5 autocorrelation of the 5-day cumulative residual. Negative = mean-reverting.
+        l3_subsector_er:
+          type: number
+          nullable: true
+          description: Subsector variance-explained fraction — the signal-quality conditioning variable.
+        signal_quality_quintile:
+          type: integer
+          nullable: true
+          description: 1-5 quintile of l3_subsector_er (5 = tight subsector tracker = cleanest reversion regime).
+    ResidualSignalRow:
+      description: A universe cross-section row — a ResidualSignalReading keyed by ticker.
+      allOf:
+        - $ref: "#/components/schemas/ResidualSignalReading"
+        - type: object
+          required: [ticker]
+          properties:
+            ticker:
+              type: string
+              description: Stock ticker.
     LstarResponse:
       type: object
       description: >
@@ -3744,6 +3793,217 @@ paths:
               schema:
                 $ref: "#/components/schemas/RateLimitExceeded"
 
+  /residual-signal/{ticker}:
+    get:
+      summary: Residual mean-reversion factor — snapshot + history for one ticker
+      description: >
+        Phase D residual mean-reversion factor. `residual_z_5d` is the trailing
+        5-day cumulative L3 orthogonal residual return, z-scored by the stock's
+        own 60-day residual volatility (negative = oversold, positive =
+        overbought).
+
+
+        A combo-input factor building block for multi-signal alpha stacks — NOT
+        a standalone strategy. Gross Sharpe ~0.79 (decile long-short, 5-day
+        horizon), ~1.28 within the high-subsector-ER quintile; net of
+        market-impact costs, standalone capacity caps near ~$1M book. Every
+        response carries `capacity_note` with this disclosure.
+
+
+        **Billing:** $0.02 per request.
+      operationId: getResidualSignal
+      tags: [Risk Metrics]
+      x-pricing:
+        capability_id: residual-signal
+        tier: premium
+        model: per_request
+        cost_usd: 0.02
+        currency: USD
+        billing_code: residual_signal_v1
+      parameters:
+        - name: ticker
+          in: path
+          required: true
+          schema: { type: string }
+          example: AAPL
+        - name: days
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 730
+            default: 90
+          description: Calendar-day lookback for the returned history window.
+      responses:
+        "200":
+          description: Latest signal reading + history window.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ticker: { type: string }
+                  as_of_date: { type: string, format: date }
+                  signal: { $ref: "#/components/schemas/ResidualSignalReading" }
+                  history:
+                    type: array
+                    items: { $ref: "#/components/schemas/ResidualSignalReading" }
+                  capacity_note: { type: string }
+                  methodology_link: { type: string }
+        "400":
+          description: Invalid request.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/ErrorResponse" }
+        "401":
+          description: Missing or invalid Bearer token.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/ErrorResponse" }
+        "402":
+          description: Insufficient balance.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/InsufficientBalance" }
+        "404":
+          description: Ticker not in the active universe.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/ErrorResponse" }
+        "429":
+          description: Rate limit exceeded.
+          headers:
+            Retry-After:
+              schema: { type: integer }
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/RateLimitExceeded" }
+  /residual-signal/latest:
+    get:
+      summary: Residual mean-reversion factor — active-universe cross-section
+      description: >
+        Full active-universe residual mean-reversion cross-section at the latest
+        trading day, sorted by `residual_z_5d` ascending (most oversold first),
+        paginated. Combo-input factor — see `/residual-signal/{ticker}` for the
+        framing and capacity disclosure.
+
+
+        **Billing:** $0.02 per request.
+      operationId: getResidualSignalLatest
+      tags: [Risk Metrics]
+      x-pricing:
+        capability_id: residual-signal
+        tier: premium
+        model: per_request
+        cost_usd: 0.02
+        currency: USD
+        billing_code: residual_signal_v1
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          schema: { type: integer, minimum: 1, maximum: 2000, default: 500 }
+        - name: offset
+          in: query
+          required: false
+          schema: { type: integer, minimum: 0, default: 0 }
+      responses:
+        "200":
+          description: Paginated universe cross-section.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  as_of_date: { type: string, format: date }
+                  count: { type: integer }
+                  total: { type: integer }
+                  rows:
+                    type: array
+                    items: { $ref: "#/components/schemas/ResidualSignalRow" }
+                  capacity_note: { type: string }
+        "401":
+          description: Missing or invalid Bearer token.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/ErrorResponse" }
+        "402":
+          description: Insufficient balance.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/InsufficientBalance" }
+        "429":
+          description: Rate limit exceeded.
+          headers:
+            Retry-After:
+              schema: { type: integer }
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/RateLimitExceeded" }
+  /residual-signal/decile/{n}:
+    get:
+      summary: Residual mean-reversion factor — members of decile n
+      description: >
+        Current members of residual-signal decile `n` (1 = most oversold,
+        10 = most overbought), sorted by `residual_z_5d`. Combo-input factor —
+        see `/residual-signal/{ticker}` for the framing and capacity disclosure.
+
+
+        **Billing:** $0.02 per request.
+      operationId: getResidualSignalDecile
+      tags: [Risk Metrics]
+      x-pricing:
+        capability_id: residual-signal
+        tier: premium
+        model: per_request
+        cost_usd: 0.02
+        currency: USD
+        billing_code: residual_signal_v1
+      parameters:
+        - name: n
+          in: path
+          required: true
+          schema: { type: integer, minimum: 1, maximum: 10 }
+          example: 1
+      responses:
+        "200":
+          description: Decile members.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  as_of_date: { type: string, format: date }
+                  decile: { type: integer }
+                  count: { type: integer }
+                  rows:
+                    type: array
+                    items: { $ref: "#/components/schemas/ResidualSignalRow" }
+                  capacity_note: { type: string }
+        "400":
+          description: Invalid decile (must be 1-10).
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/ErrorResponse" }
+        "401":
+          description: Missing or invalid Bearer token.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/ErrorResponse" }
+        "402":
+          description: Insufficient balance.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/InsufficientBalance" }
+        "429":
+          description: Rate limit exceeded.
+          headers:
+            Retry-After:
+              schema: { type: integer }
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/RateLimitExceeded" }
   /correlation:
     post:
       summary: Correlation vs macro factor returns

--- a/content/docs/methodology.mdx
+++ b/content/docs/methodology.mdx
@@ -457,6 +457,29 @@ The residual $\varepsilon$ at L3 is your true idiosyncratic return. Positive res
 
 ---
 
+## Residual Mean-Reversion Signal
+
+The L3 residual — the part of a stock's return left after market, sector, and subsector exposures are hedged out — is, by construction, the genuinely idiosyncratic component. The **residual mean-reversion signal** measures how stretched that residual is right now and surfaces it as a factor.
+
+**The signal.** For each stock, `residual_z_5d` is the trailing 5-day cumulative L3 residual return, z-scored by the stock's own 60-day residual volatility. A large negative value means the stock has under-performed its cascade-implied path over the past week ("oversold"); a large positive value means it has over-performed ("overbought").
+
+**What it is — and what it isn't.** This is a **combo-input factor** — a building block for multi-signal alpha stacks, not a standalone trading strategy. In a 5-year backtest the cross-sectional decile long-short carries a gross Sharpe of ~0.79 (rising to ~1.28 within the high-subsector-ER quintile). But under realistic market-impact costs (Kissell-Glantz square-root model) the net-of-cost capacity caps below ~$1M of book size:
+
+| Book size | Net Sharpe (decile L-S) |
+| --- | --- |
+| $0.5M | ~0.0 |
+| $1M | ~−0.2 |
+| $5M | ~−1.0 |
+| $25M | ~−2.8 |
+
+The signal is informative *pre-cost*; it earns its place inside a diversified signal portfolio where many uncorrelated factors combine, not as a strategy traded on its own. Every API response carries a `capacity_note` stating this.
+
+**Signal-quality conditioning.** The reversion is materially cleaner for stocks that track their subsector tightly. `signal_quality_quintile` (1–5, derived from `L3_subsector_ER`) flags this: quintile 5 — the tightest subsector trackers — show gross Sharpe ~1.28 vs ~0.20 in the middle quintiles. A residual deviation only means "temporary dislocation" when the stock normally tracks its cohort; for loose trackers the residual is idiosyncratic drift that does not revert.
+
+**Access.** `GET /api/residual-signal/{ticker}` (snapshot + history), `/api/residual-signal/latest` (universe cross-section), `/api/residual-signal/decile/{n}` (decile members). SDK: `client.residual_signal()`, `client.residual_signal_latest()`. This is informational analytics, not investment advice.
+
+---
+
 ## How We Compare to Traditional Risk Models
 
 | Feature | RiskModels | Barra / Axioma |

--- a/lib/chat/tools.ts
+++ b/lib/chat/tools.ts
@@ -30,6 +30,7 @@ import {
 } from "@/lib/risk/hedge-recommendation-service";
 import { DEFAULT_USER_SEGMENT } from "@/lib/dal/hedge-recommendation";
 import { getL3DecompositionService } from "@/lib/risk/l3-decomposition-service";
+import { getResidualSignalForTicker } from "@/lib/risk/residual-signal-service";
 import {
   computeFactorCorrelation,
   DEFAULT_MACRO_FACTORS,
@@ -66,6 +67,10 @@ function fnTool(
 }
 
 const getRiskMetricsArgs = z.object({
+  ticker: TickerSchema,
+});
+
+const getResidualSignalArgs = z.object({
   ticker: TickerSchema,
 });
 
@@ -586,6 +591,26 @@ async function execPortfolioRisk(args: z.infer<typeof portfolioRiskArgs>) {
   return body;
 }
 
+/**
+ * Phase D residual mean-reversion factor for one ticker. Returns the latest
+ * reading only — the 63-point history is dropped (chat narrates the current
+ * state; SDK/API callers get the full series). Always surfaces `capacity_note`
+ * so the agent frames this as a combo-input factor, not a trade idea.
+ */
+async function execGetResidualSignal(
+  args: z.infer<typeof getResidualSignalArgs>,
+) {
+  const { ticker } = args;
+  const result = await getResidualSignalForTicker(ticker, 90);
+  if (!result) {
+    throw new Error(
+      `No residual signal for ticker ${ticker} (not in the active universe, or insufficient history).`,
+    );
+  }
+  const { history, ...snapshot } = result;
+  return { ...snapshot, history_points: history.length };
+}
+
 export interface ChatToolDef {
   /** Stable tool name (OpenAI function name) */
   name: string;
@@ -636,6 +661,23 @@ export const CHAT_TOOLS_REGISTRY: ChatToolDef[] = [
     capabilityId: "hedge-basket",
     argSchema: getHedgeBasketArgs,
     executor: async (a) => execGetHedgeBasket(getHedgeBasketArgs.parse(a)),
+  },
+  {
+    name: "get_residual_signal",
+    openaiTool: fnTool(
+      "get_residual_signal",
+      "Residual mean-reversion factor for a ticker: `residual_z_5d` (5-day cumulative L3 orthogonal residual, z-scored — negative = oversold, positive = overbought), `decile_rank` (1-10 cross-sectional), `signal_quality_quintile` (1-5 by subsector-tracking quality; 5 = cleanest reversion regime), `industry_percentile`, and `residual_autocorr_5d` (negative = mean-reverting). This is a COMBO-INPUT FACTOR for multi-signal alpha stacks — NOT a standalone strategy and NOT a trade recommendation. Always quote the `capacity_note` verbatim: the signal is informative pre-cost (gross Sharpe ~0.79) but net-of-impact capacity caps near ~$1M book. Never tell the user to buy or sell based on it; describe the reading and its conditioning only.",
+      {
+        ticker: {
+          type: "string",
+          description: "US stock ticker symbol, e.g. AAPL, NVDA, MSFT",
+        },
+      },
+      ["ticker"],
+    ),
+    capabilityId: "residual-signal",
+    argSchema: getResidualSignalArgs,
+    executor: async (a) => execGetResidualSignal(getResidualSignalArgs.parse(a)),
   },
   {
     name: "get_l3_decomposition",

--- a/mcp/data/openapi.json
+++ b/mcp/data/openapi.json
@@ -1368,6 +1368,72 @@
           }
         }
       },
+      "ResidualSignalReading": {
+        "type": "object",
+        "description": "One residual mean-reversion reading. In /residual-signal/{ticker} this is both the latest `signal` object and each `history` item; history items additionally carry `date`.\n",
+        "properties": {
+          "date": {
+            "type": "string",
+            "format": "date",
+            "description": "Trading day (present on history items; omitted on the latest `signal`)."
+          },
+          "residual_z_5d": {
+            "type": "number",
+            "nullable": true,
+            "description": "5-day cumulative L3 residual return, z-scored by 60-day residual vol. Negative = oversold."
+          },
+          "signal_strength": {
+            "type": "number",
+            "nullable": true,
+            "description": "Absolute value of residual_z_5d."
+          },
+          "decile_rank": {
+            "type": "integer",
+            "nullable": true,
+            "description": "1-10 cross-sectional decile of residual_z_5d (1 = most oversold)."
+          },
+          "industry_percentile": {
+            "type": "number",
+            "nullable": true,
+            "description": "0-1 percentile of residual_z_5d within the stock's EODHD industry cohort."
+          },
+          "residual_autocorr_5d": {
+            "type": "number",
+            "nullable": true,
+            "description": "Trailing-252d lag-5 autocorrelation of the 5-day cumulative residual. Negative = mean-reverting."
+          },
+          "l3_subsector_er": {
+            "type": "number",
+            "nullable": true,
+            "description": "Subsector variance-explained fraction — the signal-quality conditioning variable."
+          },
+          "signal_quality_quintile": {
+            "type": "integer",
+            "nullable": true,
+            "description": "1-5 quintile of l3_subsector_er (5 = tight subsector tracker = cleanest reversion regime)."
+          }
+        }
+      },
+      "ResidualSignalRow": {
+        "description": "A universe cross-section row — a ResidualSignalReading keyed by ticker.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ResidualSignalReading"
+          },
+          {
+            "type": "object",
+            "required": [
+              "ticker"
+            ],
+            "properties": {
+              "ticker": {
+                "type": "string",
+                "description": "Stock ticker."
+              }
+            }
+          }
+        ]
+      },
       "LstarResponse": {
         "type": "object",
         "description": "Per-(ticker, date) recommended hedge level (L1/L2/L3) with the chosen level's dispatched hedge ratios and total explained-return. Arrays are parallel by date index. Each L\\* is a standalone hedge solution (not stacked layers) — `market_hr`/`sector_hr`/`subsector_hr` come from the chosen level's solver and are `null` where the chosen level doesn't use that ETF (sector_hr is null when L\\*=L1; subsector_hr is null when L\\*∈{L1,L2}).\n",
@@ -5330,6 +5396,362 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded.",
+            "headers": {
+              "Retry-After": {
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RateLimitExceeded"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/residual-signal/{ticker}": {
+      "get": {
+        "summary": "Residual mean-reversion factor — snapshot + history for one ticker",
+        "description": "Phase D residual mean-reversion factor. `residual_z_5d` is the trailing 5-day cumulative L3 orthogonal residual return, z-scored by the stock's own 60-day residual volatility (negative = oversold, positive = overbought).\n\nA combo-input factor building block for multi-signal alpha stacks — NOT a standalone strategy. Gross Sharpe ~0.79 (decile long-short, 5-day horizon), ~1.28 within the high-subsector-ER quintile; net of market-impact costs, standalone capacity caps near ~$1M book. Every response carries `capacity_note` with this disclosure.\n\n**Billing:** $0.02 per request.\n",
+        "operationId": "getResidualSignal",
+        "tags": [
+          "Risk Metrics"
+        ],
+        "x-pricing": {
+          "capability_id": "residual-signal",
+          "tier": "premium",
+          "model": "per_request",
+          "cost_usd": 0.02,
+          "currency": "USD",
+          "billing_code": "residual_signal_v1"
+        },
+        "parameters": [
+          {
+            "name": "ticker",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "AAPL"
+          },
+          {
+            "name": "days",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 730,
+              "default": 90
+            },
+            "description": "Calendar-day lookback for the returned history window."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Latest signal reading + history window.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ticker": {
+                      "type": "string"
+                    },
+                    "as_of_date": {
+                      "type": "string",
+                      "format": "date"
+                    },
+                    "signal": {
+                      "$ref": "#/components/schemas/ResidualSignalReading"
+                    },
+                    "history": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/ResidualSignalReading"
+                      }
+                    },
+                    "capacity_note": {
+                      "type": "string"
+                    },
+                    "methodology_link": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid Bearer token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Insufficient balance.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InsufficientBalance"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Ticker not in the active universe.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded.",
+            "headers": {
+              "Retry-After": {
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RateLimitExceeded"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/residual-signal/latest": {
+      "get": {
+        "summary": "Residual mean-reversion factor — active-universe cross-section",
+        "description": "Full active-universe residual mean-reversion cross-section at the latest trading day, sorted by `residual_z_5d` ascending (most oversold first), paginated. Combo-input factor — see `/residual-signal/{ticker}` for the framing and capacity disclosure.\n\n**Billing:** $0.02 per request.\n",
+        "operationId": "getResidualSignalLatest",
+        "tags": [
+          "Risk Metrics"
+        ],
+        "x-pricing": {
+          "capability_id": "residual-signal",
+          "tier": "premium",
+          "model": "per_request",
+          "cost_usd": 0.02,
+          "currency": "USD",
+          "billing_code": "residual_signal_v1"
+        },
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2000,
+              "default": 500
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated universe cross-section.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "as_of_date": {
+                      "type": "string",
+                      "format": "date"
+                    },
+                    "count": {
+                      "type": "integer"
+                    },
+                    "total": {
+                      "type": "integer"
+                    },
+                    "rows": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/ResidualSignalRow"
+                      }
+                    },
+                    "capacity_note": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid Bearer token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Insufficient balance.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InsufficientBalance"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded.",
+            "headers": {
+              "Retry-After": {
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RateLimitExceeded"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/residual-signal/decile/{n}": {
+      "get": {
+        "summary": "Residual mean-reversion factor — members of decile n",
+        "description": "Current members of residual-signal decile `n` (1 = most oversold, 10 = most overbought), sorted by `residual_z_5d`. Combo-input factor — see `/residual-signal/{ticker}` for the framing and capacity disclosure.\n\n**Billing:** $0.02 per request.\n",
+        "operationId": "getResidualSignalDecile",
+        "tags": [
+          "Risk Metrics"
+        ],
+        "x-pricing": {
+          "capability_id": "residual-signal",
+          "tier": "premium",
+          "model": "per_request",
+          "cost_usd": 0.02,
+          "currency": "USD",
+          "billing_code": "residual_signal_v1"
+        },
+        "parameters": [
+          {
+            "name": "n",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 10
+            },
+            "example": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Decile members.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "as_of_date": {
+                      "type": "string",
+                      "format": "date"
+                    },
+                    "decile": {
+                      "type": "integer"
+                    },
+                    "count": {
+                      "type": "integer"
+                    },
+                    "rows": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/ResidualSignalRow"
+                      }
+                    },
+                    "capacity_note": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid decile (must be 1-10).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid Bearer token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Insufficient balance.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InsufficientBalance"
                 }
               }
             }

--- a/sdk/riskmodels/client.py
+++ b/sdk/riskmodels/client.py
@@ -930,6 +930,90 @@ class RiskModelsClient:
         attach_sdk_metadata(df, lineage, kind="l3_decomposition")
         return df
 
+    def residual_signal(
+        self,
+        ticker: str,
+        *,
+        days: int = 90,
+        as_dataframe: bool = False,
+    ) -> dict[str, Any] | pd.DataFrame:
+        """Fetch the residual mean-reversion factor for a single ticker.
+
+        The signal is the L3 orthogonal residual's 5-day mean-reversion factor
+        (Phase D). It is a **combo-input building block** for multi-signal
+        alpha stacks — informative pre-cost (gross Sharpe ~0.79) but not a
+        standalone strategy; net-of-impact capacity caps near ~$1M book. Every
+        response carries ``capacity_note`` with the full disclosure.
+
+        Args:
+            ticker: Stock ticker symbol (e.g. ``"AAPL"``).
+            days: Calendar-day lookback for the returned history window
+                (default 90).
+            as_dataframe: If True, return the history as a DataFrame (one row
+                per trading day) with the latest snapshot + capacity_note in
+                ``df.attrs``. If False (default), return the full dict.
+
+        Returns:
+            Dict with ``ticker``, ``as_of_date``, ``signal`` (residual_z_5d,
+            signal_strength, decile_rank, industry_percentile,
+            residual_autocorr_5d, l3_subsector_er, signal_quality_quintile),
+            ``history``, ``capacity_note``, ``methodology_link``. With
+            ``as_dataframe=True``, the history DataFrame.
+
+        Example:
+            >>> client = RiskModelsClient.from_env()
+            >>> sig = client.residual_signal("AAPL")
+            >>> print(sig["signal"]["residual_z_5d"], sig["signal"]["decile_rank"])
+        """
+        t, _ = resolve_ticker(ticker, self)
+        body, lineage, _r = self._transport.request(
+            "GET", f"/residual-signal/{t}", params={"days": days}
+        )
+        if not as_dataframe:
+            return body
+        df = pd.DataFrame(body.get("history", []))
+        attach_sdk_metadata(df, lineage, kind="residual_signal")
+        df.attrs["residual_signal_snapshot"] = body.get("signal")
+        df.attrs["capacity_note"] = body.get("capacity_note")
+        return df
+
+    def residual_signal_latest(
+        self,
+        *,
+        limit: int = 500,
+        offset: int = 0,
+        as_dataframe: bool = False,
+    ) -> dict[str, Any] | pd.DataFrame:
+        """Fetch the residual mean-reversion factor across the active universe.
+
+        Returns the latest-teo cross-section, sorted by ``residual_z_5d``
+        ascending (most "oversold" first), paginated. See :meth:`residual_signal`
+        for the combo-input framing and capacity disclosure.
+
+        Args:
+            limit: Page size (default 500, max 2000).
+            offset: Pagination offset (default 0).
+            as_dataframe: If True, return the rows as a DataFrame.
+
+        Returns:
+            Dict with ``as_of_date``, ``count``, ``total``, ``rows``,
+            ``capacity_note``. With ``as_dataframe=True``, the rows DataFrame.
+
+        Example:
+            >>> client = RiskModelsClient.from_env()
+            >>> df = client.residual_signal_latest(limit=10, as_dataframe=True)
+            >>> print(df[["ticker", "residual_z_5d", "decile_rank"]])
+        """
+        body, lineage, _r = self._transport.request(
+            "GET", "/residual-signal/latest", params={"limit": limit, "offset": offset}
+        )
+        if not as_dataframe:
+            return body
+        df = pd.DataFrame(body.get("rows", []))
+        attach_sdk_metadata(df, lineage, kind="residual_signal_latest")
+        df.attrs["capacity_note"] = body.get("capacity_note")
+        return df
+
     def get_factor_correlation(
         self,
         ticker: str | list[str],


### PR DESCRIPTION
## Summary
Discovery + convenience layer for the `/api/residual-signal` endpoints (PR #97).

- **SDK**: `client.residual_signal()` + `client.residual_signal_latest()`
- **Chat tool**: `get_residual_signal` — returns the latest reading (history dropped for chat context); doctrine frames it as a combo-input factor, never a buy/sell call, and quotes `capacity_note`
- **Methodology doc**: "Residual Mean-Reversion Signal" section — gross-Sharpe + Kissell-Glantz capacity table + the signal-quality (subsector-ER) conditioning result
- **OpenAPI**: three `/residual-signal` paths + `ResidualSignalReading`/`ResidualSignalRow` schemas; `mcp/data/openapi.json` regenerated

## Test plan
- [x] `tsc --noEmit` clean on `lib/chat/tools.ts`
- [x] `OPENAPI_SPEC.yaml` → JSON build succeeds; residual-signal paths present
- [x] `client.py` compiles
- [ ] Exercise `client.residual_signal("AAPL")` against the live endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)