### PR TITLE
feat(lstar): historical residual_return on GET /api/lstar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the RiskModels API surface and public assets.
 ### Added
 
 - **`GET /api/lstar` — `residual_return` series** — Parallel daily array of Lstar-dispatched residual returns (`l1_rr` / `l2_rr` / `l3_rr` by chosen level), aligned with existing `dates` and `lstar`. OpenAPI `LstarResponse` updated; unit tests in `tests/lstar-service.test.ts`.
+- **Python SDK — `RiskModelsClient.get_lstar()`** — Wraps `GET /lstar`; returns a DataFrame with `date`, dispatched hedge ratios, `total_er`, and `residual_return`. Registered in `capabilities.py` discover output.
 
 ## [0.3.5] — 2026-05-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the RiskModels API surface and public assets.
 
 ## [Unreleased]
 
+### Added
+
+- **`GET /api/lstar` — `residual_return` series** — Parallel daily array of Lstar-dispatched residual returns (`l1_rr` / `l2_rr` / `l3_rr` by chosen level), aligned with existing `dates` and `lstar`. OpenAPI `LstarResponse` updated; unit tests in `tests/lstar-service.test.ts`.
+
 ## [0.3.5] — 2026-05-26
 
 ### Added

--- a/OPENAPI_SPEC.yaml
+++ b/OPENAPI_SPEC.yaml
@@ -1418,6 +1418,7 @@ components:
         - sector_hr
         - subsector_hr
         - total_er
+        - residual_return
         - l2_sector_er
         - l3_subsector_er
         - threshold_used
@@ -1464,6 +1465,16 @@ components:
           description: >
             Sum of explained-return components at the chosen level (market + sector + subsector,
             omitting residual).
+          items:
+            type: number
+            format: float
+            nullable: true
+        residual_return:
+          type: array
+          description: >
+            Daily simple residual return at the chosen Lstar level (`l1_rr`, `l2_rr`, or `l3_rr`
+            from returns decomposition). Parallel to `dates`; `null` when Lstar or source return
+            is unavailable. Not a hedge ratio and not explained-risk variance (`l*_res_er`).
           items:
             type: number
             format: float
@@ -3808,8 +3819,8 @@ paths:
 
         Default `θ = 0.01` (1%). The chat-facing default is server-authoritative; SDK callers can override
         via `?threshold=`. Response carries the chosen level's market / sector / subsector hedge ratios
-        (nulls below the chosen level), the chosen level's total ER, and the raw `l2_sector_er` /
-        `l3_subsector_er` inputs for audit. See the side study at
+        (nulls below the chosen level), the chosen level's total ER and daily residual return
+        (`residual_return`), and the raw `l2_sector_er` / `l3_subsector_er` inputs for audit. See the side study at
         `RM_ORG/content/Medium/series/drafts/lstar_selection/` for why 1% is the default.
 
         **Billing:** $0.02 per request.

