### PR TITLE
feat(ecosystem): UTM-tag cross-site links (Q.14 phase 2)

### DIFF
--- a/components/EcosystemBar.tsx
+++ b/components/EcosystemBar.tsx
@@ -6,6 +6,11 @@ const SITES: { id: EcosystemSite; label: string; href: string }[] = [
   { id: 'app', label: 'API', href: 'https://riskmodels.app' },
 ];
 
+/** Cross-site UTM tags so .org/.net/.app traffic is attributable (Q.14 phase 2). */
+function withUtm(href: string, from: EcosystemSite): string {
+  return `${href}?utm_source=riskmodels-${from}&utm_medium=ecosystem-bar&utm_campaign=cross-site`;
+}
+
 /**
  * Cross-site ecosystem strip (MASTER_BACKLOG Q.14) — the same three-link
  * element on riskmodels .org / .net / .app, current site marked. Keeps the
@@ -37,7 +42,7 @@ export function EcosystemBar({
             </span>
           ) : (
             <a
-              href={s.href}
+              href={withUtm(s.href, current)}
               className="text-zinc-400 transition-colors hover:text-zinc-100"
             >
               {s.label}


### PR DESCRIPTION
## What

MASTER_BACKLOG **Q.14 phase 2** — UTM attribution on the cross-site ecosystem links; **3 of 3** (rm_org #8, riskmodels.net #126, this).

The phase-1 `EcosystemBar` already cross-links every page to the other two sites; this makes that traffic **measurable**. Each cross-site link now carries `utm_source=riskmodels-<site>`, `utm_medium=ecosystem-bar`, `utm_campaign=cross-site`.

With this, all three properties tag their cross-links identically — cross-marketing between `.org / .net / .app` is fully attributable.

## Test plan

- `npm run build` — ✅ green

🤖 Generated with [Claude Code](https://claude.com/claude-code)