### PR TITLE
feat(ecosystem): consistent cross-site footer strip (Q.14)

### DIFF
--- a/components/EcosystemBar.tsx
+++ b/components/EcosystemBar.tsx
@@ -1,0 +1,50 @@
+export type EcosystemSite = 'org' | 'net' | 'app';
+
+const SITES: { id: EcosystemSite; label: string; href: string }[] = [
+  { id: 'org', label: 'Research', href: 'https://riskmodels.org' },
+  { id: 'net', label: 'Workspace', href: 'https://riskmodels.net' },
+  { id: 'app', label: 'API', href: 'https://riskmodels.app' },
+];
+
+/**
+ * Cross-site ecosystem strip (MASTER_BACKLOG Q.14) — the same three-link
+ * element on riskmodels .org / .net / .app, current site marked. Keeps the
+ * three properties legible as one linked product group.
+ */
+export function EcosystemBar({
+  current,
+  className = '',
+}: {
+  current: EcosystemSite;
+  className?: string;
+}) {
+  return (
+    <div
+      className={`flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] ${className}`}
+      aria-label="RiskModels ecosystem"
+    >
+      <span className="uppercase tracking-[0.2em] text-zinc-600">RiskModels</span>
+      {SITES.map((s, i) => (
+        <span key={s.id} className="inline-flex items-center gap-3">
+          {i > 0 ? (
+            <span aria-hidden className="text-zinc-700">
+              /
+            </span>
+          ) : null}
+          {s.id === current ? (
+            <span className="text-zinc-300" aria-current="page">
+              {s.label}
+            </span>
+          ) : (
+            <a
+              href={s.href}
+              className="text-zinc-400 transition-colors hover:text-zinc-100"
+            >
+              {s.label}
+            </a>
+          )}
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import { EcosystemBar } from './EcosystemBar';
 
 export default function Footer() {
   return (
@@ -54,6 +55,10 @@ export default function Footer() {
               Legal / Disclosures
             </Link>
           </nav>
+        </div>
+
+        <div className="mt-3 border-t border-white/5 pt-3">
+          <EcosystemBar current="app" />
         </div>
       </div>
     </footer>


### PR DESCRIPTION
## What

MASTER_BACKLOG **Q.14** (riskmodels.app part) — the consistent ecosystem strip; **3 of 3**.

## Changes

- New **`EcosystemBar`** — `RiskModels · Research / Workspace / API`, current site marked; identical structure to the rm_org and .net strips, styled to the `.app` zinc footer.
- Added to `components/Footer.tsx` (below the existing footer row).

With this, all three sites — `.org` (#7), `.net` (#125), `.app` (this) — carry the same ecosystem strip. Phase 2 (separate): contextual hand-off CTAs + UTM attribution.

## Test plan

- `npm run build` — ✅ green (after `npm install` — `node_modules` was stale, missing `@anthropic-ai/sdk`; unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)