--- a/app/api/lstar/route.ts
+++ b/app/api/lstar/route.ts
@@ -32,9 +32,10 @@ function classifyLstarError(message: string): string {
  * θ defaults to 1% (chat-safe). SDK callers can override via `?threshold=`.
  *
  * Response carries the lstar string per date, the chosen level's market /
- * sector / subsector HRs (nulls below the chosen level), and the raw ER
- * inputs (`l2_sector_er`, `l3_subsector_er`) so callers can audit or apply
- * their own threshold without a second request.
+ * sector / subsector HRs (nulls below the chosen level), the chosen level's
+ * daily residual return (`residual_return`), and the raw ER inputs
+ * (`l2_sector_er`, `l3_subsector_er`) so callers can audit or apply their
+ * own threshold without a second request.
  */
 export const GET = withBilling(
   async (request: NextRequest, context: BillingContext) => {

--- a/lib/risk/lstar-service.ts
+++ b/lib/risk/lstar-service.ts
@@ -44,6 +44,11 @@ export interface LstarResult {
   subsector_hr: (number | null)[];
   /** Total explained-return at the chosen level (market + sector + subsector). */
   total_er: (number | null)[];
+  /**
+   * Daily simple residual return at the chosen Lstar level (`l1_rr` / `l2_rr` / `l3_rr`).
+   * Parallel to `dates`; null when Lstar or source return is unavailable.
+   */
+  residual_return: (number | null)[];
   /** Raw inputs to the selection rule, surfaced for audit / SDK override. */
   l2_sector_er: (number | null)[];
   l3_subsector_er: (number | null)[];
@@ -65,6 +70,17 @@ export function pickLstar(
   if (l3SubEr != null && l3SubEr >= threshold) return "L3";
   if (l2SecEr != null && l2SecEr >= threshold) return "L2";
   return "L1";
+}
+
+/** Residual return at the chosen Lstar level (same dispatch rule as hedge ratios). */
+export function dispatchLstarResidualReturn(
+  chosen: LstarLevel | null,
+  row: { l1_rr?: number | null; l2_rr?: number | null; l3_rr?: number | null },
+): number | null {
+  if (chosen === "L3") return (row.l3_rr as number | null) ?? null;
+  if (chosen === "L2") return (row.l2_rr as number | null) ?? null;
+  if (chosen === "L1") return (row.l1_rr as number | null) ?? null;
+  return null;
 }
 
 export class LstarService {
@@ -105,6 +121,9 @@ export class LstarService {
       "l3_mkt_er",
       "l3_sec_er",
       "l3_sub_er",
+      "l1_rr",
+      "l2_rr",
+      "l3_rr",
     ];
 
     const rows = await fetchHistory(symbolRecord.symbol, keys, {
@@ -128,6 +147,7 @@ export class LstarService {
     const sector_hr: (number | null)[] = [];
     const subsector_hr: (number | null)[] = [];
     const total_er: (number | null)[] = [];
+    const residual_return: (number | null)[] = [];
     const l2_sector_er: (number | null)[] = [];
     const l3_subsector_er: (number | null)[] = [];
 
@@ -169,6 +189,8 @@ export class LstarService {
         subsector_hr.push(null);
         total_er.push(null);
       }
+
+      residual_return.push(dispatchLstarResidualReturn(chosen, p));
     }
 
     return {
@@ -179,6 +201,7 @@ export class LstarService {
       sector_hr,
       subsector_hr,
       total_er,
+      residual_return,
       l2_sector_er,
       l3_subsector_er,
       threshold_used: threshold,
@@ -201,6 +224,7 @@ export class LstarService {
       sector_hr: [],
       subsector_hr: [],
       total_er: [],
+      residual_return: [],
       l2_sector_er: [],
       l3_subsector_er: [],
       threshold_used: threshold,

--- a/lib/risk/lstar-service.ts
+++ b/lib/risk/lstar-service.ts
@@ -24,6 +24,8 @@ import {
   resolveSymbolByTicker,
   fetchHistory,
   pivotHistory,
+  extractMetric,
+  type PivotedHistoryRow,
   type V3MetricKey,
 } from "@/lib/dal/risk-engine-v3";
 
@@ -75,11 +77,11 @@ export function pickLstar(
 /** Residual return at the chosen Lstar level (same dispatch rule as hedge ratios). */
 export function dispatchLstarResidualReturn(
   chosen: LstarLevel | null,
-  row: { l1_rr?: number | null; l2_rr?: number | null; l3_rr?: number | null },
+  row: PivotedHistoryRow,
 ): number | null {
-  if (chosen === "L3") return (row.l3_rr as number | null) ?? null;
-  if (chosen === "L2") return (row.l2_rr as number | null) ?? null;
-  if (chosen === "L1") return (row.l1_rr as number | null) ?? null;
+  if (chosen === "L3") return extractMetric(row, "l3_rr");
+  if (chosen === "L2") return extractMetric(row, "l2_rr");
+  if (chosen === "L1") return extractMetric(row, "l1_rr");
   return null;
 }
 

--- a/mcp/data/openapi.json
+++ b/mcp/data/openapi.json
@@ -1568,6 +1568,7 @@
           "sector_hr",
           "subsector_hr",
           "total_er",
+          "residual_return",
           "l2_sector_er",
           "l3_subsector_er",
           "threshold_used",
@@ -1628,6 +1629,15 @@
           "total_er": {
             "type": "array",
             "description": "Sum of explained-return components at the chosen level (market + sector + subsector, omitting residual).\n",
+            "items": {
+              "type": "number",
+              "format": "float",
+              "nullable": true
+            }
+          },
+          "residual_return": {
+            "type": "array",
+            "description": "Daily simple residual return at the chosen Lstar level (`l1_rr`, `l2_rr`, or `l3_rr` from returns decomposition). Parallel to `dates`; `null` when Lstar or source return is unavailable. Not a hedge ratio and not explained-risk variance (`l*_res_er`).\n",
             "items": {
               "type": "number",
               "format": "float",
@@ -5420,7 +5430,7 @@
     "/lstar": {
       "get": {
         "summary": "Recommended hedge level (L*) per date with dispatched HRs",
-        "description": "Per-(ticker, date) recommended hedge level — the simplest level whose marginal explained-return clears the threshold:\n\n  • if `L3_subsector_ER ≥ θ` → `L3` (3-ETF hedge: market + sector + subsector)\n  • elif `L2_sector_ER ≥ θ` → `L2` (2-ETF hedge: market + sector)\n  • else                    → `L1` (1-ETF hedge: market only)\n\nDefault `θ = 0.01` (1%). The chat-facing default is server-authoritative; SDK callers can override via `?threshold=`. Response carries the chosen level's market / sector / subsector hedge ratios (nulls below the chosen level), the chosen level's total ER, and the raw `l2_sector_er` / `l3_subsector_er` inputs for audit. See the side study at `RM_ORG/content/Medium/series/drafts/lstar_selection/` for why 1% is the default.\n**Billing:** $0.02 per request.\n",
+        "description": "Per-(ticker, date) recommended hedge level — the simplest level whose marginal explained-return clears the threshold:\n\n  • if `L3_subsector_ER ≥ θ` → `L3` (3-ETF hedge: market + sector + subsector)\n  • elif `L2_sector_ER ≥ θ` → `L2` (2-ETF hedge: market + sector)\n  • else                    → `L1` (1-ETF hedge: market only)\n\nDefault `θ = 0.01` (1%). The chat-facing default is server-authoritative; SDK callers can override via `?threshold=`. Response carries the chosen level's market / sector / subsector hedge ratios (nulls below the chosen level), the chosen level's total ER and daily residual return (`residual_return`), and the raw `l2_sector_er` / `l3_subsector_er` inputs for audit. See the side study at `RM_ORG/content/Medium/series/drafts/lstar_selection/` for why 1% is the default.\n**Billing:** $0.02 per request.\n",
         "operationId": "getLstar",
         "tags": [
           "Risk Metrics"

--- a/sdk/riskmodels/capabilities.py
+++ b/sdk/riskmodels/capabilities.py
@@ -528,6 +528,43 @@ _SDK_METHODS: list[dict[str, Any]] = [
         "returns": {"type": "pandas.DataFrame", "description": "Columns l3_market_hr, l3_*_er, …"},
     },
     {
+        "name": "get_lstar",
+        "aliases": [],
+        "summary": "Lstar-dispatched HRs and residual returns (GET /lstar).",
+        "description": (
+            "Per-date recommended hedge level (L1/L2/L3) with dispatched hedge ratios, "
+            "total explained-return, and daily residual return at the chosen level."
+        ),
+        "scopes": ["risk-decomposition", "hedging"],
+        "parameters": [
+            {"name": "ticker", "type": "string", "required": True, "description": "Symbol."},
+            {
+                "name": "market_factor_etf",
+                "type": "string",
+                "required": False,
+                "description": "Optional market ETF override (e.g. SPY).",
+            },
+            {
+                "name": "years",
+                "type": "integer",
+                "required": False,
+                "default": 1,
+                "description": "Calendar years of daily history (1–15).",
+            },
+            {
+                "name": "threshold",
+                "type": "number",
+                "required": False,
+                "default": 0.01,
+                "description": "Marginal-ER threshold for L1/L2/L3 selection.",
+            },
+        ],
+        "returns": {
+            "type": "pandas.DataFrame",
+            "description": "Columns date, lstar, market_hr, sector_hr, subsector_hr, total_er, residual_return, …",
+        },
+    },
+    {
         "name": "get_factor_correlation",
         "aliases": [],
         "summary": "Correlation vs macro factors (POST /correlation).",

--- a/sdk/riskmodels/client.py
+++ b/sdk/riskmodels/client.py
@@ -64,6 +64,7 @@ from .parsing import (
     factor_correlation_batch_item_to_row,
     factor_correlation_body_to_row,
     l3_decomposition_json_to_dataframe,
+    lstar_json_to_dataframe,
     parquet_bytes_to_dataframe,
     rankings_grid_headline,
     rankings_grid_to_dataframe,
@@ -953,6 +954,47 @@ class RiskModelsClient:
             last = df.iloc[-1].to_dict()
             run_validation(last, mode=mode, er_tolerance=self._er_tolerance)
         attach_sdk_metadata(df, lineage, kind="l3_decomposition")
+        return df
+
+    def get_lstar(
+        self,
+        ticker: str,
+        *,
+        market_factor_etf: str | None = None,
+        years: int = 1,
+        threshold: float | None = None,
+    ) -> pd.DataFrame:
+        """Historical Lstar selection with dispatched hedge ratios and residual returns.
+
+        Calls ``GET /lstar``. For each trading date, the API picks the simplest hedge
+        level (L1/L2/L3) whose marginal explained-return clears ``threshold`` (default
+        1%), then returns that level's market/sector/subsector hedge ratios, total ER,
+        and daily residual return.
+
+        Args:
+            ticker: Stock ticker symbol (e.g. ``"NVDA"``).
+            market_factor_etf: Market factor ETF override (default SPY on server).
+            years: Calendar years of daily history (1–15).
+            threshold: Marginal-ER threshold for Lstar selection (default 0.01).
+
+        Returns:
+            DataFrame with columns: ``date``, ``lstar``, ``market_hr``, ``sector_hr``,
+            ``subsector_hr``, ``total_er``, ``residual_return``, ``l2_sector_er``,
+            ``l3_subsector_er``.
+        """
+        t, _ = resolve_ticker(ticker, self)
+        params: dict[str, Any] = {"ticker": t, "years": years}
+        if market_factor_etf:
+            params["market_factor_etf"] = market_factor_etf
+        if threshold is not None:
+            params["threshold"] = threshold
+        body, lineage, _ = self._transport.request("GET", "/lstar", params=params)
+        df = lstar_json_to_dataframe(body)
+        attach_sdk_metadata(df, lineage, kind="lstar")
+        if threshold is not None and not df.empty:
+            df.attrs["threshold_used"] = threshold
+        elif isinstance(body, dict) and body.get("threshold_used") is not None:
+            df.attrs["threshold_used"] = body["threshold_used"]
         return df
 
     def residual_signal(

--- a/sdk/riskmodels/parsing.py
+++ b/sdk/riskmodels/parsing.py
@@ -30,6 +30,24 @@ def ticker_returns_json_to_dataframe(body: dict[str, Any]) -> pd.DataFrame:
     return df
 
 
+def lstar_json_to_dataframe(body: dict[str, Any]) -> pd.DataFrame:
+    n = len(body.get("dates") or [])
+    if n == 0:
+        return pd.DataFrame()
+    cols = {
+        "date": body["dates"],
+        "lstar": body.get("lstar", [None] * n),
+        "market_hr": body.get("market_hr", [None] * n),
+        "sector_hr": body.get("sector_hr", [None] * n),
+        "subsector_hr": body.get("subsector_hr", [None] * n),
+        "total_er": body.get("total_er", [None] * n),
+        "residual_return": body.get("residual_return", [None] * n),
+        "l2_sector_er": body.get("l2_sector_er", [None] * n),
+        "l3_subsector_er": body.get("l3_subsector_er", [None] * n),
+    }
+    return pd.DataFrame(cols)
+
+
 def l3_decomposition_json_to_dataframe(body: dict[str, Any]) -> pd.DataFrame:
     n = len(body.get("dates") or [])
     if n == 0:

--- a/sdk/tests/test_client_mock.py
+++ b/sdk/tests/test_client_mock.py
@@ -130,3 +130,53 @@ def test_get_plaid_holdings_calls_endpoint():
     out = client.get_plaid_holdings()
     assert "/plaid/holdings" in captured["url"]
     assert out["connections_count"] == 0
+
+
+def test_get_lstar_returns_dataframe_with_residual_return():
+    captured = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        return httpx.Response(
+            200,
+            json={
+                "ticker": "NVDA",
+                "dates": ["2026-01-02", "2026-01-03"],
+                "lstar": ["L3", "L2"],
+                "market_hr": [0.9, 0.8],
+                "sector_hr": [0.1, 0.2],
+                "subsector_hr": [0.05, None],
+                "total_er": [0.7, 0.5],
+                "residual_return": [0.012, 0.008],
+                "l2_sector_er": [0.02, 0.015],
+                "l3_subsector_er": [0.03, 0.01],
+                "threshold_used": 0.01,
+                "market_factor_etf": "SPY",
+                "universe": "US_EQUITY",
+                "data_source": "zarr",
+            },
+            headers={"X-Risk-Model-Version": "ERM3-test"},
+        )
+
+    client = RiskModelsClient(
+        base_url="https://riskmodels.app/api",
+        api_key="test",
+        validate="off",
+        http_client=httpx.Client(transport=httpx.MockTransport(handler)),
+    )
+    df = client.get_lstar("NVDA", years=2, threshold=0.01)
+    assert "/lstar" in captured["url"]
+    assert "ticker=NVDA" in captured["url"]
+    assert list(df.columns) == [
+        "date",
+        "lstar",
+        "market_hr",
+        "sector_hr",
+        "subsector_hr",
+        "total_er",
+        "residual_return",
+        "l2_sector_er",
+        "l3_subsector_er",
+    ]
+    assert len(df) == 2
+    assert df.iloc[0]["residual_return"] == 0.012

--- a/tests/lstar-service.test.ts
+++ b/tests/lstar-service.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  dispatchLstarResidualReturn,
+  pickLstar,
+  LSTAR_DEFAULT_THRESHOLD,
+} from "@/lib/risk/lstar-service";
+
+describe("pickLstar", () => {
+  it("defaults to L1 when marginal ERs are below threshold", () => {
+    expect(pickLstar(0.005, 0.008, LSTAR_DEFAULT_THRESHOLD)).toBe("L1");
+  });
+
+  it("chooses L2 when sector ER clears threshold but subsector does not", () => {
+    expect(pickLstar(0.02, 0.005, LSTAR_DEFAULT_THRESHOLD)).toBe("L2");
+  });
+
+  it("chooses L3 when subsector ER clears threshold", () => {
+    expect(pickLstar(0.005, 0.02, LSTAR_DEFAULT_THRESHOLD)).toBe("L3");
+  });
+
+  it("returns null when both ER inputs are missing", () => {
+    expect(pickLstar(null, null, LSTAR_DEFAULT_THRESHOLD)).toBeNull();
+  });
+});
+
+describe("dispatchLstarResidualReturn", () => {
+  const row = { l1_rr: 0.01, l2_rr: 0.02, l3_rr: 0.03 };
+
+  it("routes to the matching level residual return", () => {
+    expect(dispatchLstarResidualReturn("L1", row)).toBe(0.01);
+    expect(dispatchLstarResidualReturn("L2", row)).toBe(0.02);
+    expect(dispatchLstarResidualReturn("L3", row)).toBe(0.03);
+  });
+
+  it("returns null when Lstar is undetermined", () => {
+    expect(dispatchLstarResidualReturn(null, row)).toBeNull();
+  });
+});

--- a/tests/lstar-service.test.ts
+++ b/tests/lstar-service.test.ts
@@ -25,7 +25,7 @@ describe("pickLstar", () => {
 });
 
 describe("dispatchLstarResidualReturn", () => {
-  const row = { l1_rr: 0.01, l2_rr: 0.02, l3_rr: 0.03 };
+  const row = { teo: "2026-01-01", l1_rr: 0.01, l2_rr: 0.02, l3_rr: 0.03 };
 
   it("routes to the matching level residual return", () => {
     expect(dispatchLstarResidualReturn("L1", row)).toBe(0.01);


### PR DESCRIPTION
## Summary

- Adds **`residual_return`** to `GET /api/lstar` — a daily array of Lstar-dispatched residual returns aligned with existing `dates`, `lstar`, and hedge-ratio series.
- Dispatches `l1_rr` / `l2_rr` / `l3_rr` from returns zarr using the same level selection logic as hedge ratios (`pickLstar` + threshold).
- Updates OpenAPI `LstarResponse` and adds unit tests for `dispatchLstarResidualReturn`.

## Test plan

- [x] `npm test -- tests/lstar-service.test.ts` (6 tests pass)
- [x] `npm run build:openapi`
- [ ] After deploy: `GET https://riskmodels.app/api/lstar?ticker=NVDA&years=1` returns `residual_return` array same length as `dates`
- [ ] Spot-check: on dates where `lstar=3`, values match L3 residual; where `lstar=1`, match L1 residual


Made with [Cursor](https://cursor.com)