### PR TITLE
feat(agent): P0 artifact render tools for chat and MCP

### DIFF
--- a/content/docs/macro-factors.mdx
+++ b/content/docs/macro-factors.mdx
@@ -1,0 +1,144 @@
+---
+title: Factor correlation (macro + style)
+description: Stock correlations (gross and ERM3 residuals) against the macro and style factor sleeves stored in macro_factors, plus raw long-format series.
+---
+
+# Factor correlation (macro + style)
+
+RiskModels stores **daily factor total returns** in Supabase **`macro_factors`**: one row per **`factor_key`** and trading date (**`teo`**), with **`return_gross`** and optional **`metadata`**. Two sleeves share the table and the correlation endpoints:
+
+- **Macro sleeve (10 keys)** — rates, credit, commodities, FX, volatility, crypto. Backed by **`ds_macro_factor.zarr`**.
+- **Style sleeve (8 keys)** — momentum, quality, low vol, value, growth, size, dividend, moat. Mirrored from **`ds_etf.zarr`** into the same table, with **`metadata.category = "style"`** so callers can distinguish the two.
+
+All 18 canonical keys are valid anywhere a **`factor_key`** is accepted.
+
+## Macro sleeve (10 keys)
+
+| Key | Underlying | Typical meaning |
+| --- | --- | --- |
+| `inflation` | TIP | US TIPS — inflation expectations proxy |
+| `term_spread` | VGIT | Intermediate Treasury — long-end / slope proxy (`ust10y2y` legacy alias) |
+| `short_rates` | BIL | 1–3mo Treasury bills — short-rate proxy |
+| `credit` | HYG | High-yield corporate — credit spread proxy |
+| `oil` | USO | WTI crude daily return |
+| `gold` | GLD | Gold daily return |
+| `usd` | UUP | US Dollar (DXY) daily return (`dxy` legacy alias) |
+| `volatility` | VXX | VIX short-term futures — captures roll cost |
+| `bitcoin` | BITO | Bitcoin futures ETF (`btc` alias) |
+| `vix_spot` | FRED VIXCLS | Pure spot VIX (`vix` legacy alias) |
+
+`volatility` and `vix_spot` are **different factors** — VXX captures futures roll dynamics and term structure; VIXCLS is the pure spot index. Keep both if you care about regime detection vs cost of carrying vol.
+
+## Style sleeve (8 keys)
+
+| Key | Underlying | History | Interpretation |
+| --- | --- | --- | --- |
+| `momentum` | MTUM | 2013-04– | MSCI USA Momentum |
+| `quality` | QUAL | 2013-07– | MSCI USA Quality |
+| `low_vol` | USMV | 2011-10– | MSCI USA Min Vol (`minvol` alias) |
+| `value` | VLUE | 2013-04– | MSCI USA Value |
+| `growth` | IWF | 2000-05– | Russell 1000 Growth |
+| `size` | IWM | 2000-05– | Russell 2000 small-cap (`small_cap` alias) |
+| `dividend` | SCHD | 2011-10– | Schwab US Dividend Equity (`div`, `yield` aliases) |
+| `moat` | MOAT | 2012-04– | VanEck Wide Moat |
+
+MSCI factor ETFs only go back to 2011–2013; pre-launch windows return `null` correlations. IWF/IWM extend to 2000-05 for deeper growth/size history.
+
+### Why style factors pair naturally with ERM3 residuals
+
+The ERM3 cascade (L1 market → L2 sector → L3 subsector) produces a **residual** that is **orthogonal by construction** to SPY, the sector ETF, and the subsector ETF. When you correlate that residual against a raw style ETF (MTUM, QUAL, …), the market and sector components embedded in the style ETF contribute **zero** to the correlation. What remains is the **pure-style tilt** sitting inside your idiosyncratic residual — the part of your "alpha" that actually comes from systematic style exposure you did not consciously size for.
+
+Use **`return_type=l3_residual`** with style factors to read this cleanly. `gross` works too but conflates market / sector / subsector exposure back in.
+
+Common names aliases are normalized server-side: `mtum` → `momentum`, `qual` → `quality`, `usmv` / `minvol` → `low_vol`, `vlue` → `value`, `iwf` → `growth`, `iwm` / `small_cap` → `size`, `schd` / `div` → `dividend`, `moat` → `moat`.
+
+## Correlation vs a stock (ERM3)
+
+Use these when you want **Pearson** or **Spearman** correlation between a **stock** return series and one or more factor series:
+
+- **`POST /api/correlation`** — single ticker or batch (array of tickers).
+- **`GET /api/metrics/{ticker}/correlation`** — same math; pass factor keys as a comma-separated **`factors`** (or **`factor`**) query parameter.
+
+**`return_type`** selects the **stock** return series (not the factor series):
+
+| Value | Meaning |
+| --- | --- |
+| `gross` | Stock gross daily return |
+| `l1` | Residual vs market only (uses L1 hedge ratio and SPY) |
+| `l2` | Residual vs market + sector ETFs |
+| `l3_residual` | Residual after L3 hedge replication (market + sector + subsector ETFs) — **recommended for style factors** |
+
+Correlations are **return correlations** in roughly **[-1, 1]** — they are **not** hedge notionals (**`l3_market_hr`**) or variance shares (**`l3_residual_er`**). See [SEMANTIC_ALIASES.md](https://github.com/Cerebellum-Archive/RiskModels_API/blob/main/SEMANTIC_ALIASES.md) for full semantics and JSON Schema links.
+
+The implementation requires **at least ~30** overlapping paired days per factor; otherwise that factor's entry is `null`. A `null` is not a sign error — it means insufficient overlap (including pre-launch windows for short-history MSCI style factors).
+
+### Example: style DNA of a residual
+
+```python
+from riskmodels import RiskModelsClient
+
+client = RiskModelsClient.from_env()
+
+style = client.get_factor_correlation_single(
+    "NVDA",
+    factors=["momentum", "quality", "low_vol", "value",
+             "growth", "size", "dividend", "moat"],
+    return_type="l3_residual",
+    window_days=504,       # ~2 years
+)
+print(style["correlations"])
+# e.g. {"momentum": 0.41, "quality": 0.10, "low_vol": -0.19, "value": -0.31,
+#       "growth": 0.28, "size": -0.06, "dividend": -0.12, "moat": 0.08}
+```
+
+A PM reads this as: "My NVDA residual — the part I thought was pure idiosyncratic alpha — is materially positive momentum and negative value. If I am value-styled, I am carrying anti-value exposure inside my residual that I did not consciously size."
+
+## Raw factor time series (no ticker)
+
+**`GET /api/macro-factors`** returns **long-format** rows: **`factor_key`**, **`teo`**, **`return_gross`** (and optional **`metadata`** when non-empty), for a date range you choose. No equity ticker is required. Both sleeves are returned when no filter is passed.
+
+Query parameters:
+
+- **`factors`** or **`factor`** — comma-separated keys (optional; default all **18** canonical keys).
+- **`start`**, **`end`** — inclusive **`YYYY-MM-DD`** (optional; defaults: **`end`** = today UTC, **`start`** = five calendar years before **`end`**). Maximum span: **20 years**.
+
+OAuth scope: **`macro-factor-series`**. Billing is per request (see OpenAPI / pricing).
+
+**Python SDK** (requires scope on your key):
+
+```python
+from riskmodels import RiskModelsClient
+
+client = RiskModelsClient.from_env()
+
+# Macro series only
+macro = client.get_macro_factor_series(
+    factors=["bitcoin", "vix_spot", "oil"],
+    start="2023-01-01",
+    end="2023-12-31",
+    as_dataframe=True,
+)
+
+# Style series only
+style = client.get_macro_factor_series(
+    factors=["momentum", "quality", "low_vol", "value"],
+    start="2023-01-01",
+    end="2023-12-31",
+    as_dataframe=True,
+)
+```
+
+**CLI:**
+
+```bash
+riskmodels macro-factors --factors momentum,quality,low_vol --start 2023-01-01 --end 2023-12-31
+```
+
+JSON Schema for the success body: **`/schemas/macro-factors-series-v1.json`** (also under **MCP** `schema-paths`).
+
+## Related
+
+- [API Documentation](/docs/api) — hub and live asset examples
+- [API Reference](/api-reference) — full OpenAPI
+- [ERM3 Engine](/docs/erm3-engine) — L1 → L3 cascade and residual construction
+- [Authentication](/docs/authentication) — OAuth scopes including **`macro-factor-series`**

--- a/content/docs/response-metadata.mdx
+++ b/content/docs/response-metadata.mdx
@@ -1,0 +1,53 @@
+---
+title: Response metadata and HTTP headers
+description: JSON _metadata lineage, optional history fields, billing headers, and how Parquet or CSV exports differ from JSON.
+---
+
+# Response metadata and HTTP headers
+
+Metered JSON responses combine **model lineage** (`_metadata`), optional **history provenance** (`data_source`, `range`), **billing telemetry** (`_agent` or mirrored HTTP headers), and **risk lineage** (`X-Risk-*` headers). This page is the portal summary; the full contract lives in [RESPONSE_METADATA.md](https://github.com/BlueWaterCorp/RiskModels_API/blob/main/RESPONSE_METADATA.md) on GitHub.
+
+## `_metadata` (JSON bodies)
+
+| Field | Meaning |
+| --- | --- |
+| `model_version` | ERM3 build label (for example `ERM3-L3-v30`). |
+| `data_as_of` | Latest trading date reflected in the snapshot or series. |
+| `factor_set_id` | Factor universe identifier. |
+| `universe_size` | Equity count in the tradable universe. |
+| `factors` | L3 factor ETF identifiers when present. |
+
+### History responses: `data_source` and `range`
+
+Some time-series JSON payloads extend `_metadata` with:
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `data_source` | string | Daily history is served from consolidated **Zarr** on GCS (see [API_HISTORY_SUPABASE_AND_ZARR.md](https://github.com/BlueWaterCorp/RiskModels_API/blob/main/docs/API_HISTORY_SUPABASE_AND_ZARR.md)). |
+| `range` | two ISO dates | Inclusive date bounds of the rows returned. |
+
+These fields are **omitted from Parquet and CSV** bodies — use the same **`X-Risk-Model-Version`**, **`X-Data-As-Of`**, **`X-Factor-Set-Id`**, and **`X-Universe-Size`** headers on the HTTP response for lineage when you export tabular formats.
+
+## HTTP headers you should log
+
+| Header | When to use it |
+| --- | --- |
+| `X-Risk-Model-Version`, `X-Data-As-Of`, `X-Factor-Set-Id`, `X-Universe-Size` | Reproducibility and support tickets alongside `_metadata`. |
+| `X-API-Cost-USD`, `X-API-Billing-Code`, `X-Cache-Status` | Cost attribution; cached responses bill **0** when documented. |
+| `X-Request-ID`, `X-Response-Latency-Ms` | Latency debugging and correlation with server logs. |
+| `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset` | Client-side throttling (see [Authentication](/docs/authentication)). |
+
+## JSON vs Parquet vs CSV
+
+- **JSON** (default): structured payload, `_metadata` in body where documented, `_agent` on metered routes.
+- **`?format=parquet`**, **`?format=csv`**, or **`Accept: application/vnd.apache.parquet`** / **`Accept: text/csv`**: single flat table; **no** `_metadata` object in the file — rely on **`X-Risk-*`** and cost headers on the response.
+
+Use Parquet for typed pipelines (pandas, Polars, Arrow); CSV for spreadsheets.
+
+## `GET /api/health` — coverage signal
+
+The health payload includes **`teo_coverage`** (names may evolve; see OpenAPI **`/health`** schema). Use **`latest_session_returns_pending`**: when **true**, gross returns coverage on the newest `teo` is sparse versus the stock universe (often intraday backfill). Pair with **`latest_teo_coverage_pct`** for how complete that session is.
+
+---
+
+**See also:** [Returns decomposition metrics](/docs/returns-decomposition-metrics) (distinct from ER and hedge ratios), [Authentication](/docs/authentication), [API Reference](/api-reference).

--- a/content/docs/returns-decomposition-metrics.mdx
+++ b/content/docs/returns-decomposition-metrics.mdx
@@ -1,0 +1,51 @@
+---
+title: Returns decomposition metrics (CFR / FR / RR)
+description: Daily simple return keys l*_cfr, l*_fr, and l*_rr from ds_erm3_returns — distinct from hedge ratios and explained risk (ER).
+---
+
+# Returns decomposition metrics (`l*_cfr` / `l*_fr` / `l*_rr`)
+
+ERM3 can sync **nine optional daily metrics** (`l1_cfr` … `l3_rr`, including incremental `l*_fr`) into the V3 pipeline: wide columns on **`security_history_latest`** when present, and **historical slices** served from consolidated **Zarr** via the public API (the legacy long-form `security_history` table is not used by this API). They describe **actual simple returns** from a returns-decomposition pipeline step, not hedge notionals and not variance fractions.
+
+## What the keys mean
+
+| Wire key | Meaning |
+| --- | --- |
+| `l1_cfr` | Combined factor return through **L1** (market) |
+| `l1_fr` | Incremental **L1** (market-only) factor return |
+| `l1_rr` | Residual return at **L1** |
+| `l2_cfr` | Combined factor return through **L2** (sector) |
+| `l2_fr` | Incremental **L2** (sector) factor return on top of L1 |
+| `l2_rr` | Residual return at **L2** |
+| `l3_cfr` | Combined factor return through **L3** (subsector) |
+| `l3_fr` | Incremental **L3** (subsector) factor return on top of L1+L2 |
+| `l3_rr` | Residual return at **L3** |
+
+**Units:** daily **simple** returns as **decimals** (same convention as `returns_gross`), e.g. `0.01` ≈ 1%.
+
+**Naming:** `*_cfr` = **c**ombined **f**actor **r**eturn; `*_rr` = **r**esidual **r**eturn at that level.
+
+## Not the same as ER or hedge ratios
+
+- **`l*_res_er`** (and other `*_er` fields) are **explained risk** — variance shares in [0, 1] from hedge-weight regressions.
+- **`l*_mkt_hr`**, **`l*_sec_hr`**, **`l*_sub_hr`** are **hedge ratios** (dollars of ETF per {'$'}1 of stock).
+- The **`l*_cfr` / `l*_rr`** series come from **`ds_erm3_returns_*`** (returns decomposition), not from `ds_erm3_hedge_weights`.
+
+Do not confuse **`l3_rr`** (residual **return** for one day) with informal “residual risk” language around **`l3_residual_er`** (idiosyncratic **variance** share). See [SEMANTIC_ALIASES.md](https://github.com/BlueWaterCorp/RiskModels_API/blob/main/SEMANTIC_ALIASES.md#returns-decomposition-l_cfr--l_rr) for the full wire ↔ SDK name table.
+
+## Where they appear in the API
+
+- **`GET /api/metrics/{ticker}`** — optional fields under `metrics` when populated on the latest row.
+- **Daily history** — `GET /api/ticker-returns` and data-plane history routes return Zarr-backed series; `_metadata.data_source` / `_metadata.range` describe provenance on JSON (see [Response metadata](/docs/response-metadata)).
+- **`security_history_latest`** — optional wide columns when the ERM3 sync has materialized them (`supabase/migrations/` in this repo).
+
+Sync progress uses **`erm3_sync_state_v3`** with **`table_name = security_history_returns_decomp`**.
+
+## Populating data (ERM3 sync)
+
+This repository does not ship the ERM3 sync CLI. In the **ERM3** repo, V3 sync supports the returns-decomposition dataset (often included in dataset set **`all`**) and a ticker filter:
+
+- CLI: **`--returns-decomp-tickers`** with values such as **`mag7`**, **`all`**, or a comma-separated ticker list.
+- Python: **`run_sync(..., returns_decomp_tickers="mag7" | "all" | "A,B,C")`**.
+
+See the propagation note [ERM3_V3_RETURNS_DECOMP_SUPABASE_PROPAGATION.md](https://github.com/BlueWaterCorp/RiskModels_API/blob/main/docs/planning/ERM3_V3_RETURNS_DECOMP_SUPABASE_PROPAGATION.md) for zarr variables, `metric_key` table, and checklist.

--- a/docs/ANTHROPIC_CLOUD_AGENTS.md
+++ b/docs/ANTHROPIC_CLOUD_AGENTS.md
@@ -1,0 +1,111 @@
+# Anthropic cloud agents + RiskModels API
+
+**Canonical strategy (cross-repo):** **Client Memory Layer (CML)** vs vendor **managed-runtime thread memory**, **`.net`** vs **`.app`** ownership, activation-first sequencing, and phased build live in the **BWMACRO** hub: `docs/architecture/intelligence_runtime/MANAGED_COGNITIVE_RUNTIME_STRATEGY.md` (sibling clone per `docs/SUBMODULES.md`). **This file** stays **implementation-only**: Anthropic SKUs, spike, billing hooks, compliance — not CML schema.
+
+**Status:** Engineering design — captures SKU decision, spike procedure, billing model for a future **Claude Managed Agents** integration, and compliance notes. Does not change runtime behavior of `POST /api/chat` (OpenAI) until Option A is explicitly scheduled.
+
+---
+
+## 1. SKU decision (Options A / B / C)
+
+| Option | Description | Decision |
+|--------|-------------|----------|
+| **A** | **Claude Messages API** — replace the OpenAI loop in `app/api/chat` with Anthropic `messages` + `tool_use` / `tool_result`; same stateless request shape. | **Primary near-term** when we invest in “Claude in `/api/chat`”: smallest billing surface, no Anthropic session-runtime meter. |
+| **B** | **Claude Managed Agents** — Anthropic-hosted sessions (SSE, persisted history, agent toolsets, optional MCP); see [Managed Agents overview](https://platform.claude.com/docs/en/managed-agents/overview). | **Phase 2 / gated**: run [`scripts/spike-claude-managed-agents.mjs`](../scripts/spike-claude-managed-agents.mjs), compare token + **active session time** + RiskModels MCP debits vs. product value. API is **beta** (`anthropic-beta: managed-agents-2026-04-01`). |
+| **C** | **MCP-only** — clients use Cursor, Claude Desktop, or any MCP host against `https://riskmodels.app/api/mcp/...` with their API key. | **Always-on distribution**: already shipped; keep docs and install UX strong. **No substitute** for hosted `/api/chat` but lowest lift for “cloud shift” narratives. |
+
+**Resolved:** Ship **C** continuously; pursue **A** on the existing chat path when product asks for Claude quality / prompt caching without session economics; pursue **B** only after a successful internal spike and pricing sign-off.
+
+### Phase alignment (see BWMACRO strategy §5)
+
+| Build phase | Typical LLM path on `.app` | Managed agents (Option B) |
+|-------------|--------------------------|---------------------------|
+| **Phase 1 — activation + CML** | **A** or current OpenAI loop for thin chat copy; prioritize `/snapshot` | **Defer** — not on cold onboarding path |
+| **Phase 2 — retained research** | **A** stays valid for developers | **B** gated on spike +$/session proof; `.net`-side sessions |
+| **Phase 3 — workspace scale** | Unchanged MCP + REST | Optional hybrid |
+
+---
+
+## 2. Current product baseline (unchanged by this doc)
+
+- **`POST /api/chat`** — OpenAI tool loop, capability `chat-risk-analyst`: per-token LLM + per-tool debits aligned with REST capabilities (`lib/agent/billing-middleware.ts`, `lib/agent/capabilities.ts`).
+- **MCP** — Bearer `Authorization`; each tool call bills like the underlying REST route (`mcp/data/openapi.json`).
+
+---
+
+## 3. Time-boxed spike (Option B)
+
+**Goal:** Validate create agent → environment → session → send message → stream until idle; record wall time and IDs for cost follow-up in Anthropic Console.
+
+**Prerequisites:**
+
+- `ANTHROPIC_API_KEY` with Managed Agents access (beta header required on all calls).
+- Optional: `ANTHROPIC_MANAGED_AGENTS_SPIKE_MODEL` (default `claude-haiku-4-5` in script).
+- **RiskModels MCP inside the agent** is a follow-on: configure MCP servers on the [agent definition](https://platform.claude.com/docs/en/managed-agents/quickstart) per Anthropic docs; use a test `RISKMODELS_API_KEY` and monitor **billing_events** / balance for MCP tool traffic.
+
+**Run:**
+
+```bash
+export ANTHROPIC_API_KEY=...
+node scripts/spike-claude-managed-agents.mjs
+```
+
+**Measure:** Wall-clock session duration (script logs), then reconcile with Anthropic usage/billing for **tokens** and **managed session runtime** (verify current rates on [Anthropic pricing](https://docs.anthropic.com/en/docs/about-claude/pricing)). Compare with a comparable task via **`POST /api/chat`** (token + tool USD).
+
+---
+
+## 4. Billing design (Option B — when/if enabled)
+
+Upstream Anthropic charges at least:
+
+- **Tokens** (input/output/cache) at published model rates.
+- **Managed session runtime** while the session status is **running** (verify latest $/hour or $/minute on Anthropic pricing; third-party summaries are not contractual).
+
+Downstream RiskModels charges (unchanged):
+
+- **MCP / REST tools** — same as today per capability.
+
+Customer-facing packaging options:
+
+1. **BYO Anthropic + our MCP** — customer pays Anthropic directly; we bill only RiskModels tool usage (simplest).
+2. **RiskModels-hosted sessions** — we pay Anthropic; customer pays prepaid balance with **pass-through + margin** on tokens + session time + existing tool debits.
+
+**Proposed capability IDs** (register in `lib/agent/capabilities.ts` + OpenAPI only when product ships B):
+
+| Capability id | Meter | Notes |
+|---------------|-------|--------|
+| `managed-agent-input-tokens` | Per 1K tokens (in) | Map from Anthropic usage logs. |
+| `managed-agent-output-tokens` | Per 1K tokens (out) | Same. |
+| `managed-agent-session-minute` | Per minute **running** | Round up/down per finance policy; confirm vs Anthropic meter. |
+| *(existing)* `metrics-snapshot`, `ticker-returns`, … | Per MCP/REST call | Unchanged. |
+
+**Preflight / caps:** Extend `agent_accounts` (or a new table) with **max concurrent sessions** and **daily session-time budget** before creating a session server-side.
+
+**Internal ops:** Dashboard line: Anthropic invoice vs. revenue (tokens + session + tool); alert when tool/MCP cost dominates margin.
+
+**Code pointer:** Design constants live in [`lib/agent/managed-agent-billing-design.ts`](../lib/agent/managed-agent-billing-design.ts) until capabilities are wired.
+
+---
+
+## 5. Data residency, subprocessors, and session state (Option B)
+
+When using **Claude Managed Agents**, **user prompts, assistant outputs, and tool traces** for the session are processed and **persisted by Anthropic’s managed session store** (with their container/runtime for built-in tools). That is a different data boundary than stateless `POST /api/chat` today.
+
+**Action items before enterprise sales of hosted B:**
+
+1. Update customer-facing **subprocessor / DPA** list to include **Anthropic** for managed-agent workloads (and any MCP hosts if not already covered).
+2. Document in Terms / security page: **what** is sent to Anthropic (prompts, holdings/tickers from tool args, etc.).
+3. Offer **BYO key / BYO Anthropic org** where customers require **zero** RiskModels-hosted LLM spend (pattern 1 in §4).
+4. Review **branding** constraints for partners ([Anthropic Managed Agents branding guidelines](https://platform.claude.com/docs/en/managed-agents/overview)).
+
+---
+
+## 6. Next steps (product)
+
+1. **Phase 1 / activation:** Prefer **snapshot latency + Client Memory Layer** on `.net` (`MANAGED_COGNITIVE_RUNTIME_STRATEGY.md` §3–§5). For Claude on `.app` chat only: **Option A** behind flag; avoid session-meter paths on first visit.
+2. **Phase 2:** Complete **managed-agents spike** metrics + pricing; then bridge routes (`/api/managed-sessions/...`) + billing capability IDs — only if `.net` product adopts Option B for retained threads.
+3. Keep **Option C** on [quickstart](https://riskmodels.app/quickstart) and MCP install flows.
+
+---
+
+*Last updated: aligned with `MANAGED_COGNITIVE_RUNTIME_STRATEGY.md` (Client Memory Layer, phased build).*

--- a/docs/CHAT_MANUAL_QA.md
+++ b/docs/CHAT_MANUAL_QA.md
@@ -1,0 +1,163 @@
+# Manual QA: Agentic POST /api/chat
+
+Smoke-test the AI Risk Analyst chat endpoint with a **real API key** and sufficient prepaid balance. Chat is billed **per LLM token** plus **per data tool** (same rates as the matching REST capabilities). Tool `search_tickers` is **free**.
+
+For authentication patterns, see [AUTHENTICATION_GUIDE.md](../AUTHENTICATION_GUIDE.md).
+
+## Prerequisites
+
+1. **Server-side:** `OPENAI_API_KEY` must be set wherever the Next app runs (local `.env.local`, Vercel, etc.). If missing, chat returns **503** with a configuration message.
+2. **Client-side:** A valid RiskModels **API key** or session JWT (`Authorization: Bearer …`). Keys are created after login at [riskmodels.app](https://riskmodels.app) (Account → Usage / API).
+3. **Balance:** Enough credits for at least one chat turn (LLM estimate + 1–2 tools). Typical NVDA smoke test: roughly a few thousandths of a dollar LLM + **metrics-snapshot** + **ticker-returns** (see preflight below).
+4. **Tier:** Chat uses capability `chat-risk-analyst` (premium per-token). Free-tier-only accounts may get **402** or tier limits from `withBilling`; that is expected until upgraded.
+
+Set a base URL and key for the examples:
+
+```bash
+export BASE_URL="https://riskmodels.app"   # or http://localhost:3000 for local dev
+export RISKMODELS_API_KEY="rm_agent_live_..."  # your key
+```
+
+## 1. Preflight: cost estimate (optional)
+
+Confirms the `chat` mapping and lists **per-tool** reference prices (`available_tools`). LLM line is an estimate only; actual token usage is returned on the real chat response.
+
+```bash
+curl -sS -X POST "$BASE_URL/api/estimate" \
+  -H "Authorization: Bearer $RISKMODELS_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "endpoint": "chat",
+    "params": {
+      "messages": [{ "role": "user", "content": "What is NVDA'\''s L3 market hedge ratio?" }]
+    }
+  }' | jq .
+```
+
+Expect: `estimated_cost_usd`, `note` mentioning tool billing, and `available_tools[]` with `name`, `capability_id`, `cost_per_call_usd`.
+
+## 2. Primary smoke test (curl)
+
+Ask for a live metric **and** history so the model should call **get_risk_metrics** and **get_ticker_returns** (it may skip **search_tickers** when the ticker is explicit).
+
+```bash
+curl -sS -X POST "$BASE_URL/api/chat" \
+  -H "Authorization: Bearer $RISKMODELS_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "messages": [
+      {
+        "role": "user",
+        "content": "What is NVDA'\''s current L3 market hedge ratio and how has it changed over the last year?"
+      }
+    ]
+  }' | tee /tmp/chat-smoke.json | jq '{
+    message: .message.content[:400],
+    tool_calls_summary,
+    _agent: ._agent
+  }'
+```
+
+### Pass criteria
+
+- **HTTP 200**
+- **`message.content`:** Plain-language answer mentioning real-looking **l3_mkt_hr** (or equivalent) and some sense of change over time (not generic boilerplate only).
+- **`tool_calls_summary`:** Non-null array with at least **two** entries in most runs (e.g. `get_risk_metrics`, `get_ticker_returns`). Tool names and `cost_usd` / `latency_ms` populated; `error` null unless a tool failed.
+- **`_agent`:** `llm_cost_usd`, `tool_cost_usd`, `tool_calls`, `cost_usd` ≈ llm + tools, `request_id` set.
+- **Cost line:** Body text often ends with a cost line; if the model omits it, the server appends **`**API tool costs:**`** (see `appendCostLineIfMissing` in the route).
+
+Full JSON is useful for debugging:
+
+```bash
+jq . /tmp/chat-smoke.json
+```
+
+## 3. Optional request flags
+
+```json
+{
+  "parallel_tool_calls": false,
+  "execute_tools_sequentially": true
+}
+```
+
+Add these next to `messages` to force OpenAI off parallel tool calls and/or run server-side tools one-by-one (useful if you suspect ordering or provider quirks).
+
+## 4. Edge-case prompts (manual)
+
+Run the same `curl` pattern; swap the user `content`:
+
+| Scenario | Prompt (idea) | What to check |
+|----------|----------------|---------------|
+| Company name | “Tell me about Apple’s risk profile.” | `search_tickers` then metrics-style tools; plausible AAPL data. |
+| Portfolio | “Analyze risk for 50% NVDA, 30% AAPL, 20% MSFT.” | `compute_portfolio_risk_index` in `tool_calls_summary`; structured portfolio fields in the answer. |
+| Bad ticker | “Hedge ratio for ticker XYZZINVALID?” | Tool error in summary or structured error in narrative; **no invented numbers**. |
+| Low balance | Use an account with ~$0 after a successful tool-heavy turn | Tool result or narrative mentions **insufficient balance** / top-up; `cost_usd` 0 on failed paid tools. |
+| Large history | “Show TSLA daily context over 15 years.” | Response still bounded; returns data may show truncation / summary in tool payload. |
+| Macro only | “How did gold vs bitcoin perform this year?” | Prefer **get_macro_factors** without stock tools (model-dependent). |
+
+## 5. HTTP codes to expect
+
+| Status | Meaning |
+|--------|--------|
+| **401** | Missing/invalid Bearer token. |
+| **402** | Insufficient balance (or payment required) on the **chat** pre-charge. |
+| **429** | Rate limit / free-tier limit (if applicable). |
+| **502** | OpenAI upstream error (bad key, outage, or bad model name). |
+| **503** | `OPENAI_API_KEY` not configured on the server. |
+
+## 6. Local dev quick check
+
+```bash
+cd /path/to/RiskModels_API
+# Ensure OPENAI_API_KEY and Supabase/env match a working deployment
+npm run dev
+```
+
+Then point `BASE_URL` at `http://localhost:3000` and repeat the curl calls.
+
+## 7. Typecheck (no live key)
+
+```bash
+npm run typecheck
+```
+
+This does not call OpenAI or Supabase; it only verifies the TypeScript build.
+
+## 8. RiskModels portal (`riskmodels.net` / local dev)
+
+The consumer portal proxies chat to the same RiskModels API (`POST /api/chat`) via **same-origin** `POST /chat` → `riskmodels_com` route `POST /api/chat` (see Risk_Models repo). Use this checklist in a browser (not only curl).
+
+### Prerequisites (portal)
+
+1. **Portal env:** `RISKMODELS_API_SERVICE_KEY` (or `GATEWAY_SERVICE_KEY`) if you want **anonymous** guest chat; otherwise guests get **503** (“sign in”). For **IP rate limits** across instances, set `UPSTASH_REDIS_REST_URL` and `UPSTASH_REDIS_REST_TOKEN` (anonymous: 5 requests/day/IP; authenticated users also use Redis for per-plan daily caps when configured).
+2. **Logged-in test:** Cookie session on the portal; the proxy forwards the Supabase **JWT** to `riskmodels.app` so billing hits that user’s API account.
+3. **Optional:** `cd Risk_Models/riskmodels_com && npm run typecheck && npm run build` (no live OpenAI).
+
+### Logged-in UI pass
+
+1. Open `/chat` while signed in.
+2. Send the **primary** NVDA prompt (same as §2).
+3. **Pass criteria:** Assistant markdown shows real metrics; expandable **Tools used** lists ≥2 tools with costs/latencies; footer badges show LLM / Tools / Total; `X-Chat-Auth: user` (DevTools → Network → `/api/chat` response headers).
+
+### Anonymous / guest pass
+
+1. Open `/chat` in a private window (no portal session).
+2. Send a short prompt (e.g. company name or “Search for Apple”).
+3. Expect **limited** responses, **amber** guest banner, and `X-Chat-Auth: anonymous` on `/api/chat`. After **5** requests/day from the same IP (with Upstash configured), expect **429** and sign-in / pricing CTAs.
+
+### Subscription tier cap (authenticated)
+
+Users without an **active/trialing** subscription are treated as **free** for portal daily caps (**5**/day). **Professional/Enterprise:** **100**/day. **Fintech:** no portal daily cap (`chat_queries_per_day: 0` in tier table = unlimited proxy turns; API billing still applies). Over cap → **429** with header `X-Chat-Quota: tier`.
+
+### Edge cases (portal)
+
+Repeat the scenarios in §4 in the **browser**; confirm tool errors appear in the tools panel and the assistant does not invent data for bad tickers.
+
+### Streaming note
+
+Portal UI currently consumes the **JSON** chat response. **SSE / `response_mode: hybrid`** streaming is **not** wired end-to-end until the public API exposes a stable stream contract and the portal proxy parses it; treat streaming as a follow-up.
+
+---
+
+**Summary:** One successful **primary** run with `tool_calls_summary` showing paid tools + sane `_agent` costs is enough for a minimal smoke pass. Use the edge-case table when hardening before release. For the portal, add §8 checks before shipping `riskmodels.net`.

--- a/docs/DISCOVERY_SKILL_INTEGRATION_PLAN.md
+++ b/docs/DISCOVERY_SKILL_INTEGRATION_PLAN.md
@@ -1,0 +1,113 @@
+# Discovery Skill Integration Plan
+
+**Date:** 2026-04-05
+**Skill:** `riskmodels-api-discovery` (`.cursor/skills/riskmodels-api-discovery/SKILL.md`)
+**Trigger:** Skill upgraded in `fa06bc0`; need to align API routes, CLI endpoint, and MCP discovery data.
+
+---
+
+## Status snapshot
+
+| Source | Entry count | Notes |
+|--------|-------------|-------|
+| `lib/agent/capabilities.ts` | ~15 capabilities | Canonical billing/pricing registry |
+| `mcp/data/capabilities.json` | 12 entries | Stale — missing portfolio-risk-snapshot, plaid, cli-query, sdk-python |
+| `mcp/data/schema-paths.json` | 9 indexed | 2 orphan schemas (`estimate-v1`, `risk-metadata-v1`) not indexed |
+| `OPENAPI_SPEC.yaml` | Covers most routes | Missing `format=pdf\|png` on risk-snapshot, missing Plaid routes |
+| SDK `capabilities.py` | Full method registry | Authoritative for Python client; includes `discover()` |
+
+---
+
+## 1. API — Align discovery sources with live routes
+
+### 1a. Create `docs/portfolio-risk-snapshot-runbook.md`
+
+The discovery skill references this file as the worked "discovery → minimal PDF client" example. It does not exist.
+
+**Contents:** Step-by-step showing (1) call `riskmodels_list_endpoints`, (2) call `riskmodels_get_capability("portfolio-risk-snapshot")`, (3) minimal Python/curl to POST and receive PDF. Reference the SDK's `get_portfolio_risk_snapshot_pdf()` and the `examples/python/portfolio_risk_snapshot_pdf.py` script.
+
+### 1b. Update `OPENAPI_SPEC.yaml`
+
+- Add `format` enum (`pdf`, `json`, `png`) to `/portfolio/risk-snapshot` POST parameters.
+- Add `application/pdf` and `image/png` response content types.
+- Add Plaid routes (`/plaid/link-token`, `/plaid/exchange-public-token`, `/plaid/holdings`) — currently undocumented.
+
+### 1c. Verify Zod ↔ capabilities ↔ OpenAPI alignment
+
+Audit `lib/api/schemas.ts` against `capabilities.ts` parameter specs. Known risk: the risk-snapshot route accepts `title` (Zod) but some docs may reference `name`. The discovery skill explicitly warns about this.
+
+---
+
+## 2. CLI (`/api/cli/query`) — Surface through discovery
+
+### 2a. Add `cli-query` to `mcp/data/capabilities.json`
+
+The capability exists in `capabilities.ts` (id: `cli-query`, cost: $0.003/request) but is absent from the MCP data file. Agents using MCP discovery currently cannot find it.
+
+### 2b. Update discovery skill fallback docs
+
+Add a note in the discovery skill's "Repo sources" section that `cli-query` can be used for ad-hoc data exploration when the user wants raw SQL access (SELECT-only, rate-limited).
+
+---
+
+## 3. MCP — Sync discovery data with `capabilities.ts`
+
+### 3a. Sync `capabilities.json` ← `capabilities.ts`
+
+Add missing entries:
+
+| Capability ID | Why missing |
+|---------------|-------------|
+| `portfolio-risk-snapshot` | New premium endpoint ($0.25) |
+| `portfolio-risk-index` | Existed in code, never added to MCP |
+| `plaid-link-token` | Integration endpoint |
+| `plaid-holdings` | Integration endpoint |
+| `plaid-exchange-token` | Integration endpoint |
+| `batch-analysis` | Per-position billing |
+| `sdk-python` | Version hint endpoint |
+| `cli-query` | SQL access endpoint |
+
+### 3b. Update `schema-paths.json`
+
+Index all schema files in `mcp/data/schemas/`:
+- Add `estimate-v1.json` (exists on disk, not indexed)
+- Add `risk-metadata-v1.json` (exists on disk, not indexed)
+- Create and add `portfolio-risk-snapshot-v1.json`
+- Create and add `portfolio-risk-index-v1.json`
+
+### 3c. Consider new MCP resource: `riskmodels:///semantic-aliases`
+
+The discovery skill references `SEMANTIC_ALIASES.md` as a key repo source, but the MCP server doesn't expose it. Adding it as a resource lets agents using MCP-only discovery (no repo checkout) access field name mappings.
+
+---
+
+## 4. Cross-cutting alignment
+
+### 4a. Root `SKILL.md` ↔ discovery skill consistency
+
+Both files now reference MCP tools. Verify tool names match (`riskmodels_list_endpoints`, `riskmodels_get_capability`, `riskmodels_get_schema`) and fallback order is identical.
+
+### 4b. BWMACRO portfolio-hedge-analyst pricing
+
+The BWMACRO skill references $0.002/position for batch analysis. Current `capabilities.ts` has $0.005/position. Update the BWMACRO skill's Step 2 cost estimate section.
+
+### 4c. Repo-sync-enforcer checklist
+
+After all changes, run the BWMACRO repo-sync-enforcer:
+```
+- [ ] RiskModels_API: capabilities.json, schema-paths.json, OpenAPI updated
+- [ ] Risk_Models: schemas copied, schema-paths.json updated
+- [ ] BWMACRO: current_state.md updated, hedge-analyst pricing corrected
+```
+
+---
+
+## Execution order
+
+1. **MCP data sync** (3a, 3b) — unblocks everything else
+2. **OpenAPI update** (1b) — schema source of truth
+3. **New schemas** (3b) — depend on OpenAPI being correct
+4. **Runbook** (1a) — references correct schemas
+5. **CLI discovery** (2a, 2b) — independent, can parallel with 3-4
+6. **Cross-cutting** (4a-4c) — final pass
+7. **Repo-sync-enforcer** (4c) — verify no drift

--- a/docs/DOC_PRECISION_CLEANUP_PLAN.md
+++ b/docs/DOC_PRECISION_CLEANUP_PLAN.md
@@ -1,0 +1,84 @@
+# Documentation precision cleanup plan
+
+**Scope:** Hedge ratios vs classical betas, Supabase V3 naming, endpoint facts, and (optionally) marketing copy.  
+**Canonical field semantics:** [SEMANTIC_ALIASES.md](../SEMANTIC_ALIASES.md), [ENGINE_METHOD_NOTES.md](../ENGINE_METHOD_NOTES.md) §3.
+
+---
+
+## Goals
+
+1. **Stop equating `*_hr` with “betas”** in reference docs unless the text explicitly scopes meaning (e.g. informal “market beta” for the **L3 market leg only**, with a pointer to units and hierarchy).
+2. **Align backend description with V3 reality:** replace stale references to legacy Supabase tables in the OpenAPI narrative.
+3. **Correct user-facing endpoint summaries** where they disagree with implemented routes.
+
+---
+
+## Canonical definitions (single source of truth)
+
+Keep **[SEMANTIC_ALIASES.md](../SEMANTIC_ALIASES.md)** as the normative field reference. Include a short subsection **“Hedge ratios vs classical regression betas”** that states:
+
+- `*_hr` are **`dollar_ratio`** (ETF notional per $1 stock).
+- At **L2/L3**, legs are **hierarchical, ETF-executable hedge weights**, not guaranteed to equal univariate OLS slopes of the stock on each ETF alone.
+- **Explained risk (`*_er`)** is the right language for variance explained / hierarchical decomposition; cite **[ENGINE_METHOD_NOTES.md](../ENGINE_METHOD_NOTES.md)** §3.
+
+Avoid duplicating long engine prose—link out.
+
+---
+
+## File-by-file changes (RiskModels_API)
+
+### 1. [OPENAPI_SPEC.yaml](../OPENAPI_SPEC.yaml) — `info.description`
+
+- **Problem:** Legacy mention of `erm3_betas` / `erm3_rankings` as the live Supabase contract.
+- **Change:** Describe **V3** tables: `security_history`, `security_history_latest`, `symbols`, `trading_calendar`, `erm3_landing_chart_cache`, `macro_factors`. State that **rankings** come from rank metric keys in `security_history` (see `fetchTopRankingsSnapshot` in `lib/dal/risk-engine-v3.ts`), not a separate `erm3_rankings` table.
+- **MCP tool copy:** `analyze_portfolio` description must **not** claim **Sharpe** unless the batch/metrics routes actually return it.
+
+**Regenerate:** `npm run build:openapi` → updates `public/openapi.json` and `mcp/data/openapi.json`.
+
+### 2. [SUPABASE_TABLES.md](../SUPABASE_TABLES.md)
+
+- Replace the metric_key row that merged “Hedge ratios / betas” with precise **dollar_ratio** + hierarchical wording and a link to `SEMANTIC_ALIASES.md`.
+
+### 3. [README_API.md](../README_API.md)
+
+- **`/api/ticker-returns`:** Document **L3** HR/ER in the series; point to `/api/l3-decomposition`, `/api/data/security-history/...`, or OpenAPI for L1/L2 **history** as appropriate.
+- **`/api/metrics/{ticker}`:** Do **not** claim Sharpe unless implemented; list actual snapshot fields (`metrics` nesting, wire keys).
+- **Quickstart:** Use `m.metrics` and abbreviated wire keys (`l3_mkt_hr`, `l3_res_er`, `vol_23d`) consistent with the route.
+- **Optional:** Short **Data plane** note for `/api/data/*` (not fully in OpenAPI; gateway soft-auth in `lib/gateway-auth.ts`).
+
+### 4. [docs/SNAPSHOT_CONTENT_MAP.md](SNAPSHOT_CONTENT_MAP.md)
+
+- Prefer **HR** / **hedge ratio** in wireframe copy; use “informal market beta” only where the narrative means L3 market HR or portfolio `portfolio_mkt_hr`-style aggregates.
+
+### 5. [CHANGELOG.md](../CHANGELOG.md)
+
+- Record doc + OpenAPI + optional portal/email changes under **[Unreleased]** (or the release that ships them).
+
+### 6. Optional consistency pass
+
+- Grep markdown for **`erm3_betas` / `erm3_rankings`** outside historical migrations/archives.
+- **Sibling repos:** `Risk_Models/riskmodels_com` (email, glossary, `erm3_wisdom`, ticker tape mocks, MCP `openapi.json` sync), `RM_ORG` (README “copy precision” note; leave narrative Medium articles unless intentionally rewriting positioning).
+
+---
+
+## Verification
+
+- `npm run build:openapi` succeeds; `mcp/data/openapi.json` has no stale **Data** paragraph and no false **Sharpe** in `analyze_portfolio` if removed from YAML.
+- README_API endpoint table and quickstarts match `app/api/metrics/[ticker]/route.ts` and `app/api/ticker-returns/route.ts`.
+
+---
+
+## Out of scope (unless explicitly expanded)
+
+- **Rewriting all marketing copy site-wide** (every landing sentence, blog, ad). The plan targets **reference accuracy** and **high-trust surfaces** (OpenAPI, SUPABASE, README_API, key components/emails), not a full brand rewrite.
+- **API behavior changes** (e.g. adding Sharpe or L1/L2 columns to `ticker-returns`)—this plan is **docs-first** unless product requests it.
+
+---
+
+## Implementation status (as of 2026-04)
+
+Executed in **RiskModels_API**: `SEMANTIC_ALIASES.md`, `OPENAPI_SPEC.yaml`, `SUPABASE_TABLES.md`, `README_API.md`, `docs/SNAPSHOT_CONTENT_MAP.md`, `sync-mcp-from-risk-models.sh` note, portal components (`UseCases`, `AgenticSection`, `TerminalShowcase`, pricing page), `emails/low-balance.tsx`, `lib/chat/system-prompt.ts`, `CHANGELOG.md`, OpenAPI JSON regen.
+
+Executed in **Risk_Models** (`riskmodels_com`): mirrored `openapi.json`, same low-balance email pattern, `erm3_wisdom.md`, `glossary-data.ts` (`l1_mkt_hr`), `useTickerTapeData.ts` mocks, `about-panel.tsx`, `layout.tsx` keywords.
+
+Executed in **RM_ORG**: `README.md` subsection on copy precision; Medium/dist narrative left unchanged by design.

--- a/docs/SDK_ENPOINT
+++ b/docs/SDK_ENPOINT
@@ -1,0 +1,78 @@
+**Yes, you can absolutely add endpoints that return SDK-style Python code** for an agent (or any client) to fetch and run a finely tuned graph on your API's risk metrics (e.g., L3 hedge ratios, explained risk, residuals, volatility time series, etc.).  
+
+Your platform at riskmodels.app is already **highly agent-native** (MCP server, `/.well-known/agent-manifest`, `riskmodels-py` SDK with `to_llm_context()` + semantic metadata, discoverable tools via `riskmodels_list_endpoints` / `riskmodels_get_schema`, etc.), so this fits perfectly and extends what you already have.
+
+### Why this works well on your stack
+- You control the full backend (OpenAPI 3.0 spec + MCP server in the repo).
+- The existing Python SDK (`riskmodels-py`) already returns clean `pandas` DataFrames / `xarray.Dataset` objects with `attrs` for legends, semantic cheatsheets, and lineage — perfect input for plotting code.
+- Agents (Cursor, Claude, Zed, etc.) already know how to call your MCP tools and can execute the returned Python code locally or in a sandbox.
+- No platform restrictions on adding endpoints — the docs explicitly call out extensibility via the MCP server.
+
+### Recommended endpoint design (simple & powerful)
+Add something like this (FastAPI-style example, but works with whatever you use):
+
+```http
+GET /api/generate-graph-code
+   ?metric=l3_residual_er          # or l3_market_hr, vol_23d, etc.
+   &tickers=NVDA,AAPL,MSFT
+   &timeframe=last_2y              # or full_history, monthly, etc.
+   &style=interactive              # or static, dark_mode, etc.
+   &format=plotly                  # or matplotlib, seaborn
+```
+
+**Response** (Content-Type: `text/x-python` or `application/json` with a `"code"` field):
+
+```python
+# Finely-tuned graph code generated for riskmodels.app metrics
+# Agent: copy-paste or exec() this directly
+
+from riskmodels import RiskModelsClient
+import plotly.graph_objects as go
+from plotly.subplots import make_subplots
+import pandas as pd
+
+client = RiskModelsClient.from_env()   # auto-loads your keys
+
+# Fetch the exact data the agent needs
+df = client.get_l3_decomposition(
+    tickers=["NVDA", "AAPL", "MSFT"],
+    period="last_2y"
+)
+
+# Finely tuned interactive plot (your branding + semantic labels)
+fig = make_subplots(rows=2, cols=1, shared_xaxes=True,
+                    subplot_titles=("L3 Residual ER (%)", "Market Hedge Ratio ($)"),
+                    vertical_spacing=0.08)
+
+fig.add_trace(go.Scatter(x=df.index, y=df['l3_residual_er']*100,
+                         name="Residual Risk", line=dict(color="#00ff88", width=3)), row=1, col=1)
+
+fig.add_trace(go.Scatter(x=df.index, y=df['l3_market_hr'],
+                         name="Market HR", line=dict(color="#ff8800", width=3)), row=2, col=1)
+
+fig.update_layout(
+    title="RiskModels.app — NVDA / AAPL / MSFT L3 Decomposition (Last 2Y)",
+    template="plotly_dark",
+    height=700,
+    legend=dict(orientation="h", yanchor="bottom", y=1.02),
+    hovermode="x unified"
+)
+fig.show()   # or fig.write_html("risk_graph.html")
+```
+
+You can make it even smarter: return a full runnable script that also calls the right endpoint(s) internally, adds error handling, exports to PNG/PDF, or includes your semantic legend from the SDK.
+
+### How to expose it to agents (2-minute integration)
+1. Add the endpoint to your OpenAPI spec (Redoc will pick it up automatically).
+2. Extend the MCP server tool definitions (`riskmodels_get_capability` etc.) so agents auto-discover it.
+3. (Optional) Add it to the agent manifest and Cursor/Claude rules — your existing `to_llm_context()` helpers already make this trivial.
+4. Document the new endpoint on `/docs/agent-integration` (you already mention agents building graphs there).
+
+### Bonus ideas you can ship in the same PR
+- `/api/generate-graph-code/batch` → returns code for a multi-metric dashboard (e.g., ER vs HR waterfall + Sharpe scatter).
+- Parameter `include_sdk_snippet=true` → also returns a tiny helper function the agent can paste into its own codebase.
+- Support for `xarray` panels if the agent passes a full portfolio.
+
+This is a natural evolution of what you already built for agentic quant research. Agents will love being able to say “give me the exact Python code to graph the L3 residual drift for my portfolio” and get production-ready, branded, finely-tuned code in one call.
+
+If you want, drop the exact backend framework you're using (FastAPI/Flask/whatever) or a snippet of your current MCP tool defs and I can give you the precise code to copy-paste for the new endpoint.

--- a/docs/SNAPSHOT_CONTENT_MAP.md
+++ b/docs/SNAPSHOT_CONTENT_MAP.md
@@ -1,0 +1,464 @@
+# Snapshot Content Map — JSON-First Architecture
+
+> How a world-class consulting firm would spec eight 1-page institutional PDFs.
+> Every snapshot follows the same pipeline:
+>
+> ```
+> fetch(ticker, client) → {ticker}_R1.json → render(json) → PDF
+> ```
+>
+> The JSON is the **handshake contract**. An agent (or human) can improve any
+> chart or narrative block by editing only the renderer — the JSON file + render
+> code is a self-contained unit that needs zero API access.
+
+---
+
+## Shared Page Anatomy (all 8 pages)
+
+Every PDF is **Letter Landscape (11 × 8.5 in)** with this skeleton:
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  HEADER BAR  ·  Ticker  ·  Company  ·  Report Label     │
+├─────────────────────────────────────────────────────────┤
+│  CHIP ROW   [ KPI 1 ]  [ KPI 2 ]  [ KPI 3 ]  ...      │
+├─────────────────────────────────────────────────────────┤
+│                                                         │
+│            VISUAL PANELS  (charts / tables)              │
+│                                                         │
+├─────────────────────────────────────────────────────────┤
+│  AI NARRATIVE  ·  2–3 sentence insight paragraph         │
+├─────────────────────────────────────────────────────────┤
+│  FOOTER  ·  Confidential  ·  Data TEO  ·  SDK version   │
+└─────────────────────────────────────────────────────────┘
+```
+
+### AI Narrative Block
+
+Every page includes a **2–3 sentence analyst narrative** generated from the
+data. Think McKinsey exhibit footnote — not a wall of text, but the "so what"
+a PM reads first. The narrative is computed during `get_data`, stored as a
+string in the JSON, and rendered as a styled text block above the footer.
+
+Template for narrative generation:
+
+```
+Given {ticker} metrics and {peer/benchmark} context:
+  1. State the headline finding (strongest signal in the data)
+  2. Quantify the edge or risk (cite the number)
+  3. Frame the implication for a portfolio manager
+```
+
+---
+
+## JSON Envelope (shared across all snapshots)
+
+```json
+{
+  "schema_version": "1.0",
+  "snapshot_type": "R1",
+  "generated_utc": "2026-04-06T14:30:00Z",
+  "sdk_version": "0.3.0",
+
+  "identity": {
+    "ticker": "NVDA",
+    "company_name": "NVIDIA Corporation",
+    "sector_etf": "XLK",
+    "subsector_etf": "SMH",
+    "universe": "uni_mc_3000",
+    "teo": "2026-04-04"
+  },
+
+  "chips": [ ... ],
+  "panels": { ... },
+  "narrative": "NVDA's residual alpha is +42 bps above ...",
+  "tables": { ... }
+}
+```
+
+---
+
+## RISK SNAPSHOTS (R1 – R4)
+
+### R1 — Factor Risk Profile
+**Current × Stock** · "Where is this stock's risk coming from right now?"
+
+```
+HEADLINE:    "NVDA — Factor Risk Profile"
+QUESTION:    What % of this stock's risk is market, sector, subsector, residual?
+
+CHIPS:
+  L3 Mkt HR  |  L3 Sec HR  |  L3 Sub HR  |  Vol 23d  |  Selection Spread vs {subsector}
+
+PANELS:
+  ┌──────────────────────┬──────────────────────┐
+  │  LEFT: L3 ER Decomp  │  RIGHT: HR Cascade   │
+  │                       │                       │
+  │  Horizontal stacked   │  Grouped bar:         │
+  │  bar — 4 layers:      │  L1 → L2 → L3        │
+  │  Market / Sector /    │  showing how hedge    │
+  │  Subsector / Residual │  ratios refine by level │
+  │  (% of total ER)      │  (convergence story)  │
+  ├───────────────────────┴───────────────────────┤
+  │  BOTTOM: Peer Comparison Table                 │
+  │                                                │
+  │  Ticker | Cap Wt% | Vol | L3 Res ER | vs Avg  │
+  │  ★ NVDA |   —     | .42 |  +0.42%   | +11 bps │
+  │  AMD    | 18.2%   | .38 |  +0.31%   |  +0 bps │
+  │  ...                                           │
+  └────────────────────────────────────────────────┘
+
+NARRATIVE (auto-generated):
+  "{ticker}'s L3 residual ER of {res_er}% places it {above/below} the
+   {subsector_etf} peer average by {spread} bps. The dominant risk
+   driver is {largest_factor} ({pct}% of total explained variance),
+   suggesting {implication}."
+
+JSON.panels:
+  l3_er_bars:     { market: 0.12, sector: 0.05, subsector: 0.03, residual: 0.08 }
+  hr_cascade:     { l1: {mkt: 1.32}, l2: {mkt: 1.28, sec: 0.94}, l3: {mkt: 1.25, sec: 0.91, sub: 0.87} }
+  peer_table:     [ {ticker, weight, vol_23d, l3_residual_er, vs_peer_avg, l3_market_hr}, ... ]
+```
+
+**Data sources:** `GET /metrics/{ticker}`, `PeerGroupProxy.compare()`
+
+---
+
+### R2 — Risk Attribution Drift
+**History × Stock** · "How has this stock's risk profile changed over time?"
+
+```
+HEADLINE:    "NVDA — Risk Attribution Drift"
+QUESTION:    Are the factor exposures stable, trending, or regime-shifting?
+
+CHIPS:
+  L3 Mkt HR (latest)  |  L3 Sec HR  |  L3 Sub HR  |  Cumul α  |  Vol 23d
+
+PANELS:
+  ┌──────────────────────┬──────────────────────┐
+  │  LEFT: ER Stacked    │  RIGHT: HR Time      │
+  │  Area                │  Series              │
+  │                       │                       │
+  │  Daily L3 ER bands   │  Three lines:         │
+  │  (Market blue,       │  L3 Mkt / Sec / Sub   │
+  │  Sector teal,        │  hedge ratios over    │
+  │  Subsector slate,    │  trailing window —   │
+  │  Residual green)     │  converging or        │
+  │  stacked over time   │  diverging?           │
+  ├───────────────────────┴───────────────────────┤
+  │  BOTTOM: Cumulative ER Waterfall               │
+  │                                                │
+  │  Bar chart: total cumulative contribution of   │
+  │  each factor over the window                   │
+  │  Market: +8.2% | Sector: +1.4% | Sub: -0.3%  │
+  │  Residual (α): +4.1%                          │
+  └────────────────────────────────────────────────┘
+
+NARRATIVE:
+  "Over the trailing {months} months, {ticker}'s factor profile has
+   {stabilised / shifted}. L3 market HR averaged {avg_mkt_hr} (range
+   {min}–{max}), while residual alpha accumulated {cumul_alpha}%,
+   {ranking} among {subsector_etf} peers."
+
+JSON.panels:
+  er_stacked_area:  [ {date, market_er, sector_er, subsector_er, residual_er}, ... ]
+  hr_time_series:   [ {date, l3_market_hr, l3_sector_hr, l3_subsector_hr}, ... ]
+  cumulative_er:    { market: 8.2, sector: 1.4, subsector: -0.3, residual: 4.1 }
+```
+
+**Data sources:** `GET /ticker-returns` (daily L3 columns), `GET /metrics/{ticker}`
+
+---
+
+### R3 — Concentration Mekko
+**Current × Portfolio** · "Where is the portfolio's risk concentrated right now?"
+
+```
+HEADLINE:    "Portfolio — Risk Concentration"
+QUESTION:    Which positions and factors dominate portfolio risk?
+
+CHIPS:
+  Portfolio Vol  |  Top-5 Conc%  |  Herfindahl  |  # Positions  |  Eff. N
+
+PANELS:
+  ┌──────────────────────────────────────────────┐
+  │  TOP: Mekko / Marimekko Chart                 │
+  │                                                │
+  │  X-axis = position weight                      │
+  │  Y-axis = L3 factor stack (Mkt/Sec/Sub/Res)   │
+  │  Width of each column = portfolio weight       │
+  │  Height of each band = contribution to risk    │
+  │  Color = factor layer (navy/teal/slate/green)  │
+  │                                                │
+  │  → Reader instantly sees: "NVDA is 8% of the  │
+  │     portfolio but 22% of total risk, mostly    │
+  │     residual (green band is huge)"             │
+  ├────────────────────────────────────────────────┤
+  │  BOTTOM: Risk Contribution Table               │
+  │                                                │
+  │  Ticker | Wt% | Marg Var | Risk Cont% | L3 α  │
+  │  (sorted by risk contribution, top 10)         │
+  └────────────────────────────────────────────────┘
+
+NARRATIVE:
+  "The portfolio's risk is {concentrated / diversified} — the top
+   {n} positions contribute {pct}% of total variance. {top_ticker}
+   is the dominant risk source at {risk_cont}%, driven primarily by
+   {factor}. Effective N of {eff_n} suggests {implication}."
+
+JSON.panels:
+  mekko:           [ {ticker, weight, mkt_risk_cont, sec_risk_cont, sub_risk_cont, res_risk_cont}, ... ]
+  risk_table:      [ {ticker, weight_pct, marginal_var, risk_contribution_pct, l3_residual_er}, ... ]
+  portfolio_stats: { total_vol, herfindahl, effective_n, top5_concentration }
+```
+
+**Data sources:** `POST /batch/analyze` (portfolio mode), `PeerGroupProxy` for each position
+
+---
+
+### R4 — Style Drift
+**History × Portfolio** · "Has the portfolio's factor tilt changed over time?"
+
+```
+HEADLINE:    "Portfolio — Style Drift"
+QUESTION:    Are we drifting toward more market/sector/residual risk over time?
+
+CHIPS:
+  Avg Mkt HR  |  HR range  |  Sector Tilt Δ  |  Residual Share (now vs 6m ago)
+
+PANELS:
+  ┌──────────────────────────────────────────────┐
+  │  TOP: Stacked Area — Portfolio Factor Mix      │
+  │                                                │
+  │  Like R2 but at portfolio level:               │
+  │  daily aggregate L3 ER decomposition           │
+  │  showing how the mix of market / sector /      │
+  │  subsector / residual has shifted               │
+  ├──────────────────────┬─────────────────────────┤
+  │  BOTTOM LEFT:        │  BOTTOM RIGHT:           │
+  │  Rolling portfolio   │  Sector Allocation       │
+  │  L3 market HR (21d   │  Drift                   │
+  │  average). Informal  │  100% stacked bar by     │
+  │  market-beta read —  │  month: what % of risk   │
+  │  is PM more/less     │  came from each GICS     │
+  │  levered to market?  │  sector over time?       │
+  └──────────────────────┴─────────────────────────┘
+
+NARRATIVE:
+  "Over the trailing {months} months, portfolio L3 market HR has
+   {increased/decreased} from {start} to {end}. Residual risk share
+   moved from {old}% to {new}%, indicating {more/less} active stock
+   selection. Sector allocation shifted {toward/away from} {sector}."
+
+JSON.panels:
+  portfolio_factor_area: [ {date, mkt_er, sec_er, sub_er, res_er}, ... ]
+  rolling_portfolio_beta: [ {date, portfolio_mkt_hr_21d}, ... ]
+  sector_drift:          [ {month, sector_weights: {XLK: 0.32, XLF: 0.18, ...}}, ... ]
+```
+
+**Data sources:** `POST /batch/analyze` (time-series mode), daily rebalanced weights
+
+---
+
+## PERFORMANCE SNAPSHOTS (P1 – P4)
+
+### P1 — Return & Relative Performance
+**Current × Stock** · "How is this stock performing vs its benchmarks right now?"
+
+```
+HEADLINE:    "NVDA — Return & Relative Performance"
+QUESTION:    Is this stock outperforming its sector, subsector, and market?
+
+CHIPS:
+  1d Return  |  5d  |  1m  |  3m  |  1y  |  vs SPY (1m)  |  vs {subsector} (1m)
+
+PANELS:
+  ┌──────────────────────┬──────────────────────┐
+  │  LEFT: Trailing      │  RIGHT: Bullet       │
+  │  Return Bars         │  Gauges              │
+  │                       │                       │
+  │  Grouped bar chart:  │  3 bullet charts:     │
+  │  1d / 5d / 1m / 3m  │  Stock return vs.     │
+  │  / 1y — one cluster  │  SPY / Sector ETF /  │
+  │  per window, bars    │  Subsector ETF        │
+  │  for Stock / Sector  │  with range bands     │
+  │  / Subsector / SPY   │  (peer min/max)       │
+  ├───────────────────────┴───────────────────────┤
+  │  BOTTOM: Relative Return Heatmap               │
+  │                                                │
+  │  Matrix: rows = windows (1d..1y)               │
+  │  cols = benchmarks (SPY, Sector, Subsector)    │
+  │  cells colored green (outperform) /            │
+  │  orange (underperform) with bps values         │
+  └────────────────────────────────────────────────┘
+
+NARRATIVE:
+  "{ticker} has returned {1m_ret}% over the past month, {outperforming/
+   underperforming} {subsector_etf} by {spread} bps. Relative strength
+   is {improving/deteriorating} across horizons, with the {window}
+   signal being the {strongest/weakest}."
+
+JSON.panels:
+  trailing_returns:  { stock: {1d, 5d, 1m, 3m, 1y}, spy: {...}, sector: {...}, subsector: {...} }
+  bullet_gauges:     [ {benchmark, stock_val, bench_val, peer_range: [min, max]}, ... ]
+  relative_heatmap:  { rows: [1d, 5d, 1m, 3m, 1y], cols: [SPY, sector, subsector], values: [[...]] }
+```
+
+**Data sources:** `fetch_stock_context()` → `trailing_returns()`, `relative_returns()`
+
+---
+
+### P2 — Cumulative Performance
+**History × Stock** · "What's the equity curve story over time?"
+
+```
+HEADLINE:    "NVDA — Cumulative Performance"
+QUESTION:    How has total return evolved, and how deep were the drawdowns?
+
+CHIPS:
+  Total Return  |  Max Drawdown  |  Sharpe (rolling 63d)  |  Best Month  |  Worst Month
+
+PANELS:
+  ┌──────────────────────────────────────────────┐
+  │  TOP: Cumulative Return Lines                  │
+  │                                                │
+  │  Multi-line chart:                             │
+  │  Stock / SPY / Sector ETF / Subsector ETF      │
+  │  all rebased to 0 at start of window           │
+  │  (classic hedge fund factsheet exhibit)        │
+  ├──────────────────────┬─────────────────────────┤
+  │  BOTTOM LEFT:        │  BOTTOM RIGHT:           │
+  │  Drawdown Underwater │  Rolling Sharpe          │
+  │                       │                           │
+  │  Filled area chart   │  63-day rolling Sharpe    │
+  │  (always ≤ 0) —      │  for stock vs SPY —       │
+  │  shows depth and     │  are risk-adjusted        │
+  │  duration of every   │  returns trending up      │
+  │  drawdown episode    │  or down?                 │
+  └──────────────────────┴─────────────────────────┘
+
+NARRATIVE:
+  "{ticker} returned {total_ret}% over {months} months vs {spy_ret}%
+   for SPY. The maximum drawdown was {max_dd}%, lasting {dd_days}
+   trading days. Rolling Sharpe is currently {sharpe}, {above/below}
+   its trailing average of {avg_sharpe}."
+
+JSON.panels:
+  cumulative_lines: { stock: [{date, cum_ret}], spy: [...], sector: [...], subsector: [...] }
+  drawdown:         [ {date, drawdown_pct}, ... ]
+  rolling_sharpe:   [ {date, stock_sharpe, spy_sharpe}, ... ]
+  summary_stats:    { total_return, max_drawdown, max_dd_days, current_sharpe, avg_sharpe }
+```
+
+**Data sources:** `fetch_stock_context()` → `cumulative_returns()`, `max_drawdown_series()`, `rolling_sharpe()`
+
+---
+
+### P3 — Return Contribution
+**Current × Portfolio** · "Which positions drove portfolio return recently?"
+
+```
+HEADLINE:    "Portfolio — Return Contribution"
+QUESTION:    Who made us money and who cost us?
+
+CHIPS:
+  Portfolio 1m Ret  |  Top Contributor  |  Worst Detractor  |  Hit Rate  |  # Positions
+
+PANELS:
+  ┌──────────────────────────────────────────────┐
+  │  TOP: Waterfall Chart                          │
+  │                                                │
+  │  Classic attribution waterfall:                │
+  │  Start at 0 → each position adds/subtracts    │
+  │  → lands at portfolio total return             │
+  │  Bars colored green (gain) / orange (loss)     │
+  │  Width proportional to weight                  │
+  │  Top-10 individually, rest bucketed as "Other" │
+  ├──────────────────────┬─────────────────────────┤
+  │  BOTTOM LEFT:        │  BOTTOM RIGHT:           │
+  │  Contribution Table  │  Hit-Rate Donut          │
+  │                       │                           │
+  │  Ticker | Wt% |      │  Simple donut: % of       │
+  │  Return | Cont bps   │  positions with positive   │
+  │  (sorted by cont,    │  return vs negative,       │
+  │  top 10 + "Other")   │  with count labels         │
+  └──────────────────────┴─────────────────────────┘
+
+NARRATIVE:
+  "The portfolio returned {port_ret}% over the past month. {top_ticker}
+   was the largest contributor at {cont} bps ({weight}% weight ×
+   {ret}% return). {n_pos} of {total} positions were profitable
+   (hit rate {hit_rate}%)."
+
+JSON.panels:
+  waterfall:      [ {ticker, weight, return_1m, contribution_bps, running_total}, ... ]
+  contribution_table: [ {ticker, weight_pct, return_1m, contribution_bps}, ... ]
+  hit_rate:       { positive: 18, negative: 7, total: 25 }
+  portfolio_summary: { portfolio_return_1m, top_contributor, worst_detractor }
+```
+
+**Data sources:** `POST /batch/analyze` (portfolio mode), position weights × returns
+
+---
+
+### P4 — Portfolio vs Benchmark
+**History × Portfolio** · "Is the portfolio beating its benchmark over time?"
+
+```
+HEADLINE:    "Portfolio — Performance vs Benchmark"
+QUESTION:    What's the alpha trend and where did it come from?
+
+CHIPS:
+  Portfolio YTD  |  Benchmark YTD  |  Active Return  |  Info Ratio  |  Tracking Error
+
+PANELS:
+  ┌──────────────────────────────────────────────┐
+  │  TOP: Cumulative Return — Portfolio vs Bench   │
+  │                                                │
+  │  Two lines: portfolio and benchmark, rebased   │
+  │  Shaded area between = active return           │
+  │  (green when above, orange when below)         │
+  ├──────────────────────┬─────────────────────────┤
+  │  BOTTOM LEFT:        │  BOTTOM RIGHT:           │
+  │  Monthly Active      │  Rolling Info Ratio      │
+  │  Return Bars         │                           │
+  │                       │  63-day rolling IR line  │
+  │  Bar chart: monthly  │  with zero reference     │
+  │  portfolio - bench   │  line — is skill          │
+  │  return (green/      │  persistent or noisy?    │
+  │  orange by sign)     │                           │
+  └──────────────────────┴─────────────────────────┘
+
+NARRATIVE:
+  "The portfolio has {outperformed/underperformed} {benchmark} by
+   {active_ret}% over {months} months (annualised IR: {ir}). Active
+   return was positive in {pos_months} of {total_months} months.
+   Tracking error of {te}% implies {concentrated/diversified} active
+   bets."
+
+JSON.panels:
+  cumulative_vs_bench: { portfolio: [{date, cum_ret}], benchmark: [{date, cum_ret}] }
+  monthly_active:      [ {month, active_return_pct}, ... ]
+  rolling_ir:          [ {date, info_ratio_63d}, ... ]
+  summary_stats:       { active_return, info_ratio, tracking_error, positive_months, total_months }
+```
+
+**Data sources:** `POST /batch/analyze` (time-series), benchmark returns, portfolio weights history
+
+---
+
+## Implementation Priority
+
+```
+Phase 1 (now):   JSON serialization for S1 + S2 (proves the pipeline)
+Phase 2:         R1 = S1 rebuilt on SnapshotPage + narrative block
+                 P1 = first performance page (uses fetch_stock_context)
+                 P2 = equity curve (all helpers already exist in _data.py)
+Phase 3:         R2 = S2 rebuilt on SnapshotPage + narrative
+Phase 4:         R3, P3 = portfolio pages (need batch/portfolio mode)
+Phase 5:         R4, P4 = portfolio history (heaviest data lift)
+```
+
+---
+
+*Generated by RiskModels SDK · Consultant Navy Design System*

--- a/docs/VISUAL_COMPONENT_LIBRARY_PLAN.md
+++ b/docs/VISUAL_COMPONENT_LIBRARY_PLAN.md
@@ -1,0 +1,109 @@
+# Visual component library and /explore drill-down
+
+Roadmap for a shared chart component layer (Python SDK + riskmodels.app API + hybrid `/explore` pages).  
+Maintainers: keep this file in sync when phases ship; it mirrors the Cursor plan `visual_component_library_18810bd5`.
+
+## Implementation checklist
+
+- [ ] **Phase 1 — base:** Add `visuals/_base.py` + `visuals/components/`; define `schema_version` + shared `RenderOptions`.
+- [ ] **Phase 1 — waterfall:** Extract `VarianceWaterfallData` + builder from `waterfall.py`; keep `plot_variance_waterfall` as adapter or `from_data` entrypoint.
+- [ ] **Phase 1 — cascade:** Extract `RiskCascadeData` (and attribution variant if separate) + builders from `cascade.py`.
+- [ ] **Phase 1 — tests:** JSON round-trip + Plotly smoke tests for new component dataclasses.
+- [ ] **Phase 2 — schema:** Document visuals JSON schema (OpenAPI or JSON Schema); add `lib/visuals/*` TS builders matching Python.
+- [ ] **Phase 2 — routes:** `GET /api/visuals/waterfall` and hedge-cascade (JSON first; `png` query optional).
+- [ ] **Phase 3 — client:** Extend `ClientVisuals` with data-fetch helpers returning component dataclasses.
+- [ ] **Phase 4 — explore:** `/explore` pages (B hybrid): PNG hero by default + optional “Open interactive” Plotly from same JSON + copy snippets.
+
+## Locked decisions
+
+- **Explore / drill-down UX (choice B):** **Hybrid** — default to a **large static PNG** (high-res, fast, consistent with PDFs); add an **optional “Open interactive”** control that reveals **full Plotly** using the **same JSON** as `/api/visuals/*`. No separate business-logic path for the interactive chart.
+
+## Context (what already exists)
+
+- **[`sdk/riskmodels/visuals/`](../sdk/riskmodels/visuals/)** already centralizes several Plotly builders: [`waterfall.py`](../sdk/riskmodels/visuals/waterfall.py) (`plot_variance_waterfall`), [`cascade.py`](../sdk/riskmodels/visuals/cascade.py) (`plot_risk_cascade`, `plot_attribution_cascade`), [`l3_decomposition.py`](../sdk/riskmodels/visuals/l3_decomposition.py), MAG7 helpers, [`gallery.py`](../sdk/riskmodels/visuals/gallery.py), and a thin [`client_bridge.py`](../sdk/riskmodels/visuals/client_bridge.py) (`ClientVisuals` — mostly `save_*_png` facades).
+- **Snapshots** ([`R1Data`](../sdk/riskmodels/snapshots/r1_risk_profile.py), [`P1Data`](../sdk/riskmodels/snapshots/p1_stock_performance.py), [`DDData`](../sdk/riskmodels/snapshots/stock_deep_dive.py)) are page-level dataclasses; chart logic is mixed into snapshot/render modules and [`snapshots/_plotly_charts.py`](../sdk/riskmodels/snapshots/_plotly_charts.py).
+- **`alpha_forensic.py`** is not in this repo; the forensic reference is called out in [`snapshots/_base_template.py`](../sdk/riskmodels/snapshots/_base_template.py) / style comments — Phase 1 should mine **this repo’s** snapshot + `visuals/` code, not an external path.
+- **Portal constraint:** [`app/api/metrics/[ticker]/snapshot.png/route.ts`](../app/api/metrics/[ticker]/snapshot.png/route.ts) uses **TypeScript + Playwright** for PNG when enabled — not inline Python on the request path. Any plan that says “each API route calls the Python SDK” needs a **deployment story** (see Phase 2).
+
+## Target shape (aligned with sketch, grounded in repo)
+
+```mermaid
+flowchart LR
+  subgraph sdk [Python SDK]
+    CD[Component dataclasses]
+    RF[Render fns Plotly]
+    CB[client.visuals facades]
+    CD --> RF
+    CB --> CD
+  end
+  subgraph api [riskmodels.app API]
+    JSON[GET JSON contract]
+    PNG[GET PNG optional]
+    JSON --> TSBuild[TS builds payload OR worker]
+    PNG --> PW[Playwright or Python worker]
+  end
+  subgraph web [Next.js]
+    EXP["/explore hybrid UI"]
+    EXP --> PNG
+    EXP --> JSON
+  end
+  sdk -. schema parity .- api
+```
+
+- Add **`sdk/riskmodels/visuals/components/`** for **small, chart-only dataclasses** + **serialization** (`to_dict` / `from_dict` or shared schema version field), not a second copy of every plot function on day one.
+- Add **`sdk/riskmodels/visuals/_base.py`** (or `component_base.py`) for shared types: e.g. `RenderOptions`, `VisualSchemaVersion`, optional `lineage`/`teo` blobs — keep it minimal until patterns repeat.
+- **Keep** `R1Data` / `P1Data` / `DDData`: they **compose** component payloads (either embed dataclasses or build them inside `get_data_for_*`).
+
+## Phase 1 (low disruption) — extract first components from existing visuals
+
+**Priority pair (already implemented as functions):**
+
+1. **Variance waterfall (portfolio)** — today: `plot_variance_waterfall` takes `per_ticker`, `weights`, etc. Introduce e.g. `VarianceWaterfallData` holding the **minimal derived series** (labels, segment values, measure types, optional sigma mode flag) + a function `build_variance_waterfall_data(...)` from `PortfolioAnalysis` inputs, then `plot_variance_waterfall_from_data(data)` (thin wrapper) to avoid breaking gallery/tests.
+2. **Risk / attribution cascade** — same pattern in `cascade.py`: `RiskCascadeData` / builders + `plot_*_from_data`.
+
+**Follow-ons (still Phase 1 if time):**
+
+- **Single-ticker L3 horizontal** from `l3_decomposition.py` → `L3DecompositionData`.
+- **Mekko / MAG8:** no `mag8_mekko.py` yet — treat as **new** component after the first two are stable; reuse naming from portfolio math / future R3 spec.
+
+**Tests:** add round-trip tests `Data → dict → Data` and a smoke test that `plot_*_from_data` returns a non-empty Plotly figure for a tiny synthetic frame.
+
+## Phase 2 — `/api/visuals/*` on riskmodels.app
+
+**Reality check:** Vercel route handlers won’t reliably `import riskmodels` unless you add a **Python render service**, subprocess, or remote worker. Recommended approach:
+
+- **JSON responses:** implement **TypeScript builders** in `lib/visuals/` that use existing DAL ([`lib/dal/risk-engine-v3.ts`](../lib/dal/risk-engine-v3.ts), [`lib/portfolio/portfolio-risk-core.ts`](../lib/portfolio/portfolio-risk-core.ts)) and emit payloads that match the **Python dataclass JSON schema** (document the schema in [`OPENAPI_SPEC.yaml`](../OPENAPI_SPEC.yaml) or a small `schemas/visuals/*.json`).
+- **PNG/PDF:** reuse patterns from `snapshot.png` / PDF routes: Playwright or existing PDF pipeline; optionally add a **CI or worker** that runs Python for pixel-perfect parity with SDK.
+
+**First routes (examples):**
+
+- `GET /api/visuals/waterfall` — query: `positions` JSON or portfolio id (if you have one); returns `VarianceWaterfallData` JSON.
+- `GET /api/visuals/hedge-cascade` — same; `level=l2|l3` query param.
+
+Optional `?format=png` can proxy to the same PNG machinery as snapshots once a React “chart page” template exists.
+
+## Phase 3 — SDK `client.visuals` bridge
+
+Extend `ClientVisuals` beyond PNG savers, e.g.:
+
+- `client.visuals.variance_waterfall_data(positions)` → fetch metrics/batch → `PortfolioAnalysis` → `VarianceWaterfallData`.
+- `client.visuals.risk_cascade_data(...)` — same.
+
+Keep **lazy imports** to avoid heavy deps on import. `.plot()` can be methods on the dataclass (optional) or module-level `plot(data)` to stay testable.
+
+## Phase 4 — `/explore` drill-down (**B — hybrid**, locked above)
+
+- **Default view:** large **static PNG** (fast, consistent with PDFs), generated via the same route/worker as other snapshots.
+- **Secondary control:** “Open interactive” expands a **Plotly** panel fed by the **same JSON** contract as `/api/visuals/*` (no duplicate business logic in the page — only presentation).
+- Page chrome: collapsible JSON viewer, curl + Python snippet (reuse patterns from docs portal if any), export buttons calling `?format=png` / PDF when available.
+
+**Routing sketch:** `/explore/ticker/[ticker]/waterfall`, `/explore/ticker/[ticker]/hedge-cascade` (names TBD); `/explore` index lists teaser cards linking to these.
+
+## Out of scope for “this week” unless explicitly pulled in
+
+- Full MAG8 Mekko + R3 portfolio ID flow.
+- Rewriting all snapshot renderers to components in one pass — migrate **incrementally** after waterfall + cascade prove the pattern.
+
+## Documentation (follow-up)
+
+- Update [`SNAPSHOT_FRONTEND_ARCH.md`](SNAPSHOT_FRONTEND_ARCH.md) (or a short `VISUAL_COMPONENTS.md`) with: dataclass list, JSON schema version, and TS/Python parity rules.

--- a/docs/legal/affiliate-program.md
+++ b/docs/legal/affiliate-program.md
@@ -1,0 +1,141 @@
+# RiskModels Affiliate Program — Terms
+
+**Current version: v1.2** · Effective on the date you accept via the dashboard banner or email reply.
+
+> **This document is the source of truth.** The page rendered at
+> `riskmodels.net/terms/affiliate` mirrors this file. Bump the version
+> string at the top, append a new section to the changelog, and ship —
+> the active re-consent banner in `/affiliate` blocks every affiliate
+> dashboard until they accept the new version.
+
+---
+
+## What this program is
+
+Blue Water Macro Corp ("we", "RiskModels") runs an affiliate program that pays you a percentage of revenue we collect from API customers you refer. You ("Affiliate") get a unique referral code; people who use that code when picking up an API key are attributed to you, and we share commission on what they pay us.
+
+This is a referral / revenue-share arrangement. It is not employment, partnership, or agency. You are an independent contractor for tax and legal purposes; you are responsible for your own taxes on any commission paid.
+
+## How attribution works
+
+1. We give you a referral code (e.g. `RM-ABC123`) and a share link of the form `https://riskmodels.app/get-key?ref=YOUR_CODE`.
+2. When someone clicks the link, we log the visit (referral code, timestamp, hashed IP, hashed user-agent, source URL, UTM parameters). This is a **leading indicator** — it tells you the link is working before any signup happens. We do not store raw IPs or unhashed user-agent strings.
+3. If that visitor creates an API key in the same browser session, the key is attributed to you. The attribution is permanent for that key for as long as it exists, regardless of whether you remain in the program.
+4. As that key spends money on API usage, we calculate commission per the rate that was in effect for you **at the time the key was created** (see "Commission rate" below).
+
+If you want to publish posts using our content tools (e.g. the post-builder Colab notebook we ship to affiliates), we additionally log:
+- Which affiliate generated which chart
+- Mode (single-stock or comparison) and tickers used
+- Optional self-reported post URLs you submit via your dashboard
+
+These are tied to your account and used only for our internal reporting and your own dashboard.
+
+## Commission rate
+
+**The commission rate effective for you at the moment a referred key is created is the rate that key earns for its lifetime.** This is the most important sentence in this document and we want to be unambiguous about it.
+
+- Default rate is published on your dashboard.
+- We may negotiate a different rate with individual affiliates.
+- We may change rates with at least **14 days' written notice** (email + dashboard banner).
+  - The new rate applies only to **keys created after the change effective date**.
+  - All keys created before the change continue to earn at their original locked rate.
+  - We will not retroactively re-price historical referrals.
+
+This rule protects you from rate cuts and protects us from runaway costs if we raise the headline rate later. It also means a key created at 30% will keep paying you 30% of its revenue forever, even if we drop the public rate to 10% for new affiliates next year.
+
+## Payouts
+
+- We compute commission earned on a rolling basis from billed revenue (not from estimated or quoted revenue).
+- Payouts are processed manually for now. When your balance reaches a meaningful threshold (typically $100+), we send to the payout email on file.
+- You can update your payout email or method by replying to `service@riskmodels.app`.
+- Standard payment methods: ACH (US), Wise (international), or USDC. Check or wire by arrangement.
+- We do not pay commission on chargebacks, refunds, or fraud. If a referred customer chargebacks an invoice, the corresponding commission is reversed from your balance.
+
+## Status lifecycle
+
+Your account moves through these states. We will give you notice before any change to a less-favorable status.
+
+| Status | What it means |
+|---|---|
+| **`active`** | Normal. New referrals attribute, existing referrals pay commission. |
+| **`dormant`** | No referral-link clicks, post-builder activity, or new signups in the last 60 days. We send you a "still interested?" email. New referrals still attribute, existing referrals still pay. |
+| **`paused`** | After 30 additional days dormant with no response, or by request, or if you violate these terms. **No new referrals attribute**, but existing referrals continue paying commission. You can request reactivation at any time. |
+| **`terminated`** | Final state. **No new referrals attribute and no future commissions on existing referrals.** We pay out any remaining balance within 30 days of termination. |
+
+We may move you to `paused` or `terminated` for: violation of the posting standards (below), repeated terms violations, fraud, or material breach. We will tell you why in writing.
+
+You may move yourself to `paused` or `terminated` at any time by emailing `service@riskmodels.app`.
+
+## Posting standards
+
+When you post or share content using the program, you must:
+
+1. **Disclose the affiliate relationship.** A one-line disclosure ("I get a referral credit if you sign up") in the post or as a comment. This is FTC-required in the US and standard practice elsewhere.
+2. **Don't misrepresent the product.** Don't claim performance, accuracy, or features that aren't real. Cite the chart you generated; don't invent numbers.
+3. **Don't spam.** Respect each platform's rules (subreddit posting cadence, LinkedIn group rules, etc.). Repeated platform bans are grounds for `paused` status.
+4. **No paid traffic / SEO clickfarms.** Commission must come from organic content. Bot traffic, incentivized clicks, paid review farms, and similar tactics will result in `terminated` status and forfeiture of pending commission.
+5. **No impersonation.** Don't claim to work for RiskModels or imply endorsement beyond the affiliate relationship.
+
+## Display handle for chart watermarks
+
+If you use our chart-generation tools (the post-builder notebook, SDK snapshots, etc.), the chart includes a small attribution string of the form `via @{your_display_handle} on riskmodels.app`. This is what credits you publicly when someone screenshots and shares your work.
+
+- We set your `display_handle` from the local-part of your account email by default. You can request a different handle at any time.
+- Handles must be 2–30 characters, lowercase alphanumerics + dot/underscore/hyphen.
+- We reserve the right to reject handles that impersonate other people, contain offensive content, or are misleading (e.g. "official", "rm_admin").
+- Suppressing the watermark requires our written approval — typically reserved for institutional partners under separate agreement.
+
+## Program changes and wind-down
+
+We may change these terms at any time. Material changes (anything affecting the math of how you get paid, what we track, or your status lifecycle) trigger the active re-consent banner on your dashboard. You cannot use the dashboard until you accept the new version.
+
+If you decline the new terms, your status moves to `declined_terms_v{N}`. Existing referrals continue earning at their **previously-locked rate** under the previously-accepted terms; no new attributions are accepted. We pay out your final balance within 30 days.
+
+We may also wind down the program entirely. Two paths, our choice depending on circumstances:
+
+1. **Sunset.** New attributions stop on a public effective date. Existing referrals continue earning commission at their locked rates for **6 months** after the effective date (the "tail period"). At the end of the tail, we pay all remaining balances and the program closes.
+2. **Termination.** New attributions stop on a public effective date. **No further commissions accrue from that date**, including on existing referrals. We pay all balances owed within 30 days.
+
+We will give at least **30 days' notice** before either action. We will default to Sunset unless circumstances make Termination necessary (regulatory, fraud, business closure, etc.).
+
+## Privacy
+
+Tracking we do that touches third parties:
+- **Referral-link clicks**: visitor's IP and user-agent are SHA-256-HMAC hashed with a server-side salt before storage. Raw values are not retained. Used for click counts and unique-visitor estimates.
+- **Post-builder API usage**: standard API request logging (account, capability, latency, cost) plus metadata describing the post-builder action (mode, tickers).
+- **Self-reported post URLs**: if you paste a Reddit/Twitter/LinkedIn URL into your dashboard, we store it. We do not crawl or fetch the page beyond the host name (used to auto-classify the channel).
+
+This program-specific tracking is in addition to whatever's in our general privacy policy at `riskmodels.app/privacy`. If those conflict, the privacy policy controls for non-affiliate users; this section controls for affiliate-related data.
+
+## Disclaimers and liability
+
+- **No exclusivity.** You can promote competing products. We can sign other affiliates targeting the same audience.
+- **No guarantee of revenue.** We don't promise any specific commission outcome. Most affiliates take 4–8 weeks to see meaningful revenue.
+- **No employment relationship.** Nothing here makes you our employee, partner, or agent. You can't bind us to anything; we can't bind you.
+- **Liability cap.** Our total liability under this program is capped at the greater of (a) commission paid to you in the 12 months before the claim, or (b) $500. We are not liable for indirect, consequential, or special damages.
+- **Governing law.** These terms are governed by the laws of the State of California, USA. Disputes resolved in San Francisco.
+
+## How to contact us
+
+`service@riskmodels.app` for anything: payout method changes, status changes, terms questions, content reviews, complaints about other affiliates' behavior. We aim to reply within 2 business days.
+
+---
+
+## Changelog
+
+### v1.2 — *current*
+
+Material changes from v1.1:
+
+1. **Commission-rate locking made explicit.** The rate effective at the time a referred key is created is the rate that key earns for life. Previously this was implied by code behavior; now it is stated in the contract. (See "Commission rate".)
+2. **Status lifecycle defined.** Introduces `dormant` (60d inactivity flag) and clarifies `paused` vs `terminated` semantics. (See "Status lifecycle".)
+3. **Wind-down terms.** Defines the Sunset (6-month tail) vs Termination (30-day final settlement) paths and our 30-day notice obligation. (See "Program changes and wind-down".)
+4. **Click-tracking disclosure.** Discloses HMAC hashing of visitor IP/UA on referral-link clicks and the leading-indicator funnel in your dashboard. (See "How attribution works" and "Privacy".)
+
+These are clarifications — they describe behavior we've designed into the platform. None of them retroactively change anything about referrals attributed before v1.2's effective date.
+
+### v1.1 — superseded
+
+- Active re-consent banner introduced
+- Display-handle column for chart-watermark attribution
+- Earlier baseline. *(Pre-v1.1 history not preserved in source control; v1.1 was the first version with a documented version string.)*

--- a/docs/plans/AOM_plan.md
+++ b/docs/plans/AOM_plan.md
@@ -1,0 +1,137 @@
+# Analysis Object Model (AOM) — Implementation Plan
+
+**Status:** Superseded for day-to-day execution — see [aom_v1_sdk_execution_plan.md](./aom_v1_sdk_execution_plan.md) (locked SDK plan).  
+**Verdict (historical):** Approximately 90–95% there — good enough to build on.
+
+> Remaining work before SDK was structural clarity, not new ontology: close ambiguity leaks so implementations do not diverge.
+
+---
+
+## What is clearly solid (commit)
+
+| Element | Status |
+|---------|--------|
+| AOM sits above the API (compiler → PostgREST tables) | Committed |
+| Lens = three only (return_attribution, risk_decomposition, exposure) | Committed |
+| Hedge moved to chain (kind: "hedge_action"), not a lens | Committed |
+| View vs OutputMode clean (no summary view) | Committed |
+| Subjects usable (stock, portfolio, universe, comparison) | Committed |
+| Compiler formalized (AOM → ExecutionPlan → REST) | Committed |
+| Agents doctrine defined (docs/agents.md) | Committed |
+
+This is a coherent reasoning model, not only a schema.
+
+---
+
+## Normative checklist — seven items before SDK
+
+These are blocking for SDK freeze as documented behavior (not optional opinions).
+
+### Five structural fixes
+
+| # | Requirement | Normative content |
+|---|-------------|-------------------|
+| 1 | attribution_mode | `"incremental"` \| `"cumulative"` — default incremental. Valid only when lens ∈ return_attribution, risk_decomposition. |
+| 2 | Typed chain (no stringly stages) | `ChainStage = kind: "analyze"` (with lens, optional resolution, view, attribution_mode) or `kind: "hedge_action"` (optional depends_on). Forbidden: top-level key "stage" as stage discriminator. |
+| 3 | as_of on scope | `"latest"` \| `"YYYY-MM-DD"`. Rule (normative): when view is snapshot and as_of is present, as_of overrides date_range for selecting the snapshot row / effective observation date (avoids hacks for "latest exposure", "month-end risk", "current snapshot"). Timeseries rules remain as in SPEC. |
+| 4 | Comparison execution | Structure includes alignment: e.g. `{ "date_range": "shared", "normalize": true }`. Normative sentence: Comparison subjects are executed as independent analyses per leg and aligned post hoc according to alignment rules (SDK/compiler must not invent divergent merge semantics). |
+| 5 | Explanation contract | Includes `confidence: high \| medium \| low` in addition to headline, key_drivers, optional_metrics. |
+
+### Two small improvements
+
+| # | Requirement | Normative content |
+|---|-------------|-------------------|
+| 6 | Error contract | If analysis cannot complete: return structured error. If output_mode: explanation still emitted: degrade gracefully (no silent failure). |
+| 7 | Chain semantics | Chains execute sequentially by default. depends_on overrides straight-line ordering when a non-linear dependency is required. |
+
+---
+
+## Reconciliation — shipped artifacts (read when locking)
+
+As of the last audit against **`RiskModels_API/aom/`** and cross-repo agent docs:
+
+| # | Status |
+|---|--------|
+| 1–2 | attribution_mode and kind-based ChainStage appear implemented in SPEC + TS + examples (no `"stage"` key in `aom/`). |
+| 3 | as_of present — confirm SPEC explicitly states snapshot override rule (§Normative #3); align wording if only precedence prose exists. |
+| 4–5 | alignment + confidence present — confirm post hoc comparison sentence matches §Normative #4. |
+| 6–7 | May be partially folded into explanation fallback — elevate to explicit sections per §Normative. |
+
+---
+
+## Reasoning axes (canonical framing)
+
+| Axis | Primitives |
+|------|------------|
+| 1 — What | subject + scope |
+| 2 — How | lens + resolution + attribution_mode |
+| 3 — Output | view + output_mode |
+| 4 — Workflow | chain + ChainStage[] |
+
+---
+
+## Final verdict (plan intent)
+
+After the normative checklist is fully reflected in AOM_SPEC.md (and types/agents where needed):
+
+> **Stop designing and start building.**
+
+Past diminishing returns on abstraction — ship minimal SDK builder, then harden.
+
+### Bottom line
+
+Crossed from "good abstraction" to "system that won't collapse under real usage" once the seven items are locked in prose and types.
+
+Suggested canonical next artifact: tight, production-ready AOM_SPEC.md as the single doc agents + SDK + users orbit — achieved by applying §Normative checklist + freeze.
+
+---
+
+## Execution order (post-freeze)
+
+1. Update / finalize AOM_SPEC.md against §Normative checklist (including snapshot as_of rule and comparison sentence).
+2. Lock AOM_TYPES.ts export surface (tag/version).
+3. Build minimal SDK builder (avoid overbuilding).
+4. Smoke tests: TSLA; portfolio; comparison; exposure → hedge chain.
+
+---
+
+## Strategic placement
+
+AOM lives in **this repo** under [`aom/`](../aom/) next to [`OPENAPI_SPEC.yaml`](../../OPENAPI_SPEC.yaml). Agent constitution for callers remains in **ERM3** [`docs/agents.md`](../../../ERM3/docs/agents.md) (links back here). No breaking REST renames.
+
+---
+
+## Deliverables (RiskModels_API root)
+
+| Path | Role |
+|------|------|
+| [`aom/AOM_SPEC.md`](../aom/AOM_SPEC.md) | Canonical spec |
+| [`aom/AOM_TYPES.ts`](../aom/AOM_TYPES.ts) | Strict TS types |
+| [`aom/AOM_SKILLS.md`](../aom/AOM_SKILLS.md) | Intent shorthand |
+| [`aom/AOM_MIGRATION.md`](../aom/AOM_MIGRATION.md) | Compiler ↔ REST |
+| [`aom/SDK_REFACTOR_PLAN.md`](../aom/SDK_REFACTOR_PLAN.md) | SDK rollout |
+
+Related (ERM3): [`docs/agents.md`](../../../ERM3/docs/agents.md) — agent rules linking to this `aom/` folder.
+
+---
+
+## Diagram
+
+```
+flowchart LR
+  subgraph axes [Reasoning]
+    S[subject scope]
+    H[lens resolution attribution_mode]
+    P[view output_mode]
+    W[chain]
+  end
+  axes --> Compiler[AOM Compiler]
+  Compiler --> Plan[ExecutionPlan]
+  Plan --> API[REST tables]
+```
+
+---
+
+## Historical note
+
+Invalid pattern from early drafts: `"stage": "analyze"`. Canonical stages use `kind: "analyze" | "hedge_action"` only.

--- a/docs/plans/F1_CANONICAL_SPEC.md
+++ b/docs/plans/F1_CANONICAL_SPEC.md
@@ -1,0 +1,315 @@
+# F1 Canonical Snapshot — implementation spec for Cursor Composer
+
+**Status:** Ready to implement
+**Owner:** Cursor Composer 2 fast (or any agent picking this up)
+**Reviewer:** Conrad Gann
+**Estimated:** ~5 hours mechanical
+
+This spec is **prescriptive**. Don't redesign. Don't add features beyond what's listed. The architecture has been settled in the conversation that produced this doc — your job is to mirror the existing P1 implementation onto F1, with the differences spelled out below. If you find yourself making a design choice that isn't in this spec, stop and surface it.
+
+---
+
+## Goal
+
+Add `CanonicalFundSnapshot` to the public SDK at `RiskModels_API/sdk/riskmodels/snapshots/`, mirroring the existing `CanonicalStockSnapshot` (P1) pattern. Land contract tests and CLI-gate coverage that mirror the existing P1 9-gate contract. Use a synthetic fixture; do not attempt to read real fund zarr data (a per-fund zarr reader is a separate task).
+
+When this lands: the F1 contract architecture exists, the schema is enforced by tests, and the moment a real per-fund zarr reader ships, AGTHX renders against an enforced contract from day one.
+
+---
+
+## Read these first (mandatory)
+
+The P1 implementation is the template. Read all of these before writing anything:
+
+1. **`sdk/riskmodels/snapshots/canonical.py`** — the `CanonicalStockSnapshot` dataclass + `from_components` adapter + JSON I/O. **Copy this structure for F1; do not invent a new pattern.**
+2. **`sdk/riskmodels/snapshots/_stock_data.py`** — `P1Data` dataclass with `to_json` / `from_json`. The fund equivalent (`FundData`) will follow this exact shape.
+3. **`sdk/tests/test_canonical_snapshot.py`** — synthetic round-trip test using `__TEST__` identity. Mirror this for F1 with `__TEST_FUND__` identity.
+4. **`sdk/tests/test_canonical_snapshot_contract.py`** — real-fixture contract test parametrized over fixtures. Mirror the structure; the F1 version is parametrized over `*_f1_cache.json` fixtures (will only run when a fixture exists; gracefully skips otherwise).
+5. **`sdk/riskmodels/snapshots/contract_check.py`** — CLI gate. Add an F1 mode (e.g. `--f1` flag or a separate entry point) that runs the same gate suite against F1 fixtures.
+6. **`docs/architecture/CANONICAL_INTELLIGENCE_OBJECTS.md`** (in BWMACRO) — particularly §3 (Temporal perspective), §4 (Snapshot taxonomy), §5 (Ontology versioning), §8 (Round-trip contract testing). This locks the vocabulary.
+
+You should also know: the BWMACRO repo has a private `FundData` and `f1_tearsheet.py` that produce the institutional render. **Do not import from `bwmacro.*`.** The public canonical layer is self-sufficient — it never imports from BWMACRO. Mirror P1's discipline.
+
+---
+
+## Constraints
+
+- **Do not modify P1.** P1 is contract-frozen. Don't refactor `canonical.py` to "share more between P1 and F1" — copy the structure, keep them separate. Premature deduplication will create coupling that breaks the freeze.
+- **Do not populate `Judgment` in F1.** The field exists on the canonical (forward-compatible), but stays `None`. Editorial overlays come from BWMACRO's `derive_judgment_for_fund` (not yet built); the public SDK consumer gets the data, not the prose.
+- **Do not redesign the AOM provenance block.** Reuse `AomProvenance` as-is. F1's `composition="F1"`, `subject_type="fund"`. Lenses are the same as P1 (`return_attribution`, `risk_decomposition`, `exposure`).
+- **Do not add `attribution_source` or `coverage` fields to `PerformanceAttribution`.** Earlier draft proposed these; the current design is that F1 and M1 share the analytics block verbatim and differ only on identity / peer cohort.
+- **Do not implement M1.** M1 (13F filer composition) reuses the F1 dataclass with a different composition code and is deferred to taxonomy v2. Out of scope for this task.
+- **Do not implement a real `FundData` adapter from zarr.** Synthetic only. The per-fund zarr reader is its own task.
+- **Use `CANONICAL_ONTOLOGY_VERSION = "riskmodels-ontology/2.0"`.** F1 inherits the v2 ontology with `TemporalContext` populated.
+
+---
+
+## Deliverables
+
+### 1. Schema
+
+Create new file `sdk/riskmodels/snapshots/canonical_fund.py`. Mirror `canonical.py` structure:
+
+```python
+"""Canonical Fund Snapshot — public contract for F1 (and future M1) artifacts.
+
+Mirrors :mod:`canonical` for stocks. The analytical heart (PerformanceAttribution,
+RiskDecomposition, HedgeBasis, MacroBasis) is identical to the stock canonical —
+both derive from a holdings-reconstructed portfolio. Funds and 13F filers diverge
+only on identity, peer-cohort dimensions, and filing-lag semantics.
+"""
+
+CANONICAL_FUND_SCHEMA_VERSION = "canonical-fund/1.0"
+
+@dataclass(frozen=True)
+class FundIdentity:
+    """Stable identity band for a fund or 13F filer.
+
+    F1 (registered fund): populates fund_family, share_classes, expense_ratio.
+    M1 (13F filer): populates filer_type, aum_tier, cik, adviser_relationships
+                    via filer_metadata.
+    """
+    symbol_id: str                       # canonical fund / filer id (e.g. "BW-FUND-AGTHX")
+    name: str                            # fund / filer display name
+    as_of: str                           # ISO date
+    fund_family: str | None = None       # F1 only
+    share_class_count: int | None = None # F1 only
+    expense_ratio: float | None = None   # F1 only
+    aum_usd: float | None = None         # both
+    inception_date: str | None = None    # F1 only
+    filer_metadata: FilerMetadata | None = None  # M1 only
+
+@dataclass(frozen=True)
+class FilerMetadata:
+    """13F filer-specific identity fields. Populated for M1, None for F1."""
+    cik: str
+    filer_type: str | None = None        # e.g. "investment_adviser", "bank", "insurance"
+    aum_tier: str | None = None          # e.g. "small", "mid", "large", "mega"
+    coverage: str = "equity_sleeve"      # M1 documents that 13F is equity-only
+
+@dataclass(frozen=True)
+class HoldingRow:
+    """One position in a fund's reconstructed portfolio at as_of."""
+    ticker: str
+    weight: float                        # 0–1, fraction of equity sleeve
+    market_value_usd: float | None = None
+    shares: float | None = None
+
+    # Decomposed contribution to portfolio variance/return
+    market_share: float | None = None
+    sector_share: float | None = None
+    subsector_share: float | None = None
+    residual_share: float | None = None
+
+@dataclass(frozen=True)
+class FundPortfolio:
+    """Holdings detail block — top-N positions with decomposition."""
+    holdings: list[HoldingRow] = field(default_factory=list)
+    total_holdings_count: int = 0        # full universe; len(holdings) may be top-N truncated
+    coverage_pct: float | None = None    # sum of weights covered by `holdings` (0–1)
+
+@dataclass(frozen=True)
+class CanonicalFundSnapshot:
+    """Public contract for F1 / M1 fund-shape snapshots."""
+    schema_version: str                  # "canonical-fund/1.0"
+    generated_utc: str
+
+    identity: FundIdentity
+    core_metrics: CoreMetrics            # REUSE from canonical.py — import don't redefine
+    performance: PerformanceAttribution  # REUSE
+    risk: RiskDecomposition              # REUSE
+    portfolio: FundPortfolio             # NEW for F1/M1
+
+    peer: PeerContext | None = None      # REUSE; cohort dimension differs by composition
+    hedge: HedgeBasis | None = None      # REUSE
+    macro: MacroBasis | None = None      # REUSE
+
+    judgment: Judgment | None = None     # REUSE; populated by BWMACRO, None in public SDK
+    aom: AomProvenance | None = None     # REUSE; composition="F1" or "M1"
+    temporal: TemporalContext | None = None  # REUSE
+
+    ontology_version: str = CANONICAL_ONTOLOGY_VERSION
+
+    def to_json(self, path): ...        # mirror CanonicalStockSnapshot.to_json
+    @classmethod
+    def from_json(cls, path): ...       # mirror CanonicalStockSnapshot.from_json
+```
+
+**Reuse rules:**
+- Import `CoreMetrics`, `PerformanceAttribution`, `AttributionPoint`, `RiskDecomposition`, `DecompositionPoint`, `PeerContext`, `PeerRow`, `HedgeBasis`, `MacroBasis`, `TemporalContext`, `OBSERVATION_MODES`, `AomProvenance`, `CANONICAL_ONTOLOGY_VERSION` from `canonical.py`.
+- New types only: `FundIdentity`, `FilerMetadata`, `HoldingRow`, `FundPortfolio`, `CanonicalFundSnapshot`.
+- New constant: `CANONICAL_FUND_SCHEMA_VERSION = "canonical-fund/1.0"`.
+
+### 2. Adapter
+
+Create `from_fund_components(fund_data, *, generated_utc=None, judgment=None, aom_provenance=None, temporal=None) -> CanonicalFundSnapshot` adapter, mirroring `from_components(p1, ...)` for P1.
+
+Until a real `FundData` exists in the public SDK, define a minimal stub `FundData` dataclass in the same file (or in a new `_fund_data.py` next to `_stock_data.py`). It needs the fields the adapter reads — for the synthetic fixture, just enough to populate the canonical: `symbol_id`, `name`, `teo`, `aum_usd`, `holdings: list[dict]`, `portfolio_metrics: dict`. Mark the stub class with a docstring noting that it'll be replaced when the per-fund zarr reader ships.
+
+**Default AOM provenance for F1:**
+
+```python
+aom = aom_provenance or AomProvenance(
+    composition="F1",
+    subject_type="fund",
+    subject_id=fund_data.symbol_id,
+    as_of=fund_data.teo,
+    lenses=["return_attribution", "risk_decomposition", "exposure"],
+    resolution="full_stack",
+    view="snapshot",
+    attribution_mode="incremental",
+    observation_mode=temporal_context.observation_mode,
+)
+```
+
+**Default temporal context for F1** (N-PORT typical: ~60d filing lag):
+
+```python
+temporal_context = temporal or TemporalContext(
+    observation_mode="knowledge",
+    report_date=fund_data.teo,
+    filing_date=fund_data.filing_date_or_teo,  # accept either; default to teo if filing_date absent
+    extracted_at=None,
+)
+```
+
+If `fund_data` doesn't carry `filing_date`, default `filing_date = report_date` and document the assumption in the docstring (synthetic fixture has them equal). Real F1 fund data will carry both.
+
+### 3. Exports
+
+Update `sdk/riskmodels/snapshots/__init__.py` to export:
+- `CanonicalFundSnapshot`, `FundIdentity`, `FilerMetadata`, `HoldingRow`, `FundPortfolio`
+- `CANONICAL_FUND_SCHEMA_VERSION`
+- `from_fund_components`
+- `FundData` (the stub for now)
+
+Add to `__all__`.
+
+### 4. Synthetic-data round-trip test
+
+New file `sdk/tests/test_canonical_fund_snapshot.py`. Mirror `test_canonical_snapshot.py`. Build a `__TEST_FUND__` synthetic snapshot with realistic-shaped fields:
+
+- `FundIdentity(symbol_id="__TEST_FUND__", name="Test Fund, Inc.", as_of="2026-05-08", fund_family="Test Family", expense_ratio=0.005, aum_usd=1.0e10)`
+- `FundPortfolio(holdings=[HoldingRow("AAPL", 0.08, ...), HoldingRow("MSFT", 0.07, ...), ...], total_holdings_count=120, coverage_pct=0.85)` — five or so holdings is enough.
+- All other blocks populated with sensible synthetic values (variance shares sum to ~1.0, performance window over 1Y, etc.).
+
+Tests:
+1. **`test_schema_round_trip`** — dump → reload → equal. Mirrors P1's identical test.
+2. **`test_optional_sections_can_be_absent`** — peer / hedge / macro / judgment / aom / temporal can all be `None`; round-trip preserves.
+3. **`test_filer_metadata_optional`** — when `filer_metadata` is None (F1 case) round-trip preserves None; when populated (M1 case) round-trips equal.
+
+### 5. Real-fixture contract test
+
+New file `sdk/tests/test_canonical_fund_snapshot_contract.py`. Mirror `test_canonical_snapshot_contract.py` shape exactly:
+
+- Discover fixtures via glob pattern `*_f1_cache.json` in the same `sdk/riskmodels/snapshots/output/` directory the P1 fixtures live in. (No real F1 fixtures exist yet; the test will skip cleanly via the existing `pytest.skip(allow_module_level=True)` pattern.)
+- Parametrized over fixtures (will just be empty initially).
+- For each fixture: 9 gates, mirroring the P1 list:
+  1. `test_adapter_idempotent` — `from_fund_components` deterministic with pinned `generated_utc`.
+  2. `test_json_serialization_stable`
+  3. `test_json_round_trip`
+  4. `test_invariants` — schema_version, ontology_version, identity preservation, variance shares sum check
+  5. `test_aom_provenance_populated_and_valid` — composition="F1", subject_type="fund", lenses in vocabulary
+  6. `test_aom_provenance_round_trip`
+  7. `test_temporal_context_populated_and_valid`
+  8. `test_temporal_round_trip`
+  9. `test_pdf_renders` — *skip this one for now*. Render path is reference renderer for funds, not yet built. Add a `@pytest.mark.skip(reason="F1 reference renderer not yet implemented")` placeholder so the slot exists.
+
+Plus one F1-specific gate:
+
+10. `test_portfolio_invariants` — `coverage_pct` is in [0,1], all holding weights in [0,1], `len(holdings) <= total_holdings_count`.
+
+### 6. CLI gate extension
+
+Update `sdk/riskmodels/snapshots/contract_check.py` to add a `--composition` flag (or auto-detect from fixture filename pattern):
+- `python -m riskmodels.snapshots.contract_check --all` continues to check P1 fixtures (current behavior, unchanged).
+- `python -m riskmodels.snapshots.contract_check --all --composition f1` discovers `*_f1_cache.json` fixtures and runs the F1 gate suite.
+- Auto-detection by suffix is also acceptable — `*_p1_cache.json` → P1 path, `*_f1_cache.json` → F1 path.
+
+Reuse the existing `check_one(...)` structure. Define `check_one_fund(...)` in parallel that runs the F1 gate set. Don't try to unify the two — copy-paste with adjustments is the right call.
+
+### 7. Synthetic fixture (optional, only if useful for round-tripping)
+
+You may write `__TEST_FUND___f1_cache.json` to the output directory if it makes the contract test more useful. Otherwise leave the contract test skipping cleanly when no fixtures exist; real fixtures will land when the per-fund zarr reader ships.
+
+---
+
+## Acceptance criteria
+
+When you're done, all of these must hold. Run them and paste the output into your handoff.
+
+```bash
+cd RiskModels_API
+
+# Existing P1 tests still pass — no regressions
+python -m pytest sdk/tests/test_canonical_snapshot.py \
+                  sdk/tests/test_canonical_snapshot_contract.py \
+                  -p no:ethereum -q
+# Expected: 74 passed (or whatever the current count is — must not decrease)
+
+# New F1 synthetic round-trip tests pass
+python -m pytest sdk/tests/test_canonical_fund_snapshot.py \
+                  -p no:ethereum -q
+# Expected: 3 tests pass (round-trip, optional-sections, filer-metadata-optional)
+
+# F1 contract test runs, skips cleanly with no fixtures
+python -m pytest sdk/tests/test_canonical_fund_snapshot_contract.py \
+                  -p no:ethereum -q
+# Expected: skip message about no F1 fixtures present, exit 0
+
+# CLI P1 path unchanged
+python -m riskmodels.snapshots.contract_check --all
+# Expected: 9 fixtures pass (current behavior)
+
+# CLI F1 path runs (no fixtures, exits 1 with "no fixtures found" — that's the right
+# behavior; the gate exists but has nothing to check yet)
+python -m riskmodels.snapshots.contract_check --all --composition f1
+# Expected: "No fixtures found in ..." stderr, exit 1
+```
+
+Imports work cleanly:
+
+```python
+from riskmodels.snapshots import (
+    CanonicalFundSnapshot,
+    FundIdentity,
+    FilerMetadata,
+    HoldingRow,
+    FundPortfolio,
+    CANONICAL_FUND_SCHEMA_VERSION,
+    from_fund_components,
+)
+```
+
+---
+
+## Out of scope (don't do these)
+
+- BWMACRO institutional renderer for F1 (private, separate task)
+- `derive_judgment_for_fund` editorial engine (BWMACRO, not yet specced)
+- Real per-fund zarr reader (separate task; the F1 canonical works with synthetic fixtures until that lands)
+- M1 implementation (deferred to taxonomy v2)
+- `reference_renderer` for funds (separate task; F1 PDF/PNG render is needed but not required for this milestone)
+- Modifying P1's `canonical.py`, `_stock_data.py`, or contract test (P1 is frozen)
+- Refactoring shared blocks into a base file. Copy-paste the imports; don't extract a `canonical_base.py`. Premature abstraction.
+- Schema field additions to `PerformanceAttribution` (e.g. `attribution_source`, `coverage`). Earlier draft proposed these; final decision is *do not add*.
+
+---
+
+## Handoff back
+
+When done:
+1. Paste the output of the four pytest commands and two CLI commands above.
+2. List the new files created and the existing files modified (one line each).
+3. Note any places where the P1 pattern didn't translate cleanly — those are conversation points, not failures.
+4. Stop. Don't proceed to F1 with real data, M1, or the BWMACRO render — those need design conversations the next round.
+
+---
+
+## Style notes
+
+- Match the existing code style in the SDK: type hints, frozen dataclasses, docstrings on every dataclass and public function.
+- Single-line module docstring. Short field-level comments (~10 chars) where the meaning isn't obvious.
+- No comments explaining what the code does — names should carry it. Comments only for non-obvious "why."
+- No emojis. No marketing language in docstrings — institutional voice.
+- Don't write a CHANGELOG entry; this lands as part of the F1 milestone, the wider PR will handle it.

--- a/docs/plans/F1_FUNDDATA_PROMOTION_SPEC.md
+++ b/docs/plans/F1_FUNDDATA_PROMOTION_SPEC.md
@@ -1,0 +1,208 @@
+# Promote FundData reader from BWMACRO to public SDK
+
+**Status:** Ready to implement
+**Owner:** Cursor Composer 2 fast (or any agent picking this up)
+**Reviewer:** Conrad Gann
+**Estimated:** ~3 hours mechanical
+**Prerequisite:** F1 canonical schema + reference renderer landed in `feat/d8-13f-api` (commit `87e5dc0`)
+
+This spec is **prescriptive**. The architecture is settled — your job is to move code from BWMACRO to the public SDK while preserving the public/private trust direction.
+
+---
+
+## Goal
+
+Move the `FundData` reader (dataclasses + GCS-zarr I/O) from `BWMACRO/src/bwmacro/snapshots/funds/_data.py` (private, 991 lines) to `RiskModels_API/sdk/riskmodels/snapshots/_fund_data.py` (public, currently a 103-line stub). After the move:
+
+- `from riskmodels.snapshots import FundData, FundHolding, get_data_for_f1` works
+- BWMACRO's `f1_tearsheet.py` and any other importers consume the *public* `FundData`, not their own local copy
+- Cloud Run can render funds in pure Python without importing from `bwmacro.*`
+- Anything Supabase-credential-dependent stays private in BWMACRO
+
+Mirrors the existing pattern where `P1Data` is public in the SDK and BWMACRO's stock institutional renderers consume it.
+
+---
+
+## Read these first (mandatory)
+
+In order:
+
+1. **`BWMACRO/src/bwmacro/snapshots/funds/_data.py`** — the source. 991 lines. Read it end-to-end before deciding what moves and what stays. The header docstring documents the design.
+2. **`RiskModels_API/sdk/riskmodels/snapshots/_fund_data.py`** — the current stub (103 lines). This gets replaced.
+3. **`RiskModels_API/sdk/riskmodels/snapshots/_stock_data.py`** — `P1Data` is the public-SDK pattern. Mirror this.
+4. **`RiskModels_API/sdk/riskmodels/snapshots/canonical_fund.py`** — `from_fund_components(FundData)` is the consumer. After your changes, the field shapes used here must still match.
+5. **`BWMACRO/src/bwmacro/snapshots/funds/f1_tearsheet.py`** (1895 lines) — the BWMACRO consumer that needs its imports updated.
+
+---
+
+## Public/private split — decide this first
+
+`_data.py` mixes two kinds of code:
+
+| Public-safe (move to SDK) | Private (stay in BWMACRO) |
+|---|---|
+| `FundData` dataclass | Supabase-credential-dependent calls |
+| `FundHolding` dataclass | `_supabase_query` helper |
+| `_open_fund_zarr` (GCS-only, no auth) | `_resolve_holdings_metadata` (uses Supabase) |
+| `_funds_latest_path` (path resolution) | `_resolve_l3_decomposition` (uses Supabase) |
+| `from_fixture_row` (synthetic-fixture loader) | Any function that requires `BW_SUPABASE_URL` / `BW_SUPABASE_ANON_KEY` env vars |
+| `load_fund_from_fixture` (file loader) | Any function that imports `bwmacro.*` |
+
+`get_data_for_f1` is the orchestrator. **Audit it line-by-line** to determine what calls can run with public credentials only (GCS read of `gs://rm_api_public/funds/...` is public; Supabase reads need auth). Split it accordingly:
+
+- **`get_data_for_f1` in public SDK** — reads GCS-zarr, returns a `FundData` populated with what zarr provides. No Supabase.
+- **`enrich_fund_data_with_supabase(fund_data) -> FundData`** in BWMACRO — adds the holdings-metadata and L3-decomposition fields that today require Supabase. Returns an enriched `FundData`. BWMACRO's institutional renderer chains: `fd = riskmodels.snapshots.get_data_for_f1(id); fd = bwmacro.snapshots.funds.enrich(fd); render(fd)`.
+
+If the audit reveals that `get_data_for_f1` cannot be cleanly split without rewriting too much, **stop and surface it**. A safer fallback is: move only the dataclasses (`FundData`, `FundHolding`) and the synthetic-fixture loader (`from_fixture_row`, `load_fund_from_fixture`); leave all GCS-zarr I/O in BWMACRO as a Phase-2 task. Document this clearly in your handoff so the boundary is obvious.
+
+---
+
+## Constraints
+
+- **Do not modify P1 code.** P1 is contract-frozen.
+- **Do not modify the canonical contract** in `canonical_fund.py`. The `FundData` shape must still match what `from_fund_components` consumes.
+- **Do not import from `bwmacro.*` in the public SDK.** This is the inviolable boundary.
+- **Do not import private credentials anywhere in the public SDK.** No Supabase keys, no auth tokens, no env-var lookups for credentialed services.
+- **Do not leak BWMACRO-private logic** (Judgment derivation, narrative helpers, editorial vocabulary) into the public SDK.
+- **Do not break BWMACRO's existing tests.** After the import-path update, BWMACRO's f1_tearsheet must still render correctly.
+- **Do not break the public SDK's existing tests.** The synthetic round-trip + contract gate must still pass.
+- **Do not preserve the stub.** Replace it. The stub was a placeholder; the real `FundData` is the goal.
+- **Do not add new fields to `FundData`** that don't exist in the BWMACRO source. If you find a field needed for the canonical that BWMACRO doesn't provide, surface it.
+
+---
+
+## Deliverables
+
+### 1. Audit the BWMACRO source
+
+Produce a short audit (in your handoff message, not committed) listing:
+- Each function in `_data.py` and whether it requires Supabase / BWMACRO imports
+- Public-safe functions you're moving
+- Private-staying functions and why
+
+This forces you to think before moving code.
+
+### 2. Replace `RiskModels_API/sdk/riskmodels/snapshots/_fund_data.py`
+
+The stub becomes the real implementation. Move:
+
+- `FundHolding` dataclass — verbatim from BWMACRO
+- `FundData` dataclass — verbatim from BWMACRO
+- Public-safe helpers — `_open_fund_zarr`, `_funds_latest_path`, `from_fixture_row`, `load_fund_from_fixture`, and any others your audit identifies
+- `get_data_for_f1` — *only the public-safe path*. If splitting cleanly is hard, make it return the unenriched `FundData` and document that Supabase enrichment lives in BWMACRO
+
+The new file should be ~400-700 lines depending on how much survives the public/private split.
+
+### 3. Update `from_fund_components`
+
+If `FundData`'s field names differ from the stub's, update `from_fund_components` in `canonical_fund.py` to match. The `CanonicalFundSnapshot` contract stays unchanged — only the adapter's input-side mapping shifts.
+
+### 4. Refactor BWMACRO's `funds/_data.py`
+
+Two clean approaches; pick whichever the audit makes natural:
+
+- **Re-export shim:** `from bwmacro.snapshots.funds._data import FundData, FundHolding` becomes `from riskmodels.snapshots import FundData, FundHolding` (re-exported for back-compat). The BWMACRO file shrinks to the Supabase enrichment helpers + a backward-compatible re-export block. Existing BWMACRO importers don't need to change immediately.
+- **Direct refactor:** delete the BWMACRO copy entirely and update every importer to use `riskmodels.snapshots`. Cleaner end state but a larger blast radius.
+
+**Recommend the re-export shim.** Lower risk, smaller PR, and the importer migration can be a follow-up cleanup task if desired.
+
+### 5. Update BWMACRO importers
+
+At minimum, `f1_tearsheet.py`. Grep for any other file that imports from `bwmacro.snapshots.funds._data` and decide based on the approach above.
+
+If you took the re-export shim route, no importer changes are strictly needed — but it's still good practice to update at least `f1_tearsheet.py` to import directly from `riskmodels.snapshots` so the trust direction is visible in the source.
+
+### 6. Update SDK exports
+
+Add to `RiskModels_API/sdk/riskmodels/snapshots/__init__.py`:
+
+```python
+from ._fund_data import (
+    FundData,
+    FundHolding,
+    get_data_for_f1,
+    from_fixture_row,
+    load_fund_from_fixture,
+    # ...any other public helpers your audit identified
+)
+```
+
+Add to `__all__`. The existing `FundData` re-export from the stub stays — it just now points at the real implementation.
+
+### 7. Synthetic-fixture path
+
+Verify the existing synthetic test in `sdk/tests/test_canonical_fund_snapshot.py` still works. The test builds a `CanonicalFundSnapshot` directly without calling `FundData.from_*`, so changing `FundData`'s shape shouldn't break it — but if it does, fix the test minimally (don't alter the assertion logic).
+
+If `from_fixture_row` is in the moved code, write a small test in `sdk/tests/test_canonical_fund_snapshot.py` (or a new `test_fund_data.py`) that round-trips `FundData` via `from_fixture_row` against a small inline dict.
+
+---
+
+## Acceptance criteria
+
+Run these and paste output:
+
+```bash
+# 1. Public SDK tests (full suite, no regressions)
+cd RiskModels_API
+python -m pytest sdk/tests/test_canonical_snapshot.py \
+                  sdk/tests/test_canonical_snapshot_contract.py \
+                  sdk/tests/test_canonical_fund_snapshot.py \
+                  sdk/tests/test_canonical_fund_snapshot_contract.py \
+                  -p no:ethereum --no-header -q
+
+# 2. CLI gate still works (P1 + F1 paths)
+python -m riskmodels.snapshots.contract_check --all
+python -m riskmodels.snapshots.contract_check --all --composition f1
+
+# 3. Public imports work
+python -c "from riskmodels.snapshots import FundData, FundHolding, get_data_for_f1; print('OK')"
+
+# 4. BWMACRO tests still pass
+cd ../BWMACRO
+.venv/bin/python -m pytest src/bwmacro/snapshots/funds/ tests/snapshots/funds/ \
+                            -p no:ethereum --no-header -q
+
+# 5. BWMACRO f1_tearsheet still renders (run any existing render-test or smoke script)
+# If a render smoke test exists in BWMACRO, run it. If not, document that no smoke test exists.
+
+# 6. The public SDK does not import from bwmacro.*
+grep -rn "from bwmacro\|import bwmacro" RiskModels_API/sdk/
+# Expected: no matches
+```
+
+All six must pass. If anything breaks, fix or surface — don't push broken code.
+
+---
+
+## Out of scope (do not do these)
+
+- Cloud Run service deployment (separate task, depends on this landing)
+- Modifying `CanonicalFundSnapshot` shape
+- Modifying P1 code or P1 tests
+- Adding new GCS data sources or new fund universes
+- Refactoring the Supabase enrichment helpers themselves (just isolate them)
+- Moving `f1_tearsheet.py` or any BWMACRO renderer
+- Promoting `FundJudgment` / Judgment derivation — that's BWMACRO-private editorial layer
+
+---
+
+## Handoff back
+
+When done:
+
+1. Paste the audit (function-by-function: public-safe vs private-staying with reasoning) — this is the most important part of the handoff.
+2. Paste the output of the six acceptance commands.
+3. List files moved, files modified, files deleted (one line each).
+4. Note any places where the public/private split was awkward — these are conversation points, not failures.
+5. Confirm: did you take the re-export shim route or the direct refactor route?
+6. Stop. Don't touch Cloud Run, M1, or the polish work the intern is doing.
+
+---
+
+## Style notes
+
+- Match the existing SDK code style. Frozen dataclasses where the data is immutable, regular dataclasses where mutation is expected.
+- No comments explaining what code does. Comments only for non-obvious "why."
+- No emojis. Institutional voice in docstrings.
+- Don't add CHANGELOG entries; this lands as part of the F1 milestone.
+- Keep the moved file's docstring honest about what it provides and what it doesn't (Supabase enrichment is in BWMACRO).

--- a/docs/plans/F1_REFERENCE_RENDERER_SPEC.md
+++ b/docs/plans/F1_REFERENCE_RENDERER_SPEC.md
@@ -1,0 +1,365 @@
+# F1 Reference Renderer — implementation spec for Cursor Composer
+
+**Status:** Ready to implement (after `F1_CANONICAL_SPEC.md` lands)
+**Owner:** Cursor Composer 2 fast (or any agent picking this up)
+**Reviewer:** Conrad Gann
+**Estimated:** ~3 hours mechanical
+**Prerequisite:** `F1_CANONICAL_SPEC.md` complete — `CanonicalFundSnapshot` and `from_fund_components` exist in `riskmodels.snapshots`
+
+This spec is **prescriptive**. Don't redesign. Don't add visual flourishes beyond what's listed. The P1 reference renderer is the template — your job is to mirror it for F1, with the differences spelled out below.
+
+---
+
+## Goal
+
+Add the public reference renderer for `CanonicalFundSnapshot`. Single-page institutional layout, deterministic, no narrative, no curated peer presentation, no inference at render time. Mirrors the architectural role of `reference_renderer.py` for stocks: a trustworthy baseline that the GCS pre-render pipeline runs without importing from BWMACRO.
+
+When this lands: F1 PDFs / PNGs are renderable from the public canonical; Cloud Run can serve them; the BWMACRO institutional renderer can be built on top of the same canonical without bypassing this layer.
+
+---
+
+## Read these first (mandatory)
+
+1. **`sdk/riskmodels/snapshots/reference_renderer.py`** — the P1 reference renderer. Section structure, helper functions, panel layout, theme usage. **Mirror this; don't invent a new pattern.**
+2. **`sdk/riskmodels/snapshots/_page.py`** — `SnapshotPage` layout engine. The page geometry (rows × cols, panel slicing) is what you compose against.
+3. **`sdk/riskmodels/snapshots/_charts.py`** — chart primitives (`chart_hbar`, `chart_table`, etc.). Use these; do not call matplotlib directly except inside helper functions that wrap the primitives.
+4. **`sdk/riskmodels/snapshots/_theme.py`** — `THEME` palette, typography, strokes. Read all panel-painting code through `THEME`, not hard-coded colors.
+5. **`sdk/riskmodels/snapshots/canonical_fund.py`** — the F1 canonical contract. Read the field shapes you'll be drawing from.
+6. **`docs/architecture/CANONICAL_INTELLIGENCE_OBJECTS.md`** (BWMACRO) — particularly §1 (reference vs institutional renderer) so you understand the layering. **The reference renderer is deliberately less opinionated than the institutional renderer.** No narrative, no Judgment, no peer benchmarking artwork. You're not building the AGTHX tearsheet.
+
+---
+
+## Constraints
+
+- **Do not import from `bwmacro.*`.** The reference renderer is self-sufficient on the public canonical contract.
+- **Do not invoke inference (LLM calls) at render time.** Narrative is `Judgment` data, populated by BWMACRO during canonical assembly. The renderer reads narrative as data, never generates it.
+- **Do not modify `reference_renderer.py` or P1 code.** P1 is contract-frozen; F1 lives in a parallel module.
+- **Do not extract a `_base_renderer.py`.** Premature deduplication. Copy the helper functions you need (`_fmt_pct`, `_fmt_num`, the chip builder) and adjust for F1.
+- **Do not render Sharpe / drawdown panels for F1.** Per the F1 vs M1 design, those metrics are NAV-derived and we don't anchor F1 on NAV. Use the same `CoreMetrics` chips P1 uses (beta, vol_23d, max_drawdown_pct if present, sharpe_252d if present, residual_er) — but if any are `None`, render an em-dash, do not error.
+- **Do not assume holdings is populated.** Synthetic fixtures may have holdings; real-data F1 may have empty `FundPortfolio.holdings` until the per-fund zarr reader ships. Render a graceful placeholder ("Holdings reconstruction pending") when empty.
+
+---
+
+## Deliverables
+
+### 1. New file: `sdk/riskmodels/snapshots/reference_renderer_fund.py`
+
+Three public entry points, mirroring `reference_renderer.py`:
+
+```python
+def render_canonical_fund_to_pdf(
+    snap: CanonicalFundSnapshot,
+    output_path: str | Path,
+) -> Path: ...
+
+def render_canonical_fund_to_png(
+    snap: CanonicalFundSnapshot,
+    output_path: str | Path,
+) -> Path: ...
+
+def render_canonical_fund_to_png_bytes(
+    snap: CanonicalFundSnapshot,
+) -> bytes: ...
+```
+
+Internal `_build_page(snap)` function that returns a `SnapshotPage`; the three public entry points all delegate to it.
+
+### 2. Layout — single landscape page, 12×12 grid
+
+Mirror the P1 layout structure with these section assignments:
+
+| Region | Rows × Cols | Content |
+|---|---|---|
+| Header band | 0:2 × 0:12 | `{symbol_id} — {name}` title; "Fund Snapshot · As of {as_of}" subtitle; chips on the right |
+| Left rail | 2:12 × 0:3 | Identity + decomposition summary (mirrors P1's `_render_left_rail` style) |
+| Section I — Performance | 2:6 × 3:12 | Cumulative return curves (`performance.cumulative_curves`) |
+| Section II — Risk | 8:12 × 3:7 | Variance-share horizontal bar (`risk.components`) |
+| Section III — Holdings | 8:12 × 7:12 | Top-N holdings table (or empty-state placeholder) |
+
+### 3. Section renderers (mirror P1 patterns)
+
+#### `_render_left_rail(page, snap)`
+
+Identity spine — text-only summary in the left columns. Lines to render, in order:
+
+```
+IDENTITY
+Symbol         {snap.identity.symbol_id}
+Family         {snap.identity.fund_family or "—"}
+Inception      {snap.identity.inception_date or "—"}
+Expense        {fmt_pct(snap.identity.expense_ratio)}
+AUM            {fmt_aum(snap.identity.aum_usd)}   # e.g. "$118.4B"
+
+DECOMPOSITION
+Market         {fmt_pct(snap.core_metrics.market_share)}
+Sector         {fmt_pct(snap.core_metrics.sector_share)}
+Subsector      {fmt_pct(snap.core_metrics.subsector_share)}
+Residual       {fmt_pct(snap.core_metrics.residual_share)}
+```
+
+If `snap.identity.filer_metadata is not None` (M1 case — we're rendering a 13F filer), substitute the IDENTITY block with:
+
+```
+IDENTITY
+Filer          {snap.identity.symbol_id}
+Type           {filer_metadata.filer_type or "—"}
+CIK            {filer_metadata.cik}
+AUM Tier       {filer_metadata.aum_tier or "—"}
+Coverage       {filer_metadata.coverage}
+```
+
+The DECOMPOSITION block stays identical — same `core_metrics` shape applies.
+
+If `snap.macro` is populated, append a MACRO ρ block (mirroring P1's left rail).
+
+#### `_render_section_i_performance(page, snap)`
+
+Cumulative-return curves. Same structure as P1's:
+
+- Pull stable label order: target (`snap.identity.symbol_id`) → "SPY" → benchmark (if any in `cumulative_curves`) → others
+- Use `THEME.palette` for color order
+- Title: `f"I. Performance Attribution · {perf.window_label}"`
+- Y-axis: percent format
+- Sparse x-tick labels (~6 max)
+
+If `performance.cumulative_curves` is empty, render the same "Performance series unavailable" placeholder P1 uses. (Synthetic F1 fixtures may have empty curves.)
+
+#### `_render_section_ii_risk(page, snap)`
+
+Variance-share horizontal bar. Mirror P1's `_render_section_ii_risk` exactly — same `chart_hbar` call, same labels (Market / Sector / Subsector / Residual), same color palette. The data shape is identical.
+
+#### `_render_section_iii_holdings(page, snap)`
+
+Top-N holdings table. F1-specific (P1's Section III is peer context — different content, same panel slot).
+
+```python
+def _render_section_iii_holdings(page, snap):
+    ax = page.panel(row_slice=slice(8, 12), col_slice=slice(7, 12))
+    ax.set_title("III. Top Holdings",
+                 loc="left",
+                 fontsize=THEME.type.panel_title,
+                 fontweight=THEME.type.weight_bold,
+                 color=THEME.palette.navy,
+                 pad=6)
+    ax.set_xticks([]); ax.set_yticks([])
+    for spine in ax.spines.values():
+        spine.set_visible(False)
+
+    portfolio = snap.portfolio
+    if not portfolio.holdings:
+        ax.text(0.5, 0.5, "Holdings reconstruction pending",
+                ha="center", va="center",
+                color=THEME.palette.text_light,
+                transform=ax.transAxes)
+        return
+
+    # Top-N by weight, descending
+    top = sorted(portfolio.holdings, key=lambda h: h.weight, reverse=True)[:8]
+
+    rows = [
+        [
+            h.ticker,
+            _fmt_pct(h.weight),
+            _fmt_pct(h.residual_share) if h.residual_share is not None else "—",
+        ]
+        for h in top
+    ]
+
+    chart_table(ax, rows=rows, headers=["Ticker", "Wt", "Resid"])
+
+    # Caption: total holdings count + coverage
+    coverage_str = (
+        f"{portfolio.total_holdings_count} holdings · "
+        f"{_fmt_pct(portfolio.coverage_pct)} coverage"
+    )
+    page.fig.text(
+        0.83, 0.115,
+        coverage_str,
+        fontsize=THEME.type.footer,
+        color=THEME.palette.text_light,
+        ha="center", va="top",
+    )
+```
+
+### 4. Helpers
+
+Top of the file, mirror P1's helpers:
+
+```python
+def _fmt_pct(v, *, decimals=1, sign=False): ...   # exact copy from reference_renderer.py
+def _fmt_num(v, *, decimals=2): ...               # exact copy
+def _fmt_aum(v):                                  # F1-specific, new
+    """Format AUM in USD with B/M suffix."""
+    if v is None:
+        return "—"
+    if v >= 1e9:
+        return f"${v/1e9:.1f}B"
+    if v >= 1e6:
+        return f"${v/1e6:.0f}M"
+    return f"${v:,.0f}"
+
+def _build_chips(snap):
+    """Mirror P1's _build_chips but adapted for F1.
+
+    F1 chips: AUM, Holdings count, Beta, Vol 23d, Resid ER.
+    Hides any chip whose value is None.
+    """
+    cm = snap.core_metrics
+    chips = [
+        ("AUM",         _fmt_aum(snap.identity.aum_usd)),
+        ("Holdings",    str(snap.portfolio.total_holdings_count) if snap.portfolio else "—"),
+        ("Beta",        _fmt_num(cm.beta)),
+        ("Vol 23d",     _fmt_pct(cm.vol_23d)),
+        ("Resid ER",    _fmt_pct(cm.residual_er, sign=True)),
+    ]
+    return chips
+```
+
+### 5. Page assembly
+
+Mirror P1's `_build_page`:
+
+```python
+def _build_page(snap: CanonicalFundSnapshot) -> SnapshotPage:
+    title = f"{snap.identity.symbol_id} — {snap.identity.name}"
+    subtitle = f"Fund Snapshot · As of {snap.identity.as_of}"
+    if snap.identity.filer_metadata is not None:
+        subtitle = f"13F Filer Snapshot · As of {snap.identity.as_of}"
+
+    page = SnapshotPage(
+        title=title,
+        subtitle=subtitle,
+        ticker=snap.identity.symbol_id,
+        teo=snap.identity.as_of,
+        chips=_build_chips(snap),
+    )
+
+    _render_left_rail(page, snap)
+    _render_section_i_performance(page, snap)
+    _render_section_ii_risk(page, snap)
+    _render_section_iii_holdings(page, snap)
+
+    return page
+```
+
+### 6. Exports
+
+Update `sdk/riskmodels/snapshots/__init__.py` to add the three F1 render entry points alongside the P1 ones:
+
+```python
+from .reference_renderer_fund import (
+    render_canonical_fund_to_pdf,
+    render_canonical_fund_to_png,
+    render_canonical_fund_to_png_bytes,
+)
+```
+
+Add to `__all__`.
+
+### 7. Tests
+
+Append to `sdk/tests/test_canonical_fund_snapshot.py` (already exists from F1 canonical task):
+
+```python
+def test_render_pdf_produces_valid_pdf(tmp_path):
+    snap = _build_test_fund_snapshot()  # the synthetic fixture builder from prior task
+    out = tmp_path / "test_fund.pdf"
+    render_canonical_fund_to_pdf(snap, out)
+    assert out.exists()
+    assert out.stat().st_size > 1000
+    assert out.read_bytes()[:5] == b"%PDF-"
+
+def test_render_png_bytes_deterministic():
+    snap = _build_test_fund_snapshot()
+    a = render_canonical_fund_to_png_bytes(snap)
+    b = render_canonical_fund_to_png_bytes(snap)
+    assert a == b
+    assert a[:8] == b"\x89PNG\r\n\x1a\n"
+    assert len(a) > 1000
+
+def test_render_handles_empty_holdings(tmp_path):
+    """Empty FundPortfolio.holdings renders the placeholder, not an error."""
+    snap = _build_test_fund_snapshot_no_holdings()
+    out = tmp_path / "empty.png"
+    render_canonical_fund_to_png(snap, out)
+    assert out.exists()
+
+def test_render_handles_filer_identity(tmp_path):
+    """When FilerMetadata is populated, header/left-rail switch to filer mode."""
+    snap = _build_test_filer_snapshot()  # M1-style synthetic
+    out = tmp_path / "filer.png"
+    render_canonical_fund_to_png(snap, out)
+    assert out.exists()
+```
+
+You'll need to add `_build_test_fund_snapshot_no_holdings()` and `_build_test_filer_snapshot()` helpers to the test module — small variations on the existing synthetic builder.
+
+### 8. Update F1 contract test
+
+The `test_canonical_fund_snapshot_contract.py` contract test currently has a placeholder `test_pdf_renders` skipped with `@pytest.mark.skip(reason="F1 reference renderer not yet implemented")`. Remove the skip; the test should now pass as written (mirrors the P1 PDF test).
+
+---
+
+## Acceptance criteria
+
+```bash
+cd RiskModels_API
+
+# Existing P1 + F1 tests still pass
+python -m pytest sdk/tests/test_canonical_snapshot.py \
+                  sdk/tests/test_canonical_snapshot_contract.py \
+                  sdk/tests/test_canonical_fund_snapshot.py \
+                  sdk/tests/test_canonical_fund_snapshot_contract.py \
+                  -p no:ethereum -q
+
+# Imports work
+python -c "from riskmodels.snapshots import (
+    render_canonical_fund_to_pdf,
+    render_canonical_fund_to_png,
+    render_canonical_fund_to_png_bytes,
+)"
+
+# Manually render the synthetic fixture and inspect the PDF
+python -c "
+from pathlib import Path
+from riskmodels.snapshots import (
+    CanonicalFundSnapshot,
+    render_canonical_fund_to_pdf,
+)
+# build the test snapshot and render
+"
+# Output PDF should be readable, single page, landscape, with all four sections visible
+```
+
+The new tests added in deliverable (7) should all pass. The previously-skipped `test_pdf_renders` in `test_canonical_fund_snapshot_contract.py` should now pass without skip.
+
+---
+
+## Out of scope
+
+- BWMACRO institutional F1 renderer (`f1_tearsheet.py` enrichment) — separate task
+- C1 reference renderer — separate task
+- Plotly variant of the F1 renderer (web-native interactive) — separate task
+- Snapshot caching / GCS publication — that's the Dagster + Cloud Run layer, separate
+- Charts beyond the four panels listed — no Sharpe panel, no drawdown curve, no benchmark fit, no concentration plot. The reference renderer is deliberately minimal; richer presentation lives in the institutional renderer
+- AOM provenance display in the rendered output — provenance is data, not visual content
+
+---
+
+## Handoff back
+
+When done:
+1. Paste the output of the pytest command from acceptance criteria.
+2. List new files created and existing files modified (one line each).
+3. Attach (or link) one rendered example PDF + PNG of the synthetic fixture so the visual layout can be eyeballed.
+4. Note any places where the P1 pattern didn't translate cleanly.
+5. Stop. Don't proceed to BWMACRO institutional render or C1 — those are separate tasks with separate specs.
+
+---
+
+## Style notes
+
+- Match the existing renderer code style: short helper functions, frozen-dataclass reads, no inline matplotlib styling — use `THEME` everywhere.
+- No comments explaining what code does. Comments only for non-obvious "why."
+- No emojis. Institutional voice.
+- Keep the file under ~400 lines. P1's renderer is ~350 — F1 should be similar.

--- a/docs/plans/F1_RENDERER_POLISH_INTERN.md
+++ b/docs/plans/F1_RENDERER_POLISH_INTERN.md
@@ -1,0 +1,192 @@
+# F1 Reference Renderer — Visual Polish
+
+**Status:** Open work, not blocking
+**Owner:** UCLA intern (or anyone picking up async polish work)
+**Reviewer:** Conrad Gann
+**Estimated:** ~1–2 weeks part-time
+**Prerequisite knowledge:** Python, matplotlib, basic typography sense. Familiarity with institutional financial reports helpful but not required.
+
+This is a learning project. The goal is to bring the public F1 reference renderer to "publishable institutional quality" — trustworthy, clean, stable — without rewriting the architecture. You're improving an existing implementation, not starting from scratch.
+
+---
+
+## What you're working on
+
+`RiskModels_API/sdk/riskmodels/snapshots/reference_renderer_fund.py` — the deterministic baseline renderer for fund-shape canonical snapshots. It produces a single-page PDF/PNG from a `CanonicalFundSnapshot` data object: header band with chips, identity rail on the left, performance chart, risk-decomposition bars, top-holdings table.
+
+The renderer ships in the public SDK (`pip install riskmodels-py`). Anyone with the canonical contract runs it. It's the trust anchor for the GCS pre-render pipeline.
+
+A first version landed and produces correct output but is visually cramped and rough. The current preview is at `~/Downloads/f1_renderer_pass2.{pdf,png}` if you want to see the starting point.
+
+---
+
+## What "publishable institutional quality" means here
+
+The reference renderer is **deliberately less opinionated** than the BWMACRO institutional renderer. It's the public baseline — like Stripe's API docs, not Stripe's marketing site. So:
+
+- **Yes:** clean typography, balanced spacing, restrained color, panels that breathe, edge cases handled gracefully.
+- **No:** marketing flourish, narrative inserts, custom artwork, peer-comparison overlays, hedge-construction visuals. Those live in the institutional renderer (BWMACRO, private).
+
+Reference for the bar: the existing P1 reference renderer at `sdk/riskmodels/snapshots/reference_renderer.py`. F1 should feel like a sibling to it — same design language, same breathing room, same restraint. If F1 looks worse than P1 anywhere, that's a fix candidate.
+
+---
+
+## Read these first
+
+In order:
+
+1. **`sdk/riskmodels/snapshots/reference_renderer.py`** — the P1 renderer. Read it end-to-end. This is the design template you're matching for F1.
+2. **`sdk/riskmodels/snapshots/reference_renderer_fund.py`** — the F1 renderer you're polishing. Note where it diverges from P1 and ask whether the divergence is justified.
+3. **`sdk/riskmodels/snapshots/_page.py`** — the layout engine (`SnapshotPage`). Header bar, chips row, footer, panel grid.
+4. **`sdk/riskmodels/snapshots/_charts.py`** — chart primitives (`chart_hbar`, `chart_table`, etc.). All visual styling routes through these.
+5. **`sdk/riskmodels/snapshots/_theme.py`** — `THEME` palette, typography, layout constants. Read every styling decision through `THEME`. Never hard-code colors, font sizes, line widths.
+6. **`sdk/riskmodels/snapshots/canonical_fund.py`** — the data shape you're rendering. Understand what fields exist before deciding what to display.
+7. **`docs/plans/F1_REFERENCE_RENDERER_SPEC.md`** — the original spec. Constraints documented there still apply.
+
+After reading, render the synthetic fixture once before changing anything:
+
+```bash
+cd RiskModels_API
+python -c "
+from pathlib import Path
+import sys
+sys.path.insert(0, 'sdk/tests')
+from test_canonical_fund_snapshot import _build_test_snapshot
+from riskmodels.snapshots import render_canonical_fund_to_pdf
+render_canonical_fund_to_pdf(_build_test_snapshot(), Path.home() / 'Downloads' / 'f1_baseline.pdf')
+"
+```
+
+Then for each refinement, re-render and visually compare before/after. PDFs accumulate in `~/Downloads/`; keep them around so you can do side-by-side comparisons across iterations.
+
+---
+
+## Polish areas, ranked by impact
+
+Take them roughly in order, but feel free to bundle small fixes from later areas if they're adjacent. Each area is independently completable.
+
+### A. Header and title (high impact)
+
+- Install Inter font system-wide so the renderer doesn't fall back to DejaVu Sans every run. Inter `.ttf` files: download from rsms.me/inter, drop into `~/.local/share/fonts/` on Linux or system Fonts folder on macOS.
+- The header underline at `_page.py:166` (`y=0.955`) currently sits *within* the title text vertical extent (the title at `y=0.97` with `va="top"` and 14pt font reaches down to ~`y=0.947`). The line gets overdrawn by descenders. Move the line below the text baseline (try `y=0.945` or lower) so it reads as a clean separator. Same fix benefits P1.
+- Subtitle right-alignment at `x=0.95` cuts off if the as-of date string is long. Test with longer subtitle strings (multi-line view? smaller font?).
+- The synthetic fixture uses `__TEST_FUND__` which produces literal underscores rendering as fake underline artifacts. The current renderer strips them in `_build_page`. Real production symbol_ids won't have leading/trailing underscores, but verify with longer realistic names like `American Funds Growth Fund of America (AGTHX)` — does the title fit? Truncate gracefully if not.
+
+### B. Performance chart (Section I)
+
+- Legend currently lands `loc="upper left"` and overlaps the data lines. Move it outside the chart area (above or below) or use a smaller/transparent legend frame. P1 uses `loc="best"` — eyeball whether that works for F1 (it depends on data shape).
+- Y-axis tick labels (`+25%`, `+20%`, ...) sit close to the IDENTITY rail. The current panel is at `cols=slice(4, 12)` to give a buffer; verify the buffer is enough on the synthetic fixture and on real fund data with more extreme returns.
+- X-axis dates: synthetic fixture has only 2 data points so labels are sparse. Real funds have 252+ points. Ensure tick density is reasonable (~6 labels max), date format is readable, no rotation needed.
+- Curve emphasis: target curve (the fund itself) should be visually dominant; SPY and other benchmarks should be visible but secondary. Currently both use the full series-line-width. Consider thinning benchmarks.
+- When `cumulative_curves` is empty, the placeholder text "Performance series unavailable" should look intentional, not like a broken render. Consider centering it more carefully or styling it.
+
+### C. Risk decomposition (Section II)
+
+- Bar height and spacing: `chart_hbar` sets `bar_h = 0.55`. For 4 bars in a 5-row panel, this works. Confirm visually.
+- Value annotations are at `(v + offset, y_pos[i])` with `offset = 0.4`. On small bars (e.g. 5% residual share), the annotation may collide with the next bar's category label. Test with skewed distributions (e.g. one fund where market share is 90% and others are tiny).
+- Title pad: currently `pad=8` in `chart_hbar`. Adjust if needed for visual breathing room.
+- Color: bars use `THEME.palette.factor_colors` — Navy/Teal/Subsector-violet/Green. Confirm the violet reads as "subsector" against the green "residual" — the current palette is institutional but worth one check at print resolution.
+
+### D. Top holdings (Section III)
+
+- `chart_table` defaults aren't ideal for a fund-holdings table. The Ticker column renders narrow, Wt and Resid render wide. Set explicit column proportions: roughly 35% / 30% / 35% feels right for `Ticker / Wt / Resid`.
+- Empty state: "Holdings reconstruction pending" currently centers in the panel. Add a small subtitle hint like "(per-fund zarr reader in progress)" to make it feel intentional, not broken.
+- When holdings are populated, render up to 8 rows. If `total_holdings_count > 8`, the caption says "120 holdings · 85% coverage" which is correct. Confirm the caption sits properly relative to the table.
+- Cell padding inside `chart_table` may need adjustment — read the primitive's source and tweak there if the table feels cramped. **If you change `chart_table`, verify that P1 still renders correctly** (P1 uses it for peer cohort tables).
+
+### E. Left rail (identity + decomposition)
+
+- Section grouping is already in place after Pass 1. Confirm vertical breathing reads well on the synthetic fixture and on real-data fixtures (more macro factors, longer fund names).
+- Section header styling (`IDENTITY`, `DECOMPOSITION`, `MACRO ρ`) uses `chip_label` font size with bold weight. Verify the visual hierarchy reads correctly — section headers should feel distinct from row labels but not shouty.
+- Row label (left) and value (right) currently align with `va="top"`. Switch to `va="center"` if vertical alignment looks off.
+- Long values (e.g. `$1,234.5B` for AUM, or full filer CIK numbers) should not overflow into the label column. Test with long strings.
+
+### F. Edge cases (medium impact, helps real-data robustness)
+
+Render the renderer against each of these and verify nothing crashes or looks broken:
+
+- **13F filer identity** — `FilerMetadata` populated, `fund_family / share_class_count / expense_ratio / inception_date` all `None`. Subtitle should say "13F Filer Snapshot · As of …" and the rail should show filer fields, not fund fields. Build a synthetic filer snapshot to test (mirror `_build_test_snapshot` but populate `filer_metadata`).
+- **Empty holdings** — `FundPortfolio(holdings=[])` with `total_holdings_count=0`. Section III should show the placeholder; the rest of the page should still render.
+- **No macro correlations** — `snap.macro = None`. Left rail should not have the `MACRO ρ` section. Verify spacing recomputes properly.
+- **All `None` core metrics** — `CoreMetrics()` (every field defaulted to `None`). Chips row should still render with em-dashes; left rail decomposition rows should show em-dashes.
+- **Very long fund name** — `name="American Funds The Investment Company of America Class A"`. Header title should truncate or wrap gracefully, not overflow the page.
+- **Single peer / no peers** — Section III placeholder when `holdings=[]`.
+
+### G. Render determinism
+
+This is the **inviolable constraint**. The contract test asserts that two renders of the same canonical produce byte-identical PNG bytes. If you break this, the GCS pre-render pipeline can't trust the output and the whole publication architecture breaks.
+
+After every change, run:
+
+```bash
+cd RiskModels_API
+python -m pytest sdk/tests/test_canonical_fund_snapshot.py::test_render_png_bytes_deterministic \
+                  -p no:ethereum -v
+```
+
+Common causes of nondeterminism: dictionary iteration order on older Python, float-formatting locale, randomized colors, calling `now()` at render time, fonts that aren't deterministically resolved. If determinism breaks, revert and ask before proceeding.
+
+---
+
+## Hard constraints (do not violate)
+
+- **Do not modify the P1 reference renderer (`reference_renderer.py`) or any P1-related code.** P1 is contract-frozen. If you find a bug there, raise it; don't fix in passing.
+- **Do not import from `bwmacro.*`.** The reference renderer is part of the public boundary. It must run with only the public SDK installed.
+- **Do not invoke LLM/inference at render time.** Narrative is `Judgment` data, populated upstream. The renderer reads it as data, never generates it. (Currently F1 doesn't render narrative; if you decide to expose the `Judgment` field in some way, do it as static text rendering, never an inference call.)
+- **Do not extract a shared base renderer file.** It's tempting to deduplicate between P1 and F1. Resist it. The two renderers are deliberately allowed to diverge over time, and a base class makes that future divergence painful. Copy what you need; comment if helpful.
+- **Do not add new fields to `canonical_fund.py`.** The data contract is locked at v2.0 ontology. Render what's there; if a field would help, raise it as a separate spec change before adding.
+- **Do not change `_theme.py` palette colors, sizes, or spacing constants** without a quick check-in. The theme is shared with P1 and the BWMACRO institutional renderer; cosmetic changes ripple.
+- **All visual styling reads from `THEME`.** Don't hard-code `"#002a5e"` or `fontsize=14` anywhere — pull from `THEME.palette.navy` or `THEME.type.page_title`. If a value isn't in `THEME` and you need it, propose adding a constant.
+
+---
+
+## Workflow recommendation
+
+1. Make a working branch off `main`. Commit incrementally.
+2. Fix one thing at a time. Render, eyeball, refine, commit.
+3. Keep `~/Downloads/` around with intermediate previews so you can show before/after.
+4. Run `pytest sdk/tests/test_canonical_fund_snapshot*.py -p no:ethereum -q` after every change. If anything breaks, fix or revert before continuing.
+5. When you finish an area (A, B, C, ...), commit with a descriptive message — `f1-renderer: tighten holdings table column proportions`, etc.
+6. When you have ~3-5 areas done, open a PR for review. Don't try to land everything in one PR; small bundles are easier to review.
+
+---
+
+## Acceptance criteria
+
+When you think you're done:
+
+- All four canonical-snapshot test files pass (P1 + F1, synthetic + contract). No regressions.
+- Render determinism holds for both P1 and F1.
+- Synthetic-fixture preview at `~/Downloads/f1_renderer_final.{pdf,png}` looks comparable in polish to the P1 reference renderer's output.
+- Each of the F.1–F.6 edge cases renders without crashing.
+- No imports from `bwmacro.*`.
+- No changes to P1 code.
+- No new fields on canonical dataclasses.
+
+Submit: a PR against `main` with a description that lists which polish areas you covered, and attaches before/after preview images.
+
+---
+
+## Stop-and-ask boundaries
+
+If you find yourself wanting to do any of these, **stop and ask first** rather than committing the change:
+
+- Adding a new field to `CanonicalFundSnapshot` or any of its blocks
+- Adding a new chart primitive to `_charts.py`
+- Modifying `_theme.py` constants
+- Changing the public API of `render_canonical_fund_to_pdf` / `_to_png` / `_to_png_bytes`
+- Adding a new dependency to `pyproject.toml`
+- Anything that touches BWMACRO or feels cross-repo
+- Anything where you're not sure whether it's a "polish" change or an "architecture" change
+
+Aesthetic taste calls (color tweaks, padding, font sizes within the existing `THEME`) are yours to make. Architectural calls aren't.
+
+---
+
+## What done looks like
+
+The synthetic-fixture preview should pass the test of "would I be embarrassed to put this on the public docs page?" without saying "well, the institutional version is much nicer." The reference renderer doesn't need to be marketing material — but it shouldn't undercut institutional credibility either. Aim for "obviously thoughtful, deliberately restrained."
+
+Compare your final output against the P1 reference renderer's output side-by-side. They should feel like products of the same design system at the same level of polish.
+
+Have fun. This is genuinely good practice for production-quality matplotlib work.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -1,0 +1,14 @@
+# Plans (draft / roadmap)
+
+Longer-lived engineering plans that are not yet normative product docs.
+
+| Document | Summary |
+|----------|---------|
+| [AOM_plan.md](AOM_plan.md) | Analysis Object Model (AOM) — 7-item normative checklist before SDK freeze |
+| [adr-global-coverage-enhancement.md](adr-global-coverage-enhancement.md) | Expanding coverage to ADRs and global equities beyond US-listed securities |
+| [landing-page-conversion-refactor.md](landing-page-conversion-refactor.md) | Landing page refactor to drive primary CTA (explain returns) + secondary dev/API conversion |
+| [ERM3_V3_RETURNS_DECOMP_SUPABASE_PROPAGATION.md](ERM3_V3_RETURNS_DECOMP_SUPABASE_PROPAGATION.md) | Propagating returns decomposition metrics (l1_cfr, l1_rr, etc.) to Supabase, CLI, HTTP API, and SDK |
+| [gcs-parquet-vm-api-supabase-transition.md](gcs-parquet-vm-api-supabase-transition.md) | GCS Parquet cold store, GCP reader VM, Dagster export jobs, API hot/cold routing, Supabase retention |
+| [onboarding_key_email_audit.md](onboarding_key_email_audit.md) | Audit of API key email issuance paths and onboarding workflow cleanup |
+| [portfolio-diversification-metrics.md](portfolio-diversification-metrics.md) | Risk snapshot diversification metrics (concentration, correlation, effective N) |
+| [style-factors-via-macro.md](style-factors-via-macro.md) | Enhancing style factor analysis via macro_factors integration |

--- a/docs/plans/adr-global-coverage-enhancement.md
+++ b/docs/plans/adr-global-coverage-enhancement.md
@@ -1,0 +1,154 @@
+# ADR / Global Coverage Enhancement — Profile
+
+**Status:** Proposal, not scheduled. Saved for later pickup.
+**Owner:** Conrad
+**Target surfaces:** RiskModels API (`/api/data/symbols/*`, possibly new `/api/data/adrs`), riskmodels.app marketing/docs pages, Medium Part 1/2/3 appendix material.
+
+## Why this matters
+
+The current RiskModels narrative leans on US equities. But the US tape already contains ~2,100+ foreign-domiciled issuers (ADRs, Cayman/BVI shells for Chinese issuers, Canadian cross-listings, European majors, Israeli tech, LatAm). Surfacing that coverage — with the same L1/L2/L3 cascade we run on domestic names — lets us credibly claim meaningful *global* coverage without leaving the US listing universe. It also opens a targeted content angle: "what does your US-listed book actually look like through a global lens, and what fraction of MSCI ACWI ex-US market cap is reachable via ADRs?"
+
+## Current state
+
+### Data pipeline
+- `eodhd_daily.py:870` calls `_classify_adr(gen)` each run — multi-signal detection. Emits `is_adr` + `country` into the fundamentals DataFrame, logs an ADR rate per run.
+- Output flows: fundamentals DF → zarr coord `is_adr` (`eodhd_daily.py:2541`) → Supabase `symbols.is_adr` (per sync scripts).
+- `security_master.db` (SQLite, `data/providers/eodhd/raw/eodhd_extractions.db`) schema has the fields (`is_adr`, `asset_type`, `country`, `exchange`, `currency`) but **local rows are not populated** as of 2026-04-17 snapshot (all 21,875 active rows: `asset_type='EQUITY'`, `country=NULL`, `is_adr=FALSE`). This is a local-master drift, separate from what Supabase has.
+
+### API
+Already selects and returns `is_adr, isin, asset_type` in:
+- `app/api/data/symbols/[ticker]/route.ts:33,53,57`
+- `app/api/data/symbols/search/route.ts:31`
+- `app/api/data/symbols/batch/route.ts:49,70`
+- `lib/dal/risk-engine-v3.ts:97-205` (typed `SymbolRow`)
+
+What's missing:
+- No `?is_adr=true` filter on `/symbols/search`
+- No `country` field in select/return (even if Supabase has it in `metadata` jsonb)
+- No dedicated ADR list/rollup endpoint
+- Not documented in `OPENAPI_SPEC.yaml` beyond `asset_type` in `MetricsV3.meta`
+
+### Only partially-populated today
+The one ADR proxy that *is* populated across the universe is `isin` (10,277/21,875 = 47% coverage). Of those, 2,163 have non-US ISIN prefixes:
+
+| ISO | Count | Interpretation |
+|---|---|---|
+| KY | 1,136 | Cayman — overwhelmingly Chinese ADRs (BABA, PDD, JD, LI, NIO, XPEV) |
+| CA | 338 | Canadian cross-listings |
+| VG | 152 | BVI — Chinese / offshore |
+| IL | 115 | Israeli tech (MBLY, NICE, CYBR) |
+| BM | 88 | Bermuda offshore |
+| MH | 57 | Marshall Islands (shipping) |
+| IE | 50 | Ireland (ACN, MDLZ, CRH, AER) |
+| NL | 46 | Netherlands (ASML parent structure) |
+| GB | 42 | UK (BP, Shell, HSBC ADRs) |
+| LU / CH / SG / AU / JP / etc. | ≤30 each | long tail |
+
+ISIN prefix is the **fallback** signal; the real `is_adr` classification in Supabase should supersede it once we verify population.
+
+## Diagnostic to run first (before any build work)
+
+Before scheduling this enhancement, confirm what's *actually* in Supabase prod. Run against Supabase `symbols`:
+
+```sql
+SELECT
+  COUNT(*) AS total,
+  SUM(CASE WHEN is_adr = TRUE THEN 1 ELSE 0 END) AS adr_count,
+  SUM(CASE WHEN metadata->>'country' IS NOT NULL THEN 1 ELSE 0 END) AS with_country,
+  COUNT(DISTINCT metadata->>'country') AS distinct_countries
+FROM symbols;
+
+-- Top 20 ADRs by market cap
+SELECT ticker, name, metadata->>'country' AS country, latest_metrics->>'market_cap' AS mcap
+FROM symbols
+WHERE is_adr = TRUE
+ORDER BY (latest_metrics->>'market_cap')::numeric DESC NULLS LAST
+LIMIT 20;
+```
+
+Two possible outcomes:
+- **`is_adr` populated + `country` present** → content/API build is mostly plumbing (surface, filter, document). Proceed to Tier 1.
+- **`is_adr` null / country absent** → fix the sync or re-run `eodhd_daily` → backfill symbols. Treat as prereq.
+
+## Proposed changes — tiered
+
+### Tier 1: Surface what's already classified (≤1 day)
+
+**API**
+- Add `?is_adr=true|false` filter to `app/api/data/symbols/search/route.ts`.
+- Include `country` in the select (from `symbols.metadata->>'country'` or a top-level column if sync writes it).
+- Add `is_adr`, `country` to `OPENAPI_SPEC.yaml` under `SymbolRecord` / `MetricsV3.meta`.
+- Update `mcp/data/openapi.json` (cross-repo sync — see `docs/AGENTS_CROSS_REPO.md`).
+- Update `SEMANTIC_ALIASES.md` with one-line definitions.
+
+**Website / content** (riskmodels.app)
+- "Coverage" page or section showing: **X,XXX US-listed foreign issuers across YY countries**, covering top non-US names by market cap. Visual: stacked bar of ADR market cap by region (Asia / Europe / LatAm / Other) vs total ACWI ex-US market cap (external MSCI or BNY Mellon DR reference).
+- Landing page tape/treemap: toggle to show ADRs highlighted.
+
+### Tier 2: Dedicated ADR endpoint (1–2 days)
+
+```
+GET /api/data/adrs
+  ?country=CN|IL|NL|GB|...   (optional ISO filter)
+  &sector_etf=XLK|XLE|...    (optional)
+  &order_by=market_cap|latest_vol|l3_res_er
+  &limit=50
+
+Response:
+{
+  results: [{
+    ticker, name, isin, country, sector_etf, subsector_etf,
+    market_cap, latest_vol,
+    l3_mkt_hr, l3_sec_hr, l3_sub_hr, l3_res_er
+  }]
+}
+```
+
+Implementation: wrapper around `symbols` + `security_history_latest` join, filtered by `is_adr = TRUE`. No new pipeline.
+
+### Tier 3: Richer ADR metadata (pipeline enrichment)
+
+Requires pulling additional EODHD fundamentals fields (already on the account). New columns on `symbols` / `security_master`:
+
+| Field | Source | Value |
+|---|---|---|
+| `home_country` | EODHD General → CountryName | Underlying operations country (vs legal domicile) |
+| `home_exchange` | EODHD → PrimaryExchange | e.g. TWSE for TSM, KOSPI for SK, EURONEXT for ASML |
+| `home_ticker` | EODHD → HomeTicker | e.g. TSM → 2330 |
+| `adr_ratio` | EODHD Fundamentals | 1 ADR = N ordinary shares (essential for cross-listing arb) |
+| `adr_level` | EODHD / BNY Mellon DR | I, II, III, 144A, Reg S |
+| `sponsor_bank` | BNY Mellon DR directory | BNY Mellon / JPM / Citi / Deutsche (licensing check) |
+
+Then `GET /api/data/adrs/{ticker}` returns the full ADR fact sheet.
+
+## Content/marketing implications
+
+If Tier 1 data confirms coverage, the content opportunity is:
+
+1. **A dedicated "Global Coverage" page** on riskmodels.app — table of regions, ADR count, aggregate market cap, link to filtered API query. Positions the product against "US-only" perception.
+2. **A Medium follow-up (Part 4?)**: "Your US book is already global: what the ADR cascade actually looks like." Apply the same L1→L3 decomposition to TSM (Taiwan semi), BABA (China internet), NVO (Danish pharma), SHEL (UK energy), MELI (LatAm e-commerce) — show that the cascade works identically and the residual column is particularly informative for ADRs (home-market idiosyncratic risk surfaces there).
+3. **Competitive framing vs Barra/Axioma**: their global models are different products with different licensing; ours is one API, one cascade, covering both domestic and ADR exposures in the same JSON.
+
+## Open questions
+
+- Does Supabase `symbols.is_adr` already populate, or is only the zarr side populated? (Diagnostic above resolves this.)
+- Do we need to distinguish **sponsored ADRs** (Level II/III on NYSE/NASDAQ) from **unsponsored / OTC pink ADRs** for the Medium angle? Sponsored-only is the cleaner investable universe.
+- Does BNY Mellon DR directory licensing allow redistribution of sponsor_bank / adr_level in a public API? If not, we leave Tier 3 fields to internal/paid tiers only.
+- Do we want a **home-market performance comparison** (ADR vs underlying ordinary return, adjusted for FX)? Not in scope here but a natural follow-on.
+
+## Related files / reference paths
+
+- Classification logic: `/Users/conradgann/BW_Code/ERM3/erm3/core/eodhd_daily.py:855-913`
+- Schema: `/Users/conradgann/BW_Code/ERM3/erm3/core/security_master_schema.sql`
+- API symbol endpoints: `/Users/conradgann/BW_Code/RiskModels_API/app/api/data/symbols/`
+- SymbolRow typing: `/Users/conradgann/BW_Code/RiskModels_API/lib/dal/risk-engine-v3.ts:90-230`
+- OpenAPI spec: `/Users/conradgann/BW_Code/RiskModels_API/OPENAPI_SPEC.yaml`
+- Supabase table reference: `/Users/conradgann/BW_Code/RiskModels_API/SUPABASE_TABLES.md` (symbols row)
+- Cross-repo sync checklist: `/Users/conradgann/BW_Code/RiskModels_API/docs/AGENTS_CROSS_REPO.md`
+
+## Recommended order of operations (when scheduled)
+
+1. Run Supabase diagnostic above (~5 min).
+2. If `is_adr` / `country` populated → Tier 1 (filter + select + spec + one content page) in one session.
+3. Tier 2 endpoint in a follow-on session with a small UI card on riskmodels.app.
+4. Tier 3 pipeline enrichment only if Tier 1+2 traction justifies it.

--- a/docs/plans/adr-global-coverage-enhancement.md
+++ b/docs/plans/adr-global-coverage-enhancement.md
@@ -138,13 +138,13 @@ If Tier 1 data confirms coverage, the content opportunity is:
 
 ## Related files / reference paths
 
-- Classification logic: `/Users/conradgann/BW_Code/ERM3/erm3/core/eodhd_daily.py:855-913`
-- Schema: `/Users/conradgann/BW_Code/ERM3/erm3/core/security_master_schema.sql`
-- API symbol endpoints: `/Users/conradgann/BW_Code/RiskModels_API/app/api/data/symbols/`
-- SymbolRow typing: `/Users/conradgann/BW_Code/RiskModels_API/lib/dal/risk-engine-v3.ts:90-230`
-- OpenAPI spec: `/Users/conradgann/BW_Code/RiskModels_API/OPENAPI_SPEC.yaml`
-- Supabase table reference: `/Users/conradgann/BW_Code/RiskModels_API/SUPABASE_TABLES.md` (symbols row)
-- Cross-repo sync checklist: `/Users/conradgann/BW_Code/RiskModels_API/docs/AGENTS_CROSS_REPO.md`
+- Classification logic: `ERM3/erm3/core/eodhd_daily.py:855-913`
+- Schema: `ERM3/erm3/core/security_master_schema.sql`
+- API symbol endpoints: `app/api/data/symbols/`
+- SymbolRow typing: `lib/dal/risk-engine-v3.ts:90-230`
+- OpenAPI spec: `OPENAPI_SPEC.yaml`
+- Supabase table reference: `SUPABASE_TABLES.md` (symbols row)
+- Cross-repo sync checklist: `docs/AGENTS_CROSS_REPO.md`
 
 ## Recommended order of operations (when scheduled)
 

--- a/docs/plans/aom_v1_sdk_execution_plan.md
+++ b/docs/plans/aom_v1_sdk_execution_plan.md
@@ -1,0 +1,103 @@
+# AOM v1 — SDK execution plan (RiskModels API)
+
+**Status:** Locked — design freeze; execution only  
+**Updated:** 2026-04-29  
+
+**Canonical spec & types (this repo):**
+
+| Artifact | Path |
+|----------|------|
+| AOM spec (v1 stable) | [`aom/AOM_SPEC.md`](../aom/AOM_SPEC.md) |
+| Strict TypeScript types | [`aom/AOM_TYPES.ts`](../aom/AOM_TYPES.ts) |
+| Minimal SDK builder scope | [`aom/SDK_BUILDER_V1.md`](../aom/SDK_BUILDER_V1.md) |
+| SDK refactor / rollout | [`aom/SDK_REFACTOR_PLAN.md`](../aom/SDK_REFACTOR_PLAN.md) |
+| Compiler ↔ REST mapping | [`aom/AOM_MIGRATION.md`](../aom/AOM_MIGRATION.md) |
+
+> **Rule:** No further AOM ontology redesign. Changes must preserve backward compatibility of primitives and semantics (see Stability Note in `AOM_SPEC.md`).
+
+---
+
+## Purpose of this document
+
+Single **RiskModels_API** plan: what to implement after AOM v1 lock, how it relates to **`aom/`** in this repo, and explicit **non-goals**.
+
+---
+
+## Normative rules (verified in spec)
+
+All seven items are explicit in `AOM_SPEC.md` § Normative rules (v1 freeze):
+
+1. **attribution_mode** — `"incremental"` \| `"cumulative"`; default incremental; valid only for `return_attribution` and `risk_decomposition`.
+2. **as_of + snapshot** — When `view = snapshot` and `as_of` is present, it selects the effective observation date and overrides `date_range` for that analysis.
+3. **Comparison** — Comparison subjects are executed independently as full analyses and aligned post hoc according to alignment rules.
+4. **ChainStage** — Discriminator is **`kind` only**; never a JSON key named `"stage"`.
+5. **Explanation** — `headline`, `key_drivers`, `optional_metrics`, `confidence` ∈ `high` \| `medium` \| `low`.
+6. **Partial structured output** — Explanation MUST degrade gracefully and MUST NOT contradict available data.
+7. **Chain order** — Chains execute sequentially by default; `depends_on` overrides execution order when present.
+
+---
+
+## Implementation flow (consumer)
+
+1. **Build** — Construct `AOMSingleRequest` \| `AOMChainRequest` (JSON-serializable objects aligned with `AOM_TYPES.ts`).
+2. **Compile** — `AOMRequest → ExecutionPlan` (deterministic; single compiler module shared by SDK, agents, MCP).
+3. **Execute** — `ExecutionPlan →` existing PostgREST resources (see `AOM_MIGRATION.md`); no breaking REST renames.
+
+Internal fluent API (illustrative):
+
+```python
+rm.subject(stock("TSLA")).scope(...).return_attribution(...).explain()
+```
+
+Terminals: `.explain()`, `.structured()`, `.visual()` for `output_mode`.
+
+---
+
+## v1 supported operations
+
+| Operation | Subjects | Notes |
+|-----------|----------|--------|
+| `return_attribution` | stock, portfolio | Portfolio weighting per existing patterns until dedicated aggregates exist. |
+| `exposure` | stock, portfolio | Snapshot / series per spec. |
+| `comparison` | comparison | Independent legs + post hoc alignment. |
+| Chain | exposure → `hedge_action` | `chain[]` with `depends_on: "previous"` as needed. |
+
+---
+
+## Explicit non-goals (v1)
+
+- No portfolio optimization or solver layer.
+- No full query DSL beyond AOM primitives.
+- No arbitrary DAG chaining beyond spec + minimal `depends_on`.
+- No mandatory website/UI refactor — SDK boundary; migrate screens incrementally if desired.
+
+---
+
+## Rollout phases (SDK_REFACTOR_PLAN summary)
+
+| Phase | Scope |
+|-------|--------|
+| 1 | AOM types + compiler internal to SDK (alpha). |
+| 2 | Dual interface — legacy helpers + `from_aom` / builder. |
+| 3 | Default entry points emit AOM; deprecations after dual period. |
+
+---
+
+## Smoke-test checklist
+
+- Single-stock return attribution (e.g. TSLA), structured + explanation modes.
+- Portfolio path (inline or id).
+- Comparison (two legs, shared alignment).
+- Simple chain: analyze exposure → `hedge_action`.
+
+---
+
+## Related local plan
+
+Pre-lock checklist, diagram, and historical framing: [`AOM_plan.md`](./AOM_plan.md).
+
+---
+
+## External note (Cursor SDK)
+
+The [cursor/cookbook](https://github.com/cursor/cookbook) repo demonstrates **Cursor’s** TypeScript SDK for coding agents (cloud/local agents, prompts). It is **not** the RiskModels PostgREST client. Use it only if integrating Cursor agents as a separate concern—not required for AOM compilation or REST execution.

--- a/docs/plans/gcs-parquet-vm-api-supabase-transition.md
+++ b/docs/plans/gcs-parquet-vm-api-supabase-transition.md
@@ -1,0 +1,117 @@
+---
+title: GCS Parquet, reader VM, Dagster, API, and Supabase retention
+status: draft
+updated: 2026-04-09
+source: Cursor plan (execution TBD)
+---
+
+# GCS Parquet, reader VM, Dagster, API, and Supabase retention
+
+**Overview:** Add Parquet exports to the existing GCS SSOT, a small GCP reader VM behind Vercel, Dagster pipeline hooks for full and incremental Parquet builds, API routing for hot Supabase vs cold GCS, and a bounded Supabase `security_history` retention with a safe cutover.
+
+## Workstream checklist
+
+- [ ] Define GCS Parquet prefix, partition scheme (monthly), schema, and v1/staging swap for full rebuilds
+- [ ] Add ERM3 `scripts/python` export module reusing `supabase_schema_v3` extractors + pyarrow; CLI full/incremental
+- [ ] New Dagster asset + jobs (daily incremental + manual full rebuild); wire deps after final zarr for the run
+- [ ] Config-driven lookback for `send_reports_1e` sync path; optional migration to v3 `run_sync` in Dagster
+- [ ] One-off batched DELETE for `teo < cutoff`; VACUUM/ANALYZE plan; verify latest/materialized surfaces
+- [ ] Deploy private FastAPI reader on GCP VM with GCS RO IAM; JSON response parity with existing route
+- [ ] RiskModels_API: env-based hot/cold routing in `security-history` (and DAL if needed); lineage headers
+- [ ] Rollout: backfill → VM smoke → feature flag → shrink sync → prune; document in README_API / operator runbook
+
+## Context from repos
+
+- **ERM3** (sibling repo: `../ERM3`): Dagster jobs in `dagster_assets/definitions.py`; end-of-pipe step `send_reports_1e` (`dagster_assets/assets/part_1_betas.py`) runs Excel then **`sync_erm3_to_supabase.run_supabase_sync`** (legacy FactSet path). V3 long-form sync is `scripts/python/sync_erm3_to_supabase_v3.py` with `run_sync()`, `--lookback`, optional bulk COPY via `scripts/python/lib/supabase_schema_v3.py`. GCS upload is `sync_local_to_gcs` (`dagster_assets/assets/sync_local_to_gcs.py`) (Zarr SSOT).
+- **RiskModels_API** (this repo): History today is Postgres-backed via `app/api/data/security-history/[symbol]/route.ts` and DAL in `lib/dal/risk-engine-v3.ts`.
+
+```mermaid
+flowchart LR
+  subgraph erm3 [ERM3_Dagster]
+    Z[zarr_outputs]
+    Excel[send_reports_1e_step1]
+    SB[supabase_sync_bounded]
+    PQ[parquet_to_gcs]
+    Z2G[sync_local_to_gcs]
+    Z --> Excel
+    Excel --> SB
+    Z --> PQ
+    PQ --> GCS[(GCS_bucket)]
+    SB --> Supa[(Supabase_Postgres)]
+    Z --> Z2G
+    Z2G --> GCS
+  end
+  subgraph vercel [RiskModels_Vercel]
+    API[Next_route_handlers]
+    API -->|hot_range| Supa
+    API -->|cold_range| VM
+  end
+  VM[reader_VM_GCP] --> GCS
+```
+
+## 1) Parquet contract (GCS layout)
+
+- **Bucket/prefix**: Reuse existing ERM3 GCS conventions from config / `supabase_schema_v3` (`GCS_BUCKET`, `GCS_PREFIX`) with a dedicated subtree, e.g. `api_parquet/security_history/daily/` (versioned folder `v1/` if schema may evolve).
+- **Partitioning**: Hive-style **`teo_year=YYYY/teo_month=MM`** (or `teo=YYYY-MM-DD` if partitions must be daily for incremental simplicity—trade fewer files vs more metadata ops). One **Parquet file per partition** per metric group is acceptable at startup scale; document max file size targets.
+- **Schema**: Align columns with API needs: at minimum `(symbol, teo, periodicity, metric_key, metric_value)` to match current JSON from `security-history` route; add optional columns only if you denormalize (e.g. `ticker`) for reader simplicity.
+- **Idempotency**: Incremental job **overwrites** partitions for the TEO months touched in that run; full job **rewrites** entire tree under `v1/` or uses a **`staging/` → `current/`** swap to avoid half-published state.
+
+## 2) ERM3: new export + Dagster wiring
+
+- **New Python module** under `ERM3/scripts/python/` (e.g. `export_security_history_parquet_gcs.py`) that:
+  - Reuses **existing extractors** in `supabase_schema_v3` / the same zarr loaders as `sync_erm3_to_supabase_v3` to avoid drift.
+  - Writes Parquet with **pyarrow**, uploads via **gcsfs** or `google-cloud-storage` (consistent with existing ERM3 GCS patterns in `sync_erm3_to_supabase.py`).
+  - CLI modes: `--mode full`, `--mode incremental`, `--since-teo`, `--datasets`, aligned with `run_sync()` dataset flags where possible.
+- **Config** (`config.yaml` or `global`): `api_parquet_enabled`, `api_parquet_prefix`, `supabase_history_lookback_days` (for bounded Supabase sync).
+- **Dagster** (`dagster_assets/definitions.py`, new asset under `dagster_assets/assets/`):
+  - **`export_security_history_parquet_gcs` asset**: `deps=[send_reports_1e]` **or** `deps=[erm3_model_etf_betas_part_1d_l3_v17]` if you want Parquet **without** waiting on Excel—prefer **after Zarr is final** for the day (same as Supabase inputs).
+  - **`define_asset_job`** variants: e.g. `daily_erm3_pipeline_with_parquet` including the new asset; separate **`parquet_full_rebuild_job`** for rare full rebuilds (manual or scheduled monthly).
+  - **Ordering vs `sync_local_to_gcs`**: Parquet export can run **in parallel** with Zarr upload as long as both read the same local zarr snapshot; document whether export runs **before** `sync_local_to_gcs` completes to avoid reading partially uploaded remote-only state.
+- **Supabase sync alignment** in `part_1_betas.py`:
+  - **A)** Keep legacy `run_supabase_sync` but add **`lookback` / date window** from config so `security_history` (or equivalent) does not re-load full history every run, **or**
+  - **B)** Migrate Dagster FactSet path to **`sync_erm3_to_supabase_v3.run_sync()`** with explicit `--lookback` for the hot window (larger change; coordinate with tables still written only by legacy script).
+  - Record which tables remain legacy-only so you do not drop data clients still use.
+
+## 3) Supabase: retention and pruning
+
+- **Policy**: Define **`HOT_RETENTION_DAYS`** or **`HOT_MIN_TEO`** (e.g. 5 years) in one place; Supabase sync only publishes rows with `teo >= cutoff`.
+- **Prune existing rows**: One-off **batched `DELETE` from `security_history`** where `teo < cutoff` (and periodicity = `daily` if needed), run in a maintenance window; **VACUUM/ANALYZE** plan per Supabase docs; verify **RLS**, **replication**, and **indexes** still valid.
+- **Derived tables**: Refresh `security_history_latest` / materialized paths (`SUPABASE_TABLES.md`) if pipeline assumes full history exists in `security_history` (confirm in ERM3 extractors and RiskModels DAL).
+- **Extensions**: No new extension required for retention; **Timescale/pg_partman** only if you keep very large time-series **inside** Postgres—bulk history in GCS lowers extension urgency unless hypertables already exist (quick `pg_extension` check before cutover).
+
+## 4) Reader VM (GCP)
+
+- **Role**: Private HTTP service (FastAPI/Flask): `GET /history` with `symbol`, `keys`, `start`, `end`, `periodicity`; reads **only** relevant Parquet partitions via **predicate pushdown** (`pyarrow.dataset` or DuckDB); returns JSON matching existing API shape **or** optional `Accept: application/vnd.apache.parquet` for SDK hydration later.
+- **Security**: **Not** public; firewall / **VPC** / **IAP** or **mTLS** + shared secret header for Vercel server-side calls only.
+- **IAM**: VM SA with **`storage.objects.get`** on the Parquet prefix; no Supabase credentials on VM unless needed.
+- **Ops**: Single small e2 instance + systemd + Docker; health check; log **query span** and **bytes read** for cost debugging.
+
+## 5) RiskModels_API (Vercel)
+
+- **Env**: `HISTORY_READER_URL`, `HISTORY_READER_SECRET`, `SUPABASE_HOT_MIN_TEO` or `SUPABASE_HOT_LOOKBACK_DAYS`.
+- **Routing**: Extend `app/api/data/security-history/[symbol]/route.ts` (and any metric/returns routes in `lib/dal/risk-engine-v3.ts`):
+  - If `[start,end]` ⊆ hot window → current Supabase query.
+  - Else → server-side `fetch` to VM with same params; merge pagination behavior (VM may stream or page).
+- **Response metadata**: Add `data_source: postgres | gcs_parquet` (and optional `schema_version`) for lineage.
+- **Docs**: Update `README_API.md` / OpenAPI if public contract changes; SDK (`sdk/riskmodels/`) optional helper for long-range + Parquet accept header in a later phase.
+
+## 6) Rollout sequence (minimize risk)
+
+1. **Backfill Parquet to GCS** (full job) while Supabase still holds full history; validate row counts vs sample queries.
+2. **Deploy reader VM**; smoke-test with Vercel **staging** and fixed `start/end`.
+3. **Turn on API routing** for cold ranges (feature flag).
+4. **Tighten Supabase sync lookback** to hot window only.
+5. **Batch DELETE** old `security_history` rows; monitor size and query latency.
+6. **Optional**: Parquet/binary responses and `riskmodels` client methods.
+
+## 7) Testing and acceptance
+
+- **ERM3**: Dagster dry-run asset; compare Parquet **distinct (symbol, teo, metric_key)** samples against Supabase for overlapping window.
+- **API**: Contract tests for JSON equivalence (hot vs cold same slice).
+- **Load**: Cap max date span per request; 429 when exceeded.
+
+## Key risks / decisions to lock early
+
+- **Legacy vs V3 Supabase path** in Dagster: bounded lookback must apply to the **actual** writer your production FactSet job uses.
+- **EAV vs wide Parquet**: many `metric_key` rows vs wide columns—wide can shrink files but complicates incremental; start EAV-in-Parquet to match SQL shape.
+- **Pagination**: VM must honor or exceed current `page_size` / `offset` semantics for client compatibility.

--- a/docs/plans/landing-page-conversion-refactor.md
+++ b/docs/plans/landing-page-conversion-refactor.md
@@ -1,0 +1,154 @@
+# Landing Page Conversion Refactor
+
+**Status:** In Progress  
+**Created:** 2026-04-29  
+**Goal:** Drive a single outcome-focused CTA while capturing developer/API conversions as a secondary path.
+
+## Implementation Notes
+
+- Copied `RiskWalkthroughChart` from `../Risk_Models/riskmodels_com/src/components/landing/` 
+- Adapted for `.app` audience with dark theme, dual CTAs (primary user conversion + secondary dev/API path)
+- Primary CTA: Yellow banner → `/get-key` 
+- Secondary CTA: "Use this in your app or agent" → `/quickstart`
+- **FIXED**: API endpoint corrected from `/api/landing-snapshot` → `/api/landing/walkthrough-chart`
+- **FIXED**: Response parsing updated to handle `{ ticker, snapshot }` wrapper
+
+---
+
+## Objective
+
+Convert users by showing immediate value ("explain returns"), then convert developers by letting them take that exact output into their app via API.
+
+---
+
+## 1. Hero Section
+
+**Keep headline:**
+> "See what you're actually betting on."
+
+**Replace subheadline with:**
+> "Know exactly what drove your returns — market, sector, or the stock itself."
+
+**Primary CTA** (replace existing button):
+> "Explain your portfolio's returns →"
+
+**Subtext:**
+> "Paste holdings or upload CSV. Private, instant explanation."
+
+**Add secondary CTA** directly under primary (smaller, subtle):
+> "or build this into your app →"
+
+---
+
+## 2. Transition to Example
+
+Add above TSLA section:
+> "Example — what actually drove TSLA's return:"
+
+---
+
+## 3. TSLA Section (Chart Unchanged)
+
+**Add ABOVE the chart:**
+
+Large summary:
+> "TSLA is down -15.6% — driven by -20.7% stock-specific drag."
+
+Small supporting line:
+> "Market and sector added +5.1%. The loss came from the stock itself."
+
+Keep chart unchanged.
+
+---
+
+## 4. Primary Action Under Example
+
+Replace yellow box CTA text with:
+> "Explain your portfolio →"
+
+---
+
+## 5. Developer/API Conversion (Critical)
+
+Directly under the TSLA section (below CTA), add:
+
+> "Use this in your app or agent → Get API key"
+
+This should link to the API onboarding / key creation flow.
+
+---
+
+## 6. Remove Distractions
+
+Delete the three feature cards:
+- ❌ Seamless Model Integrity
+- ❌ Structural Attribution  
+- ❌ Tactical Risk Calibration
+
+---
+
+## 7. Replace with Single Value Section
+
+**Title:**
+> "What you get"
+
+**Bullets:**
+- See what actually drove your returns
+- Separate market, sector, and stock-specific performance
+- Identify hidden bets before they hurt you
+
+---
+
+## 8. Add Agent Hook
+
+Below value section, add:
+
+**Title:**
+> "Ask your portfolio anything"
+
+**Examples:**
+- "What surprised me?"
+- "Where am I overexposed?"
+- "How do I reduce tech risk?"
+
+---
+
+## 9. Principles to Follow
+
+- Lead with answer, not tool
+- One primary CTA only
+- All messaging must map to "explain returns"
+- API is a secondary conversion path tied to the output
+- No jargon (remove "decompose", "factor", "calibration" from first screen)
+- Chart supports insight, not vice versa
+
+---
+
+## 10. API Page (If Linked)
+
+Ensure API page opens with:
+
+> `POST /explain`
+
+Returns:
+- return attribution (market / sector / subsector / residual)
+- plain-English explanation
+- optional hedge ratios
+
+Do NOT lead with auth, pricing, or schema.
+
+---
+
+## End State User Flows
+
+**User path:**
+Landing → clicks "Explain your portfolio's returns" → sees output
+
+**Developer path:**
+Sees TSLA output → clicks "Use this in your app → Get API key"
+
+---
+
+## Notes
+
+This is a conversion-focused refactor, not a visual redesign. Keep existing visual strength while tightening positioning and adding a real developer conversion path.

--- a/docs/plans/onboarding_key_email_audit.md
+++ b/docs/plans/onboarding_key_email_audit.md
@@ -1,0 +1,28 @@
+# Onboarding cleanup — key email issuance audit
+
+**Status:** Approved  
+**Updated:** 2026-04-28
+
+## Summary
+
+Phase 3 of the onboarding plan required tracing **who sends** API key emails before adding workflow selectors.
+
+## Verified paths
+
+| Source | Mechanism | Template / behavior |
+|--------|-----------|---------------------|
+| **riskmodels.app** | `app/api/agent-keys/route.ts` (and related UI) | [`emails/key-issued.tsx`](../emails/key-issued.tsx) via Resend — primary “rich” onboarding email. |
+| **riskmodels.net (portal)** | Typed `sendEmail` in `Risk_Models/riskmodels_com/src/lib/email-service.ts` | Does **not** include a `free-api-key` template; transactional types are welcome, billing, usage, etc. |
+| **Legacy queue** | `Risk_Models/riskmodels_com/src/lib/email.ts` | Supports `api-key-issued` subject mapping; separate from typed `sendEmail`. |
+| **`free-api-key.tsx`** | Template file exists under portal | Not wired into `sendEmail` in the audited pass; Stripe/setup flows may redirect without emailing plaintext keys (see internal production auth notes). Template updated anyway so it stays accurate if reused. |
+
+## Decision (first pass)
+
+- **No UI workflow selector** at key issuance in this iteration.
+- **`key-issued.tsx`**: Added deterministic `npx -y riskmodels@latest install` block plus manual `mcp-remote` path for advanced users — one email covers agent vs manual MCP.
+- **Portal `free-api-key.tsx`**: Added optional MCP install section linking to **riskmodels.app/quickstart** for consistency.
+
+## Follow-ups (optional)
+
+- Wire `FreeApiKeyEmail` from a single issuance path if product wants parity with `.app` emails.
+- Add explicit `workflow` field on keys when UX has a natural home for it.

--- a/docs/plans/style-factors-via-macro.md
+++ b/docs/plans/style-factors-via-macro.md
@@ -166,10 +166,10 @@ Concrete example: take NVDA's L3 residual from Part 1 (+11.5pp over the trailing
 
 ## Related files
 
-- Python canonical source: `/Users/conradgann/BW_Code/ERM3/erm3/shared/macro_factor_constants.py`
-- TS canonical source: `/Users/conradgann/BW_Code/RiskModels_API/lib/risk/macro-factor-keys.ts`
-- Correlation API: `/Users/conradgann/BW_Code/RiskModels_API/app/api/metrics/[ticker]/correlation/route.ts`, `/api/correlation/route.ts`
-- Macro factors endpoint: `/Users/conradgann/BW_Code/RiskModels_API/app/api/macro-factors/route.ts`
+- Python canonical source: `ERM3/erm3/shared/macro_factor_constants.py`
+- TS canonical source: `lib/risk/macro-factor-keys.ts`
+- Correlation API: `app/api/metrics/[ticker]/correlation/route.ts`, `/api/correlation/route.ts`
+- Macro factors endpoint: `app/api/macro-factors/route.ts`
 - Supabase schema: `SUPABASE_TABLES.md` — `macro_factors` row
 - Build script: `erm3/**/build_macro_factor_zarr.py` (ERM3 repo)
 - Cross-repo sync checklist: `docs/AGENTS_CROSS_REPO.md`

--- a/docs/plans/style-factors-via-macro.md
+++ b/docs/plans/style-factors-via-macro.md
@@ -1,0 +1,186 @@
+# Style Factors via macro_factors — Enhancement Profile
+
+**Status:** **Tier 1 DEPLOYED 2026-04-17.** Tier 2 (convenience endpoint) and Tier 3 (website Style DNA card + Medium piece) still scheduled.
+**Owner:** Conrad
+**Target surfaces:** `macro_factors` Supabase table → `GET /api/macro-factors`, `GET /api/metrics/{ticker}/correlation`, `POST /api/correlation`; website "Style DNA" card; Medium/content angle.
+
+## Deployment notes (Tier 1 — 2026-04-17)
+
+Code landed across two repos; tonight's pipeline cycle will begin writing rows.
+
+**ERM3:**
+- `erm3/shared/macro_factor_constants.py` — added `STYLE_SLEEVE_BY_TICKER` (8 ETFs), `STYLE_FACTOR_KEYS_ORDER`, `STYLE_FACTOR_TICKERS`, `STYLE_SLEEVE_SYNC_SOURCE`.
+- `scripts/python/lib/supabase_schema_v3.py` — added `extract_style_factor_records(ds_etf, teo_iso_dates)`.
+- `scripts/python/sync_erm3_to_supabase_v3.py` — added `sync_style_factors_to_public`; wired into `run_sync` as a piggyback on the existing `"macro_factors"` dataset branch, with non-fatal exception handling so a style-sleeve failure cannot roll back an already-committed macro sync.
+
+**RiskModels_API:**
+- `lib/risk/macro-factor-keys.ts` — `MACRO_SLEEVE_FACTORS` + `STYLE_SLEEVE_FACTORS`, types, ~30 new aliases (mtum, qual, usmv, vlue, iwf, iwm, schd, moat, minvol, small_cap, div, yield, etc.).
+- `OPENAPI_SPEC.yaml` — extended `factor_key` description with both sleeves.
+- `SEMANTIC_ALIASES.md` — rewrote factor-keys table with macro + style split; defaults updated from "all six" to "all 18".
+- `mcp/data/openapi.json` — mirrored description edits for MCP consumers.
+
+**Nightly behavior.** `sync_supabase_1f.py` already calls `run_sync(datasets={"macro_factors"})`. That branch now runs the macro sync AND the style-sleeve mirror. The default `lookback=30` means each nightly cycle writes the last 30 trading days of style factor rows for all 8 keys.
+
+**Full historical backfill (one-time manual step, NOT scheduled):**
+
+```bash
+# From ERM3 repo root with monorepo venv active
+python scripts/python/sync_erm3_to_supabase_v3.py \
+  --datasets macro_factors \
+  --lookback 10000
+```
+
+This will populate history all the way back to each ETF's launch date (IWF/IWM: 2000-05; USMV/SCHD: 2011-10; MOAT: 2012-04; MTUM/QUAL/VLUE: 2013). Pre-launch rows are silently skipped (NaN returns). Safe to run any time — idempotent upsert on `(factor_key, teo)` PK.
+
+Until the one-time backfill runs, the correlation endpoints will return `null` for style factors on windows that predate the last ~30 days of coverage. 30+ days is already enough for the minimum-overlap correlation check (~30 paired days), so short windows will work immediately; long windows (252d/504d/756d) will progressively unlock as either nightly runs stack up or the manual backfill runs.
+
+## Why this matters
+
+The cascade cleanly strips market (SPY) → sector ETF → subsector ETF, leaving an idiosyncratic residual. The narrative currently calls that residual "pure idiosyncratic alpha." Technically it's only *orthogonal to the three factors we stripped* — it may still carry **style tilt** (momentum, quality, value, low-vol, growth, size) the PM didn't intend. That is a real competitive gap against Barra/Axioma, which report style loadings as first-class outputs. We can close most of it with a tiny data addition, not a new engine.
+
+The insight: **because the residual is already orthogonal to SPY and to sector/subsector ETFs, raw style-ETF daily returns already give a clean read on pure-style exposure when correlated with the residual.** The market and sector components embedded in MTUM/QUAL/USMV correlate to zero against an orthogonal residual by construction. We get "pure style" signal for free.
+
+## Proposed approach — add style factor ETFs to the existing macro factor sleeve
+
+The `macro_factors` table already handles exactly this shape: one row per `(factor_key, teo)` with `return_gross` and a `metadata` jsonb. Correlation endpoints already accept `factor_key`. Adding style factors is a data-layer change; zero new endpoints required for v1.
+
+**Key simplification:** the daily return series for MTUM, QUAL, USMV, VLUE, IWF, IWM, SCHD, MOAT are **already ingested in `ds_etf.zarr`** (the sector/style ETF price panel). That means we do not need to fetch from EODHD or extend `build_macro_factor_zarr` to pull new source data. The build step is a **mirror/sync from ds_etf → macro_factors** (or, if we prefer no duplication, a new read path that routes the correlation endpoint to ds_etf when the factor_key resolves to a style ETF).
+
+## Recommended factor set (8 style factors)
+
+| factor_key | ETF | Provider | History | Rationale |
+|---|---|---|---|---|
+| `momentum` | MTUM | MSCI USA Momentum | 2013-04 | Canonical momentum factor |
+| `quality` | QUAL | MSCI USA Quality | 2013-07 | Canonical quality factor |
+| `low_vol` | USMV | MSCI USA Min Vol | 2011-10 | Longest-history MSCI factor |
+| `value` | VLUE | MSCI USA Value | 2013-04 | Canonical value factor |
+| `growth` | IWF | Russell 1000 Growth | 2000-05 | Deep history; paired with IWD |
+| `size` | IWM | Russell 2000 | 2000-05 | Small-cap proxy; deep history |
+| `dividend` | SCHD | Schwab US Dividend Equity | 2011-10 | High-quality dividend factor |
+| `moat` | MOAT | VanEck Wide Moat | 2012-04 | Profitability / competitive advantage |
+
+**History tradeoff:** MSCI factor ETFs are cleaner "factor" products but only back to 2011-2013. Russell family (IWF, IWD, IWM) extends to 2000 at the cost of some factor purity (large-cap value and growth are not quite the same as MSCI Value / Momentum). Hybrid set above optimizes for: (a) ≥6 MSCI factors for factor purity, (b) IWF + IWM for longer-history coverage of growth and size where MSCI options are weaker.
+
+**Drop to 6 if simplicity matters:** momentum, quality, low_vol, value, growth, size — covers the Fama-French-Carhart canon plus quality/low-vol.
+
+## Implementation plan
+
+### 1. Data layer — mirror ds_etf rows into macro_factors
+
+**Committed path: mirror ds_etf → macro_factors.** Storage overhead is ~1 MB (8 series × ~4000 trading days); in return the correlation endpoint stays untouched and factor_keys "just work" end-to-end. (Alternative — routing the correlation endpoint directly at `ds_etf.zarr` — is recorded below as a fallback if Supabase row counts ever become a real concern, but not what we're building.)
+
+Concrete steps:
+
+- **Python canonical source.** Add a new `STYLE_SLEEVE_BY_TICKER` dict (MTUM→momentum, QUAL→quality, USMV→low_vol, VLUE→value, IWF→growth, IWM→size, SCHD→dividend, MOAT→moat) to `erm3/shared/macro_factor_constants.py`, parallel to the existing `MACRO_SLEEVE_BY_TICKER`. Add a `STYLE_FACTOR_KEYS_ORDER` tuple. Keep the two sleeves separate — the `ds_etf` exclusion for the *macro* sleeve stays correct; the style ETFs remain in `ds_etf` and we only mirror their return series into Supabase `macro_factors` with a category discriminator.
+
+- **Sync job.** Write `sync_style_factors_to_macro_factors.py` that:
+  - Reads daily returns for the 8 style tickers from `ds_etf.zarr`
+  - Upserts into Supabase `macro_factors` with `factor_key` = the style label (`momentum`, `quality`, …), `teo`, `return_gross`, `metadata = {"source": "ds_etf", "etf": "MTUM", "category": "style", "provider": "MSCI"}`
+  - Idempotent; safe to re-run
+  - Hooked into the daily pipeline after `ds_etf` materializes so incremental rows flow through automatically.
+
+- **Backfill.** One-time full-history run against `ds_etf.zarr` (fast — no network fetch; data already local in GCS zarr). Short-history MSCI ETFs (MTUM/QUAL/VLUE/SCHD) will simply have no rows before their respective launch dates. Document this in `SEMANTIC_ALIASES.md`.
+
+---
+
+**Fallback option (not being built):** route the correlation endpoint to read style factor returns directly from `ds_etf.zarr` via `lib/dal/zarr-reader.ts`, skipping the Supabase mirror entirely. Preserves single-source-of-truth at the cost of an extra branch in the correlation DAL. Revisit only if the mirror becomes a bottleneck.
+
+### 2. API layer — expose new keys
+
+- `lib/risk/macro-factor-keys.ts` — add 8 new canonical keys to `DEFAULT_MACRO_FACTORS`, mapping in `MACRO_FACTOR_DB_KEYS`, and aliases in `MACRO_FACTOR_ALIASES` (e.g. `mom`→`momentum`, `mtum`→`momentum`, `qual`→`quality`, `val`→`value`, `minvol`→`low_vol`, etc.).
+- Optional: introduce a `factor_category` discriminator. Two clean options:
+  - **A.** Keep flat list; add a `category` ("macro" | "style") inside `metadata` jsonb on each row. Simple.
+  - **B.** Split the TS constants into `MACRO_FACTORS` and `STYLE_FACTORS` arrays that both flow into the same DB table. Slightly cleaner for callers who want only one kind.
+- `GET /api/macro-factors` — accept optional `?category=style|macro` filter; default returns all.
+- Correlation endpoints — no code change; they already accept any `factor_key` present in `macro_factors`.
+
+### 3. Spec + SDK sync (cross-repo — see `docs/AGENTS_CROSS_REPO.md`)
+
+- `OPENAPI_SPEC.yaml` — extend `factor_key` enum; document each style factor's ETF and interpretation.
+- `mcp/data/openapi.json` — regenerate.
+- `SEMANTIC_ALIASES.md` — one-line definitions for each style key.
+- Python SDK — add `StyleFactor` enum / constants; add a convenience `client.get_style_correlations(ticker)` that loops the 8 keys and returns a dict. Optional: `client.style_dna(ticker)` returning a top-N ranked list.
+
+### 4. Convenience endpoint (optional, v1.1)
+
+```
+GET /api/metrics/{ticker}/style-correlation
+  ?window=252d|504d|756d   (default 504d = ~2y)
+
+Response:
+{
+  ticker: "NVDA",
+  window_days: 504,
+  window_start: "2024-04-12",
+  window_end: "2026-04-16",
+  residual_source: "l3",   // L3 residual (post market/sector/subsector strip)
+  correlations: {
+    momentum: 0.42,
+    quality: 0.11,
+    low_vol: -0.18,
+    value: -0.33,
+    growth: 0.28,
+    size: -0.05,
+    dividend: -0.12,
+    moat: 0.09
+  },
+  notes: "Correlations against L3 residual. Raw style-ETF returns used; orthogonality of the residual to market/sector/subsector means the market and sector components embedded in the style ETFs contribute zero by construction."
+}
+```
+
+This is a thin wrapper over the existing correlation endpoint — single call, all 8 factors, structured for "Style DNA" visualization.
+
+## Website content implications (riskmodels.app)
+
+**"Style DNA" card on the stock page** — small horizontal bar chart per factor, colored navy for positive loading, orange for negative, annotated with the factor's ETF ticker. Sits directly under the existing L3 Risk DNA. Tells the PM: "yes, you stripped market and sector, but your NVDA residual is still +0.42 momentum and –0.33 value — if you're value-styled, you are unknowingly carrying anti-value exposure in your residual."
+
+**Landing-page claim upgrade** — "We decompose every US equity down to market, sector, subsector, style factor, and idiosyncratic residual — all through one API." This closes the Barra/Axioma parity gap for the style-factor piece of the story with a tiny data addition.
+
+## Medium / content angle
+
+Fits naturally as a **Part 3.5 appendix** or a **standalone follow-up piece**. Thesis: "Your residual may not be alpha — it may still be style tilt you didn't mean to own."
+
+Concrete example: take NVDA's L3 residual from Part 1 (+11.5pp over the trailing year, looks like pure idiosyncratic alpha). Correlate with MTUM and QUAL. If MTUM correlation is strong, the residual is materially "momentum overlay on top of the semi-cycle bet" rather than pure NVDA-specific information. That's a substantively different thing for a PM to own knowingly vs unknowingly. Same cascade, one more layer.
+
+## Caveats / design decisions
+
+- **Correlation vs regression beta.** Pearson correlation answers "do these move together?" but not "what's the $ exposure?" For a full Barra-parity product the follow-on is **rolling regression of residual on style-ETF returns** to produce style *betas* (dollar or dimensionless). That's a second step; v1 correlation is enough for a visible "Style DNA" story.
+- **History matters.** MSCI factor ETFs back to 2013 only. For decade-plus lookbacks (e.g. through 2008), we rely on the Russell pair (IWF/IWD) and IWM. Document this clearly in SEMANTIC_ALIASES so users don't get surprised by NaN-filled pre-2013 rows for MTUM/QUAL/VLUE.
+- **Orthogonality holds only vs L3 residual.** If callers correlate style factors against the L2 residual or the raw stock, market/sector components of the style ETFs will leak in. The convenience endpoint should be explicit about which residual it uses.
+- **Factor overlap.** Momentum and Quality historically correlate positively; Value and Growth strongly negatively; Low-Vol and Quality moderately positively. Surface the factor-factor correlation matrix on the factor documentation page so PMs can interpret loadings in context.
+- **macro vs style mixing.** Keep them co-resident in `macro_factors` for simplicity but do add the `category` metadata field so the UI can separate the two cleanly.
+
+## Effort estimate (if scheduled)
+
+- **Tier 1 (data + API exposure):** ~half a day
+  - Add `STYLE_SLEEVE_BY_TICKER` + `STYLE_FACTOR_KEYS_ORDER` to `macro_factor_constants.py` (30 min)
+  - Write `sync_style_factors_to_macro_factors.py` that reads from existing `ds_etf.zarr` and upserts to Supabase (1-2 hr — it's just a shaped read + upsert; no source fetching since data already in ds_etf)
+  - Run full backfill (fast — all data already local in GCS zarr)
+  - Update TS factor-keys file + OpenAPI spec + semantic aliases (2 hr)
+  - Cross-repo schema sync (30 min)
+  - Smoke test via existing correlation endpoints (30 min)
+
+- **Tier 2 (convenience endpoint + SDK helpers):** 0.5 day
+
+- **Tier 3 (website "Style DNA" card + Medium piece):** 1-2 days content/design work
+
+## Related files
+
+- Python canonical source: `/Users/conradgann/BW_Code/ERM3/erm3/shared/macro_factor_constants.py`
+- TS canonical source: `/Users/conradgann/BW_Code/RiskModels_API/lib/risk/macro-factor-keys.ts`
+- Correlation API: `/Users/conradgann/BW_Code/RiskModels_API/app/api/metrics/[ticker]/correlation/route.ts`, `/api/correlation/route.ts`
+- Macro factors endpoint: `/Users/conradgann/BW_Code/RiskModels_API/app/api/macro-factors/route.ts`
+- Supabase schema: `SUPABASE_TABLES.md` — `macro_factors` row
+- Build script: `erm3/**/build_macro_factor_zarr.py` (ERM3 repo)
+- Cross-repo sync checklist: `docs/AGENTS_CROSS_REPO.md`
+
+## Recommended order of operations (when scheduled)
+
+1. Pick 6 vs 8 factors — commit to the set.
+2. Update Python constants; run `build_macro_factor_zarr` in a branch.
+3. Verify zarr writes with NaN-filled pre-launch rows for short-history factors.
+4. Sync to Supabase; spot-check a few `(factor_key, teo)` rows.
+5. Update TS + OpenAPI + SDK; deploy.
+6. Manual QA: `GET /api/metrics/NVDA/correlation?factor_key=momentum` against a reference calculation.
+7. Ship "Style DNA" card on site.
+8. Draft the Medium appendix piece.

--- a/docs/portfolio-risk-snapshot-runbook.md
+++ b/docs/portfolio-risk-snapshot-runbook.md
@@ -1,0 +1,182 @@
+# Snapshot — Discovery → Working Client Runbook
+
+**Audience:** developer or AI agent integrating with the RiskModels API for the
+first time. Goal: discover the canonical `POST /snapshot` endpoint and call it
+end-to-end without prior knowledge of the API.
+
+**Per Snapshot Architecture v3** (`BWMACRO/docs/SNAPSHOT_ARCHITECTURE_V3.md`),
+`POST /snapshot` is the only public analysis interface. Internal endpoints
+(`/decompose`, `/metrics/{ticker}`, `/portfolio/risk-snapshot`,
+`/batch/analyze`) remain callable but are not the recommended public surface.
+
+---
+
+## 1. Discover the API
+
+Public discovery manifests live at the **site origin** (no `/api` prefix):
+
+```bash
+# OpenAPI spec
+curl -s https://riskmodels.app/openapi.json | jq '.servers'
+
+# MCP server manifest (Model Context Protocol clients)
+curl -s https://riskmodels.app/.well-known/mcp.json | jq '.tools[].name'
+
+# OpenAI plugin manifest
+curl -s https://riskmodels.app/.well-known/ai-plugin.json
+```
+
+The OpenAPI `servers[0]` (`https://riskmodels.app/api`) is correct for every
+metered endpoint listed in `paths`. The `.well-known/*` paths are the one
+exception: they are served at the bare site origin without `/api`.
+
+### Via MCP
+
+```
+riskmodels_list_endpoints()
+riskmodels_get_capability({ "id": "portfolio-risk-snapshot" })
+```
+
+The `portfolio-risk-snapshot` capability covers both branches of `POST /snapshot`
+(portfolio and ticker) under one billing line; see `mcp/data/capabilities.json`.
+
+## 2. Authenticate
+
+API keys come from `https://riskmodels.app/settings#api-keys`. Format:
+`rm_agent_live_{random}_{checksum}` (production) or `rm_agent_test_{...}`
+(sandbox).
+
+```bash
+export RISKMODELS_API_KEY="rm_agent_live_..."
+```
+
+## 3. Single ticker
+
+```bash
+curl -sS -X POST "https://riskmodels.app/api/snapshot" \
+  -H "Authorization: Bearer ${RISKMODELS_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{"type":"ticker","ticker":"NVDA","lookback_days":120}' \
+  | jq '.snapshot.ticker_meta, .snapshot.variance_decomposition'
+```
+
+Expected response shape (canonical for both branches):
+
+- `snapshot.ticker_meta` *(ticker mode only)* — sector_etf, subsector_etf,
+  asset_type, **factors** (active L3 list: `[SPY, sector_etf, subsector_etf]`
+  deduped).
+- `snapshot.variance_decomposition` — market / sector / subsector / residual
+  shares of return variance.
+- `snapshot.positions[]` — per-position L3 ER and HR (one row in ticker mode).
+- `time_behavior.{teo, cumulative_return, drawdown}` — daily series over
+  `lookback_days`.
+- `attribution.{teo, gross, market, sector, subsector, residual, systematic}` —
+  daily return attribution at each level.
+- `risk_summary.{dominant_drivers, concentration, top_exposures, systematic_risk_share}`.
+- `_metadata` — model version, data_as_of, factor_set_id, **factors**
+  (per-ticker factor list when `type=ticker`), wiki_uri.
+- `_agent` — cost, request_id (per-call billing receipt).
+
+## 4. Portfolio
+
+```bash
+curl -sS -X POST "https://riskmodels.app/api/snapshot" \
+  -H "Authorization: Bearer ${RISKMODELS_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "type": "portfolio",
+    "portfolio": [
+      {"ticker": "NVDA", "weight": 0.40},
+      {"ticker": "AAPL", "weight": 0.30},
+      {"ticker": "MSFT", "weight": 0.20},
+      {"ticker": "GOOG", "weight": 0.10}
+    ],
+    "lookback_days": 252
+  }' \
+  | jq '.snapshot.variance_decomposition, .snapshot.portfolio_volatility_23d'
+```
+
+`shares` is also accepted in lieu of `weight` — the server normalizes via the
+latest `price_close`. Do not mix the two within one request.
+
+## 5. Renamed-ticker recall (FB → META)
+
+Historical-ticker recall is supported as of 2026-05-05: an old ticker resolves
+to its canonical security identifier and the response stitches both spans of
+history into one continuous series.
+
+```bash
+curl -sS "https://riskmodels.app/api/ticker-returns?ticker=FB&years=15" \
+  -H "Authorization: Bearer ${RISKMODELS_API_KEY}" \
+  | jq '.symbol, (.data | length), .data[0].date, .data[-1].date'
+# → "BW-BBG000MM2P62", 3770, "2011-05-05", "2026-05-01"
+```
+
+The same applies to `POST /snapshot {"type":"ticker","ticker":"FB"}` — the
+response carries `ticker: "FB"` (the requested label) and
+`symbol: "BW-BBG000MM2P62"` (the canonical id).
+
+## 6. Python SDK
+
+```python
+from riskmodels import RiskModelsClient
+c = RiskModelsClient.from_env()  # reads RISKMODELS_API_KEY
+
+# Single ticker
+data, lineage = c.snapshot_ticker("NVDA", lookback_days=120)
+print(data["snapshot"]["ticker_meta"]["factors"])
+# → ['SPY', 'XLK', 'SMH']
+
+# Portfolio
+data, lineage = c.snapshot(
+    {"NVDA": 0.4, "AAPL": 0.3, "MSFT": 0.2, "GOOG": 0.1},
+    lookback_days=252,
+)
+print(data["snapshot"]["variance_decomposition"])
+```
+
+## 7. CLI
+
+```bash
+riskmodels snapshot --ticker NVDA --lookback-days 120
+riskmodels snapshot --file portfolio.json --lookback-days 252
+```
+
+`portfolio.json` is either a `{"TICKER": weight, ...}` map or a list of
+`[{"ticker": "...", "weight": ...}, ...]`.
+
+## 8. MCP
+
+The server manifest at `https://riskmodels.app/.well-known/mcp.json` registers
+`post_snapshot` as the canonical analysis tool for both branches.
+
+## 9. Billing
+
+`POST /snapshot` uses the `portfolio-risk-snapshot` capability:
+**$0.25 per request** (single bundled charge, no per-position fee). Cost and
+remaining balance are returned in the response under `_agent.cost_usd` and the
+`X-Balance-Remaining` HTTP header.
+
+## 10. Common errors
+
+- **400 "Invalid request"** — body failed Zod validation. The `details` array
+  carries Zod issue paths.
+- **400 "Symbol not found for ticker X"** — registry miss after all alias
+  fallbacks. Check `https://riskmodels.app/api/tickers?q=X` for nearby matches.
+- **401** — bad / missing API key.
+- **402 "Insufficient balance"** — top up at `/settings#billing`.
+- **429** — playground rate limit (10 req/min for unauthenticated previews).
+- **5xx** — surface the `request_id` and the call timestamp; cross-check
+  `https://github.com/BlueWaterCorp/RiskModels_API/issues` for active incidents.
+
+## 11. References
+
+- [`OPENAPI_SPEC.yaml`](../OPENAPI_SPEC.yaml) — canonical contract (also at
+  `https://riskmodels.app/openapi.json`)
+- [`SEMANTIC_ALIASES.md`](../SEMANTIC_ALIASES.md) — metric naming conventions
+  (HR vs beta, ER fields, abbreviated vs long key names)
+- [`docs/ERM3_ZARR_API_PARITY.md`](./ERM3_ZARR_API_PARITY.md) — zarr ↔ API
+  field parity for power users
+- [`BWMACRO/docs/SNAPSHOT_ARCHITECTURE_V3.md`](https://github.com/BlueWaterCorp/BWMACRO/blob/main/docs/SNAPSHOT_ARCHITECTURE_V3.md) — the v3 design doc
+- [`AUTHENTICATION_GUIDE.md`](../AUTHENTICATION_GUIDE.md) — API key provisioning
+- [`.cursor/skills/riskmodels-api-discovery/SKILL.md`](../.cursor/skills/riskmodels-api-discovery/SKILL.md) — full discovery protocol

--- a/examples/README.md
+++ b/examples/README.md
@@ -14,6 +14,7 @@ Runnable scripts for the RiskModels API and Python SDK. Install the SDK from the
 | [python/ai_risk_analyst.py](python/ai_risk_analyst.py) | Python | Agent-style analyst script |
 | [typescript/quickstart.ts](typescript/quickstart.ts) | TypeScript | HTTP quickstart |
 | [typescript/hedge_portfolio.ts](typescript/hedge_portfolio.ts) | TypeScript | Portfolio hedge (TS) |
+| [agents/risk-analyst-agent/](agents/risk-analyst-agent/) | Docs | **P0** MCP + artifact registry agent guide (`riskmodels_render_artifact`, workflows) |
 
 > **Note on `portfolio_risk_metrics.py` performance**: residual returns are assembled by calling `get_ticker_returns` once per name (N requests), which is fine at the default portfolio of ~8 tickers but scales linearly with portfolio size. For larger universes prefer the batch dataset path (`get_dataset`) where the residual reconstruction can be vectorised.
 

--- a/examples/agents/risk-analyst-agent/README.md
+++ b/examples/agents/risk-analyst-agent/README.md
@@ -1,0 +1,69 @@
+# Risk Analyst Agent (MCP + Python)
+
+Reference agent that uses **RiskModels as the risk substrate** — L3 variance decomposition, ETF hedge ratios, fund/filer holdings, and deterministic artifact renders. This is the P0 “Agent Garden–style” example without hosting on Google Agent Engine: your orchestrator calls **riskmodels.app** tools; RiskModels owns the numbers.
+
+## What you get
+
+| Surface | Tool / entry |
+|--------|----------------|
+| **MCP** (Cursor, Claude Desktop, Codex) | `riskmodels_render_artifact`, `riskmodels_decompose`, `riskmodels_portfolio_decompose`, … |
+| **Hosted MCP** | `https://riskmodels.app/api/mcp/sse` + Bearer key |
+| **Chat on riskmodels.app** | Same tools via the API Risk Analyst (`render_artifact`, `get_risk_metrics`, …) |
+| **Python SDK** | `riskmodels-py` — see [`../python/ai_risk_analyst.py`](../python/ai_risk_analyst.py) |
+
+## Quick start (MCP)
+
+```bash
+export RISKMODELS_API_KEY=rm_agent_…   # https://riskmodels.app/get-key
+npx -y riskmodels@latest install
+# Claude Code also: claude mcp add --scope user --transport stdio riskmodels -- npx -y @riskmodels/mcp
+```
+
+Agent discovery: [https://riskmodels.app/llms.txt](https://riskmodels.app/llms.txt)
+
+## Example workflow (fund)
+
+1. `riskmodels` MCP: search / resolve fund → `BW-FUND-…`
+2. `riskmodels_decompose` or `get_risk_metrics` (via chat) for scalar L3 metrics
+3. `riskmodels_render_artifact` with `slug=top_holdings_erm_stacked`, `format=json`
+4. Optional narratives: `narrative_profile`, `narrative_perf_insight`, `narrative_risk_insight`
+
+```json
+{
+  "slug": "top_holdings_erm_stacked",
+  "version": "v1",
+  "subject_id": "BW-FUND-S000004563",
+  "as_of": "latest",
+  "format": "json"
+}
+```
+
+## Example workflow (13F filer)
+
+1. Resolve filer → `BW-FILER-…`
+2. Render with **explicit** `as_of` (filing period end), e.g. `2026-03-31` for cache hits
+3. Slugs: `top_holdings_erm_stacked`, `cumulative_return_strip`, `entity_header`, `risk_summary_panel`, …
+
+## Architecture
+
+```text
+Your agent (Cursor / ADK local / custom loop)
+    → MCP or REST on riskmodels.app
+        → DAL / metrics / batch analyze
+        → render-svc POST /artifacts/render (deterministic JSON/PNG)
+```
+
+**Do not** treat generic web search or LLM-drawn charts as risk truth. Artifacts are render-once; cite fields from the JSON payload.
+
+## Analyst boundary (institutional)
+
+RiskModels is an **analytical tool**, not an investment adviser. Agents should **show** hedge ratios and decomposition math, not prescribe trades. See BWMACRO `docs/architecture/intelligence_runtime/THE_ANALYST.md` §2.
+
+## Ops
+
+- **render-svc** must be deployed and `RENDER_SVC_URL` set on the API portal for `render_artifact` / `riskmodels_render_artifact` (see `services/render-svc/RUNBOOK.md`).
+- Billing: capability `artifact-render` (~$0.05/request on the API meter).
+
+## P1 note (not in this example)
+
+Portfolio what-if, drift monitoring, and higher-level **bwmacro** skills are gated on a **premium** chat tier / API scope — define before expanding tool surface.

--- a/examples/agents/risk-analyst-agent/SKILL.md
+++ b/examples/agents/risk-analyst-agent/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: risk-analyst-agent
+description: Build agents on RiskModels L3 risk data via MCP and the artifact registry. Use when wiring Cursor/Claude to decompose equities, render deterministic fund/filer panels, or document a Risk Analyst example.
+---
+
+# Risk Analyst Agent (RiskModels substrate)
+
+## Discovery
+
+1. Read https://riskmodels.app/llms.txt
+2. Install MCP: `RISKMODELS_API_KEY=… npx -y riskmodels@latest install`
+3. Prefer MCP tools `riskmodels_*` over inventing REST paths
+
+## Core tools
+
+| Goal | Tool |
+|------|------|
+| Single-name L3 snapshot | `riskmodels_decompose` or chat `get_risk_metrics` |
+| Compare names | `riskmodels_compare` |
+| Weighted portfolio | `riskmodels_portfolio_decompose` / `compute_portfolio_risk_index` |
+| Deterministic chart/table JSON | `riskmodels_render_artifact` |
+| Resolve fund | `search_funds` → `BW-FUND-…` |
+| Resolve 13F filer | `search_filers` → `BW-FILER-…` |
+
+## render_artifact contract
+
+- **slug**: `top_holdings_erm_stacked`, `cumulative_return_strip`, `narrative_profile`, `narrative_perf_insight`, `narrative_risk_insight`, plus filer panels (`entity_header`, `risk_summary_panel`, …)
+- **subject_id**: `BW-FUND-*`, `BW-FILER-*`, or `BW-PORTFOLIO-*` with `subject_payload.positions` for pasted books
+- **as_of**: `latest` for funds; filers often need explicit `YYYY-MM-DD`
+- **format**: `json` for chat (default); `png`/`svg` return base64
+
+## Rules
+
+- Fan out independent ticker/fund calls in **one** tool round when possible (API executes them in parallel).
+- Never fabricate metrics — call tools first.
+- Hedge ratios are **dollars of ETF per $1 of stock**; ER values are variance fractions in `[0,1]`.
+- Do not recommend trades; show decomposition and mechanical hedge math only.
+
+## Reference
+
+Full README: `examples/agents/risk-analyst-agent/README.md` in RiskModels_API.

--- a/lib/agent/capabilities.ts
+++ b/lib/agent/capabilities.ts
@@ -961,6 +961,66 @@ export const CAPABILITIES: Capability[] = [
     tags: ["portfolio", "pdf", "risk", "report"],
   },
   {
+    id: "artifact-render",
+    name: "Artifact registry render",
+    description:
+      "Deterministic render-once artifact from the intelligence registry (fund / filer / client_portfolio subjects). " +
+      "Invokes render-svc `POST /artifacts/render` — same contract as riskmodels.net workspace `fetchArtifact`. " +
+      "Returns JSON chart/table/narrative payloads or PNG/SVG bytes (base64). Chat tool: `render_artifact`; MCP: `riskmodels_render_artifact`.",
+    endpoint: "/artifacts/render",
+    method: "POST",
+    parameters: {
+      slug: {
+        type: "string",
+        required: true,
+        description: "Artifact slug (e.g. top_holdings_erm_stacked, narrative_profile)",
+      },
+      version: {
+        type: "string",
+        required: false,
+        description: "Semantic version tag, default v1",
+        default: "v1",
+      },
+      subject_id: {
+        type: "string",
+        required: true,
+        description: "BW-FUND-…, BW-FILER-…, or BW-PORTFOLIO-…",
+      },
+      as_of: {
+        type: "string",
+        required: false,
+        description: "YYYY-MM-DD or latest",
+        default: "latest",
+      },
+      format: {
+        type: "string",
+        required: false,
+        description: "json | png | svg",
+        enum: ["json", "png", "svg"],
+        default: "json",
+      },
+    },
+    pricing: {
+      model: "per_request",
+      tier: "premium",
+      cost_usd: 0.05,
+      currency: "USD",
+      billing_code: "artifact_render_v1",
+    },
+    performance: {
+      avg_latency_ms: 1200,
+      p95_latency_ms: 4000,
+      availability_sla: 99.5,
+      rate_limit_per_minute: 30,
+    },
+    confidence: {
+      data_quality_score: 0.98,
+      update_frequency: "daily",
+      sources: ["Funds_DAG", "ERM3", "render-svc"],
+    },
+    tags: ["artifact", "registry", "render", "fund", "filer"],
+  },
+  {
     id: "factor-correlation",
     name: "Macro factor correlation",
     description:

--- a/lib/artifacts/gcp-id-token.ts
+++ b/lib/artifacts/gcp-id-token.ts
@@ -1,0 +1,37 @@
+/**
+ * Mint Cloud Run ID tokens for server-to-server calls (render-svc).
+ * Mirrors Risk_Models `gcp-cloud-run-id-token.ts` without portal-only debug hooks.
+ */
+
+import { GoogleAuth } from "google-auth-library";
+
+function resolveGoogleAuth(): GoogleAuth | null {
+  const raw =
+    process.env.GCS_SERVICE_ACCOUNT_KEY?.trim() ||
+    process.env.GCP_SERVICE_ACCOUNT_JSON?.trim();
+  if (raw) {
+    try {
+      return new GoogleAuth({ credentials: JSON.parse(raw) as object });
+    } catch {
+      return null;
+    }
+  }
+  const keyFile = process.env.GOOGLE_APPLICATION_CREDENTIALS?.trim();
+  if (keyFile) {
+    return new GoogleAuth({ keyFile });
+  }
+  return null;
+}
+
+/** Bearer token for `targetUrl` (Cloud Run audience), or undefined if no GCP creds. */
+export async function authorizationHeaderForCloudRun(
+  targetUrl: string,
+): Promise<string | undefined> {
+  const auth = resolveGoogleAuth();
+  if (!auth) {
+    return undefined;
+  }
+  const client = await auth.getIdTokenClient(targetUrl);
+  const headers = await client.getRequestHeaders();
+  return headers.Authorization;
+}

--- a/lib/artifacts/render-client.ts
+++ b/lib/artifacts/render-client.ts
@@ -1,0 +1,192 @@
+/**
+ * Server-side client for render-svc `POST /artifacts/render`.
+ * SSOT: `services/render-svc/render_svc/artifacts.py`
+ */
+
+import { authorizationHeaderForCloudRun } from "@/lib/artifacts/gcp-id-token";
+
+export type ArtifactRenderFormat = "json" | "png" | "svg";
+
+export interface ArtifactRenderParams {
+  slug: string;
+  version?: string;
+  subject_id: string;
+  as_of?: string;
+  format?: ArtifactRenderFormat;
+  subject_payload?: Record<string, unknown> | null;
+}
+
+export interface ArtifactRenderSuccess {
+  ok: true;
+  data: unknown;
+  resolved_as_of: string;
+  gcs_path: string;
+  receipt_id: string | null;
+  format: ArtifactRenderFormat;
+}
+
+export interface ArtifactRenderFailure {
+  ok: false;
+  status: number;
+  error: string;
+  detail?: unknown;
+}
+
+export type ArtifactRenderResult = ArtifactRenderSuccess | ArtifactRenderFailure;
+
+/** Slugs with render-svc adapters wired today (see artifacts.py). */
+export const WIRED_ARTIFACT_RENDER_MATRIX: Record<
+  string,
+  { subject_kinds: string[]; notes?: string }
+> = {
+  top_holdings_erm_stacked: {
+    subject_kinds: ["fund", "client_portfolio", "filer_13f"],
+  },
+  cumulative_return_strip: {
+    subject_kinds: ["fund", "filer_13f"],
+    notes: "filer: cache hit or explicit as_of only (no live loader on miss).",
+  },
+  narrative_profile: { subject_kinds: ["fund"] },
+  narrative_perf_insight: { subject_kinds: ["fund"] },
+  narrative_risk_insight: { subject_kinds: ["fund"] },
+  entity_header: { subject_kinds: ["filer_13f"] },
+  return_composition_bars: { subject_kinds: ["filer_13f"] },
+  active_risk_composition: { subject_kinds: ["filer_13f"] },
+  risk_summary_panel: { subject_kinds: ["filer_13f"] },
+};
+
+function renderSvcUrl(): string | null {
+  const raw = process.env.RENDER_SVC_URL?.trim();
+  return raw ? raw.replace(/\/$/, "") : null;
+}
+
+function parseJsonBody(text: string): unknown {
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return { raw_text: text.slice(0, 500) };
+  }
+}
+
+/**
+ * Render a registry artifact via render-svc. JSON responses are parsed;
+ * binary formats return base64 in the result object for tool payloads.
+ */
+export async function renderArtifact(
+  params: ArtifactRenderParams,
+): Promise<ArtifactRenderResult> {
+  const base = renderSvcUrl();
+  if (!base) {
+    return {
+      ok: false,
+      status: 503,
+      error:
+        "RENDER_SVC_URL is not configured. Artifact registry renders require the render-svc Cloud Run service (see services/render-svc/RUNBOOK.md).",
+    };
+  }
+
+  const version = params.version ?? "v1";
+  const as_of = params.as_of ?? "latest";
+  const format = params.format ?? "json";
+
+  const body: Record<string, unknown> = {
+    slug: params.slug,
+    version,
+    subject_id: params.subject_id,
+    as_of,
+    format,
+  };
+  if (params.subject_payload != null) {
+    body.subject_payload = params.subject_payload;
+  }
+
+  const upstream = `${base}/artifacts/render`;
+  let authz: string | undefined;
+  try {
+    authz = await authorizationHeaderForCloudRun(base);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return {
+      ok: false,
+      status: 502,
+      error: `Failed to mint Cloud Run ID token: ${msg}`,
+    };
+  }
+
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (authz) {
+    headers.Authorization = authz;
+  }
+
+  let res: Response;
+  try {
+    res = await fetch(upstream, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body),
+    });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return {
+      ok: false,
+      status: 502,
+      error: `render-svc unreachable: ${msg}`,
+    };
+  }
+
+  const resolvedAsOf = res.headers.get("x-artifact-resolved-as-of") ?? as_of;
+  const gcsPath = res.headers.get("x-artifact-gcs-path") ?? "";
+  const receiptId = res.headers.get("x-artifact-receipt-id");
+
+  if (!res.ok) {
+    const text = await res.text();
+    let detail: unknown = text;
+    try {
+      detail = JSON.parse(text) as unknown;
+    } catch {
+      // keep text
+    }
+    const errMsg =
+      detail &&
+      typeof detail === "object" &&
+      detail !== null &&
+      "detail" in detail &&
+      typeof (detail as { detail: unknown }).detail === "string"
+        ? (detail as { detail: string }).detail
+        : `render-svc returned HTTP ${res.status}`;
+    return {
+      ok: false,
+      status: res.status,
+      error: errMsg,
+      detail,
+    };
+  }
+
+  if (format === "json") {
+    const text = await res.text();
+    return {
+      ok: true,
+      data: parseJsonBody(text),
+      resolved_as_of: resolvedAsOf,
+      gcs_path: gcsPath,
+      receipt_id: receiptId,
+      format,
+    };
+  }
+
+  const buf = await res.arrayBuffer();
+  const bytes = Buffer.from(buf);
+  return {
+    ok: true,
+    data: {
+      format,
+      content_type: res.headers.get("content-type") ?? `image/${format}`,
+      base64: bytes.toString("base64"),
+      byte_length: bytes.length,
+    },
+    resolved_as_of: resolvedAsOf,
+    gcs_path: gcsPath,
+    receipt_id: receiptId,
+    format,
+  };
+}

--- a/lib/chat/tools.ts
+++ b/lib/chat/tools.ts
@@ -43,6 +43,10 @@ import {
   sanitizePortfolioRiskIndexResult,
   truncateRowsWithSummary,
 } from "@/lib/chat/utils";
+import {
+  renderArtifact,
+  WIRED_ARTIFACT_RENDER_MATRIX,
+} from "@/lib/artifacts/render-client";
 
 function fnTool(
   name: string,
@@ -133,6 +137,15 @@ const searchFilersArgs = z.object({
 const getFilerHoldingsArgs = z.object({
   bw_filer_id: z.string().min(1, "bw_filer_id required (call search_filers first)"),
   limit: z.coerce.number().int().min(1).max(100).default(25),
+});
+
+const renderArtifactArgs = z.object({
+  slug: z.string().min(1),
+  subject_id: z.string().min(1),
+  version: z.string().default("v1"),
+  as_of: z.string().default("latest"),
+  format: z.enum(["json", "png", "svg"]).default("json"),
+  subject_payload_json: z.string().default(""),
 });
 
 const portfolioRiskArgs = z.object({
@@ -466,6 +479,51 @@ async function execGetFilerHoldings(args: z.infer<typeof getFilerHoldingsArgs>) 
     n_holdings_returned: holdings.n_holdings_returned,
     n_total_holdings: holdings.n_total_holdings,
     holdings: holdings.holdings,
+  };
+}
+
+async function execRenderArtifact(args: z.infer<typeof renderArtifactArgs>) {
+  let subject_payload: Record<string, unknown> | undefined;
+  const raw = args.subject_payload_json?.trim();
+  if (raw) {
+    try {
+      subject_payload = JSON.parse(raw) as Record<string, unknown>;
+    } catch {
+      return {
+        error: "invalid_subject_payload_json",
+        message: "subject_payload_json must be valid JSON (e.g. {\"positions\":[{\"ticker\":\"AAPL\",\"weight\":0.5}]}).",
+      };
+    }
+  }
+
+  const result = await renderArtifact({
+    slug: args.slug,
+    version: args.version,
+    subject_id: args.subject_id,
+    as_of: args.as_of,
+    format: args.format,
+    subject_payload,
+  });
+
+  if (!result.ok) {
+    return {
+      error: "artifact_render_failed",
+      status: result.status,
+      message: result.error,
+      detail: result.detail,
+      wired_slugs: WIRED_ARTIFACT_RENDER_MATRIX,
+    };
+  }
+
+  return {
+    slug: args.slug,
+    version: args.version,
+    subject_id: args.subject_id,
+    format: result.format,
+    resolved_as_of: result.resolved_as_of,
+    gcs_path: result.gcs_path,
+    receipt_id: result.receipt_id,
+    artifact: result.data,
   };
 }
 
@@ -942,6 +1000,46 @@ export const CHAT_TOOLS_REGISTRY: ChatToolDef[] = [
     capabilityId: "filer-holdings",
     argSchema: getFilerHoldingsArgs,
     executor: async (a) => execGetFilerHoldings(getFilerHoldingsArgs.parse(a)),
+  },
+  {
+    name: "render_artifact",
+    openaiTool: fnTool(
+      "render_artifact",
+      "Deterministic artifact from the intelligence registry (fund BW-FUND-…, filer BW-FILER-…, or client portfolio BW-PORTFOLIO-…). Returns JSON chart/table/narrative payloads or PNG/SVG (base64). Use AFTER search_funds/search_filers resolved a subject_id. Prefer format=json for chat tables. For client_portfolio pass subject_payload_json with {\"positions\":[{\"ticker\":\"AAPL\",\"weight\":0.5}]}. Filer slugs need explicit as_of (filing period end). Do not invent chart data — cite fields from the artifact JSON.",
+      {
+        slug: {
+          type: "string",
+          description:
+            "Artifact slug, e.g. top_holdings_erm_stacked, narrative_profile, entity_header, risk_summary_panel",
+        },
+        subject_id: {
+          type: "string",
+          description: "BW-FUND-…, BW-FILER-…, or BW-PORTFOLIO-…",
+        },
+        version: {
+          type: "string",
+          description: "Registry version tag, default v1",
+        },
+        as_of: {
+          type: "string",
+          description: "YYYY-MM-DD or latest; filers should use filing period end",
+        },
+        format: {
+          type: "string",
+          enum: ["json", "png", "svg"],
+          description: "Output format, default json",
+        },
+        subject_payload_json: {
+          type: "string",
+          description:
+            "Optional JSON string for BW-PORTFOLIO-* subjects: {\"positions\":[{\"ticker\":\"AAPL\",\"weight\":0.5}]}",
+        },
+      },
+      ["slug", "subject_id", "version", "as_of", "format", "subject_payload_json"],
+    ),
+    capabilityId: "artifact-render",
+    argSchema: renderArtifactArgs,
+    executor: async (a) => execRenderArtifact(renderArtifactArgs.parse(a)),
   },
   {
     name: "compute_portfolio_risk_index",

--- a/lib/mcp/tools/riskmodels-tools.ts
+++ b/lib/mcp/tools/riskmodels-tools.ts
@@ -2,6 +2,10 @@ import { readFileSync } from "fs";
 import { join } from "path";
 import { RiskModelsClient, type PositionInput, type WhitepaperExampleId } from "@riskmodels/sdk";
 import { z } from "zod";
+import {
+  renderArtifact,
+  WIRED_ARTIFACT_RENDER_MATRIX,
+} from "@/lib/artifacts/render-client";
 
 type McpContent = { type: "text"; text: string };
 type McpToolResult = { content: McpContent[] };
@@ -190,6 +194,66 @@ export function registerRiskModelsTools(
     async ({ positions }) => {
       try {
         return textResult(await sdk.portfolioDecompose(positions as PositionInput[]));
+      } catch (error) {
+        return errorResult(error);
+      }
+    },
+  );
+
+  server.registerTool(
+    "riskmodels_render_artifact",
+    {
+      title: "RiskModels Artifact Registry Render",
+      description:
+        "Render a deterministic registry artifact (fund, filer, or client portfolio). Returns JSON chart/table/narrative or base64 PNG/SVG. Same contract as riskmodels.net workspace fetchArtifact.",
+      inputSchema: {
+        slug: z.string().min(1).describe("Artifact slug, e.g. top_holdings_erm_stacked"),
+        version: z.string().optional().describe("Version tag, default v1"),
+        subject_id: z
+          .string()
+          .min(1)
+          .describe("BW-FUND-…, BW-FILER-…, or BW-PORTFOLIO-…"),
+        as_of: z
+          .string()
+          .optional()
+          .describe("YYYY-MM-DD or latest; filers need explicit filing period end"),
+        format: z
+          .enum(["json", "png", "svg"])
+          .optional()
+          .describe("Output format, default json"),
+        subject_payload: z
+          .record(z.string(), z.unknown())
+          .optional()
+          .describe("Required for BW-PORTFOLIO-*: { positions: [{ ticker, weight }] }"),
+      },
+    },
+    async ({ slug, version, subject_id, as_of, format, subject_payload }) => {
+      try {
+        const result = await renderArtifact({
+          slug,
+          version,
+          subject_id,
+          as_of,
+          format,
+          subject_payload: subject_payload ?? null,
+        });
+        if (!result.ok) {
+          return textResult({
+            error: result.error,
+            status: result.status,
+            detail: result.detail,
+            wired_slugs: WIRED_ARTIFACT_RENDER_MATRIX,
+          });
+        }
+        return textResult({
+          slug,
+          subject_id,
+          format: result.format,
+          resolved_as_of: result.resolved_as_of,
+          gcs_path: result.gcs_path,
+          receipt_id: result.receipt_id,
+          artifact: result.data,
+        });
       } catch (error) {
         return errorResult(error);
       }

--- a/mcp/data/capabilities.json
+++ b/mcp/data/capabilities.json
@@ -1267,5 +1267,62 @@
         }
       }
     ]
+  },
+  {
+    "id": "artifact-render",
+    "name": "Artifact registry render",
+    "description": "Deterministic render-once artifact from the intelligence registry (fund / filer / client_portfolio subjects). Invokes render-svc POST /artifacts/render. Returns JSON chart/table/narrative payloads or PNG/SVG bytes (base64). Chat tool: render_artifact; MCP: riskmodels_render_artifact.",
+    "endpoint": "/artifacts/render",
+    "method": "POST",
+    "parameters": {
+      "slug": {
+        "type": "string",
+        "required": true,
+        "description": "Artifact slug (e.g. top_holdings_erm_stacked, narrative_profile)"
+      },
+      "version": {
+        "type": "string",
+        "required": false,
+        "description": "Semantic version tag, default v1",
+        "default": "v1"
+      },
+      "subject_id": {
+        "type": "string",
+        "required": true,
+        "description": "BW-FUND-…, BW-FILER-…, or BW-PORTFOLIO-…"
+      },
+      "as_of": {
+        "type": "string",
+        "required": false,
+        "description": "YYYY-MM-DD or latest",
+        "default": "latest"
+      },
+      "format": {
+        "type": "string",
+        "required": false,
+        "description": "json | png | svg",
+        "enum": ["json", "png", "svg"],
+        "default": "json"
+      }
+    },
+    "pricing": {
+      "model": "per_request",
+      "tier": "premium",
+      "cost_usd": 0.05,
+      "currency": "USD",
+      "billing_code": "artifact_render_v1"
+    },
+    "performance": {
+      "avg_latency_ms": 1200,
+      "p95_latency_ms": 4000,
+      "availability_sla": 99.5,
+      "rate_limit_per_minute": 30
+    },
+    "confidence": {
+      "data_quality_score": 0.98,
+      "update_frequency": "daily",
+      "sources": ["Funds_DAG", "ERM3", "render-svc"]
+    },
+    "tags": ["artifact", "registry", "render", "fund", "filer"]
   }
 ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "commander": "^13.1.0",
         "framer-motion": "^11.18.2",
         "fuse.js": "^7.1.0",
+        "google-auth-library": "^9.15.1",
         "gray-matter": "^4.0.3",
         "inquirer": "^9.3.7",
         "js-yaml": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "commander": "^13.1.0",
     "framer-motion": "^11.18.2",
     "fuse.js": "^7.1.0",
+    "google-auth-library": "^9.15.1",
     "gray-matter": "^4.0.3",
     "inquirer": "^9.3.7",
     "js-yaml": "^4.1.0",

--- a/scripts/doppler-vercel-allowlist.txt
+++ b/scripts/doppler-vercel-allowlist.txt
@@ -20,6 +20,9 @@ RISKMODELS_API_SERVICE_KEY
 # Pooled billing user for .net BFF when X-RiskModels-User-Authorization is absent (same Supabase project as API).
 RISKMODELS_GATEWAY_BILLING_USER_ID
 
+# render-svc (artifact registry + chat/MCP render_artifact). Cloud Run URL + GCP_SERVICE_ACCOUNT_JSON for ID tokens.
+RENDER_SVC_URL
+
 # GCS Zarr (API history). Set in Doppler via docs/DEPLOY_ZARR_GCS_API.md Part B1.
 GCP_SERVICE_ACCOUNT_JSON
 ZARR_GCS_PREFIX

--- a/supabase/migrations/20260517100000_profiles_complimentary_professional.sql
+++ b/supabase/migrations/20260517100000_profiles_complimentary_professional.sql
@@ -1,0 +1,11 @@
+-- Mirror of canonical: Risk_Models/riskmodels_com/supabase/migrations/20260517100000_profiles_complimentary_professional.sql
+
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS complimentary_professional boolean NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN public.profiles.complimentary_professional IS
+  'When true, riskmodels.net treats the user as active professional without billing.';
+
+CREATE INDEX IF NOT EXISTS idx_profiles_complimentary_professional
+  ON public.profiles (complimentary_professional)
+  WHERE complimentary_professional = true;

--- a/supabase/migrations/20260517110000_profiles_complimentary_professional_until.sql
+++ b/supabase/migrations/20260517110000_profiles_complimentary_professional_until.sql
@@ -1,0 +1,7 @@
+-- Mirror: Risk_Models/riskmodels_com/supabase/migrations/20260517110000_profiles_complimentary_professional_until.sql
+
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS complimentary_professional_until timestamptz NULL;
+
+COMMENT ON COLUMN public.profiles.complimentary_professional_until IS
+  'When complimentary_professional is true: access ends after this instant (UTC). NULL = open-ended until revoked.';

--- a/supabase/migrations/20260520000000_security_master_add_edgar_company_name.sql
+++ b/supabase/migrations/20260520000000_security_master_add_edgar_company_name.sql
@@ -1,0 +1,9 @@
+-- ERM3 security_master pipeline includes edgar_company_name (SEC EDGAR
+-- company-profile enrichment); sync uses SELECT * and REST upsert.
+-- PostgREST rejects unknown columns (PGRST204) if this is missing.
+
+ALTER TABLE public.security_master
+  ADD COLUMN IF NOT EXISTS edgar_company_name TEXT;
+
+COMMENT ON COLUMN public.security_master.edgar_company_name IS
+  'Company name as registered with SEC EDGAR; populated from the ERM3 security_master pipeline (company-profile enrichment).';

--- a/tests/artifacts/render-client.test.ts
+++ b/tests/artifacts/render-client.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { renderArtifact } from "@/lib/artifacts/render-client";
+
+describe("renderArtifact", () => {
+  const originalFetch = global.fetch;
+  const originalEnv = process.env.RENDER_SVC_URL;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    if (originalEnv === undefined) {
+      delete process.env.RENDER_SVC_URL;
+    } else {
+      process.env.RENDER_SVC_URL = originalEnv;
+    }
+    vi.restoreAllMocks();
+  });
+
+  it("returns 503 when RENDER_SVC_URL is unset", async () => {
+    delete process.env.RENDER_SVC_URL;
+    const result = await renderArtifact({
+      slug: "narrative_profile",
+      subject_id: "BW-FUND-S000004563",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(503);
+    }
+  });
+
+  it("parses JSON success from render-svc", async () => {
+    process.env.RENDER_SVC_URL = "https://render.example.run.app";
+    global.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ slug: "narrative_profile", text: "Profile: …" }), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json",
+          "X-Artifact-Resolved-As-Of": "2025-11-30",
+          "X-Artifact-GCS-Path": "snapshots/artifacts/narrative_profile@v1/BW-FUND-X/2025-11-30.json",
+          "X-Artifact-Receipt-Id": "abc12345",
+        },
+      }),
+    );
+
+    const result = await renderArtifact({
+      slug: "narrative_profile",
+      subject_id: "BW-FUND-S000004563",
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.resolved_as_of).toBe("2025-11-30");
+      expect(result.receipt_id).toBe("abc12345");
+      expect((result.data as { slug: string }).slug).toBe("narrative_profile");
+    }
+  });
+});

--- a/tests/onboarding-upgrade.test.ts
+++ b/tests/onboarding-upgrade.test.ts
@@ -223,6 +223,7 @@ describe("RiskModels MCP live-paper tools", () => {
       "riskmodels_compare",
       "riskmodels_hedge_position",
       "riskmodels_portfolio_decompose",
+      "riskmodels_render_artifact",
       "riskmodels_whitepaper_example",
     ]);
 


### PR DESCRIPTION
## Summary
- Adds chat tool `render_artifact` and MCP `riskmodels_render_artifact` calling render-svc `POST /artifacts/render` (Cloud Run ID token via `google-auth-library`).
- Registers capability `artifact-render` (~$0.05/request, `artifact_render_v1`) and syncs `mcp/data/capabilities.json`.
- Publishes `examples/agents/risk-analyst-agent/` (README + SKILL) as the Agent Garden–style reference without Google hosting.

## Out of scope (P1)
Portfolio what-if and higher-level bwmacro skills stay gated until premium `.net` chat tier or premium API scopes are defined (see backlog O.11).

## Test plan
- [x] `npx vitest run tests/artifacts/render-client.test.ts tests/onboarding-upgrade.test.ts`
- [ ] After merge: set `RENDER_SVC_URL` + GCP invoker creds on riskmodels.app Vercel
- [ ] Smoke MCP `riskmodels_render_artifact` with `top_holdings_erm_stacked` + known `BW-FUND-…`


Made with [Cursor](https://cursor.com)