### PR TITLE
fix(billing): H.27 charge-debit filters and telemetry type

### DIFF
--- a/app/api/invoices/route.ts
+++ b/app/api/invoices/route.ts
@@ -9,6 +9,7 @@ import { createAdminClient } from "@/lib/supabase/admin";
 import { generateRequestId } from "@/lib/agent/telemetry";
 import { createAgentErrorResponse } from "@/lib/agent/response-utils";
 import { getCorsHeaders } from "@/lib/cors";
+import { applyChargeDebitFilters } from "@/lib/billing-event-filters";
 
 export const dynamic = "force-dynamic";
 
@@ -87,7 +88,13 @@ export async function GET(request: NextRequest) {
     }
 
     const all = rows ?? [];
-    const debits = all.filter((r) => r.type === "debit");
+    const debits = all.filter(
+      (r) =>
+        r.type === "debit" &&
+        (typeof r.cost_usd === "number"
+          ? r.cost_usd
+          : parseFloat(String(r.cost_usd ?? 0))) > 0,
+    );
     const totalSpent = debits.reduce((sum, r) => {
       const c =
         typeof r.cost_usd === "number"

--- a/app/api/usage/route.ts
+++ b/app/api/usage/route.ts
@@ -49,9 +49,14 @@ export async function GET() {
     return NextResponse.json({ error: 'Failed to fetch usage' }, { status: 500 });
   }
 
-  const usage = usageRows ?? [];
+  type UsageRow = {
+    created_at: string;
+    cost_usd: number | string | null;
+    capability_id: string | null;
+  };
+  const usage = (usageRows ?? []) as UsageRow[];
   const totalCalls = usage.length;
-  const totalSpend = usage.reduce((sum, row) => {
+  const totalSpend = usage.reduce((sum: number, row: UsageRow) => {
     const c =
       typeof row.cost_usd === 'number'
         ? row.cost_usd

--- a/app/api/usage/route.ts
+++ b/app/api/usage/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
 import { createAdminClient } from '@/lib/supabase/admin';
+import { applyChargeDebitFilters } from '@/lib/billing-event-filters';
 
 export const dynamic = 'force-dynamic';
 
@@ -36,11 +37,10 @@ export async function GET() {
   );
   const firstOfMonthIso = firstOfMonth.toISOString();
 
-  const { data: usageRows, error: usageError } = await admin
-    .from('billing_events')
-    .select('created_at, cost_usd, capability_id')
+  const { data: usageRows, error: usageError } = await applyChargeDebitFilters(
+    admin.from('billing_events').select('created_at, cost_usd, capability_id'),
+  )
     .eq('user_id', user.id)
-    .eq('type', 'debit')
     .gte('created_at', firstOfMonthIso)
     .order('created_at', { ascending: true });
 

--- a/lib/agent/affiliate.ts
+++ b/lib/agent/affiliate.ts
@@ -1,6 +1,7 @@
 import 'server-only';
 
 import type { SupabaseClient } from '@supabase/supabase-js';
+import { applyChargeDebitFilters } from '@/lib/billing-event-filters';
 
 /**
  * Public-side affiliate helper for riskmodels.app.
@@ -106,11 +107,9 @@ export async function getStatsForUser(
 
   let totalRevenueUsd = 0;
   if (distinctUserIds.length > 0) {
-    const { data: spendRows } = await admin
-      .from('billing_events')
-      .select('cost_usd')
-      .in('user_id', distinctUserIds)
-      .eq('type', 'debit');
+    const { data: spendRows } = await applyChargeDebitFilters(
+      admin.from('billing_events').select('cost_usd'),
+    ).in('user_id', distinctUserIds);
     for (const row of spendRows ?? []) {
       totalRevenueUsd += parseFloat(String((row as { cost_usd: unknown }).cost_usd)) || 0;
     }

--- a/lib/agent/telemetry.ts
+++ b/lib/agent/telemetry.ts
@@ -10,6 +10,7 @@ import {
   getTeoCoverageHealth,
   type TeoCoverageHealth,
 } from "@/lib/dal/teo-coverage-health";
+import { applyTelemetryFilters } from "@/lib/billing-event-filters";
 
 export interface TelemetryEvent {
   request_id: string;
@@ -85,6 +86,9 @@ export interface HealthStatus {
  * here, doubling revenue tracking on every billable request.
  *
  * Non-blocking - failures are silently ignored.
+ *
+ * Rows use type='telemetry' (see BWMACRO migration 20260526120000). Legacy rows
+ * are still discriminated via latency_ms IS NOT NULL vs balance-backed debits.
  */
 export async function logTelemetry(event: TelemetryEvent): Promise<void> {
   try {
@@ -97,6 +101,7 @@ export async function logTelemetry(event: TelemetryEvent): Promise<void> {
         user_id: event.user_id,
         request_id: event.request_id,
         capability_id: event.capability_id,
+        type: "telemetry",
         cost_usd: 0, // H.20: never duplicate the deductBalance row's cost
         latency_ms: event.latency_ms,
         success: event.success,
@@ -307,9 +312,11 @@ export async function getTelemetryMetrics(
     Date.now() - days * 24 * 60 * 60 * 1000,
   ).toISOString();
 
-  const { data: events, error } = await createAdminClient()
-    .from("billing_events")
-    .select("success, latency_ms, cost_usd")
+  const { data: events, error } = await applyTelemetryFilters(
+    createAdminClient()
+      .from("billing_events")
+      .select("success, latency_ms, cost_usd"),
+  )
     .eq("capability_id", capabilityId)
     .gte("created_at", startDate);
 

--- a/lib/billing-event-filters.ts
+++ b/lib/billing-event-filters.ts
@@ -5,13 +5,11 @@
  * Args/return are `any` — Supabase PostgrestFilterBuilder generics exceed TS
  * recursion limits when chained (.in, .gte, etc.).
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function applyChargeDebitFilters(query: any): any {
   return query.eq("type", "debit").gt("cost_usd", 0);
 }
 
 /** Request telemetry rows (one per API call; not balance debits). */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function applyTelemetryFilters(query: any): any {
   return query.not("latency_ms", "is", null);
 }

--- a/lib/billing-event-filters.ts
+++ b/lib/billing-event-filters.ts
@@ -1,0 +1,17 @@
+/**
+ * PostgREST filters for balance-backed API charges (excludes H.20 telemetry
+ * shadow rows: default type=debit, cost_usd=0, no balance_after_usd).
+ *
+ * Args/return are `any` — Supabase PostgrestFilterBuilder generics exceed TS
+ * recursion limits when chained (.in, .gte, etc.).
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function applyChargeDebitFilters(query: any): any {
+  return query.eq("type", "debit").gt("cost_usd", 0);
+}
+
+/** Request telemetry rows (one per API call; not balance debits). */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function applyTelemetryFilters(query: any): any {
+  return query.not("latency_ms", "is", null);
+}


### PR DESCRIPTION
## Summary
- Adds shared `applyChargeDebitFilters` / `applyTelemetryFilters` helpers so usage, invoices, and affiliate spend exclude H.20 zero-cost shadow debit rows.
- `logTelemetry()` now inserts `type: 'telemetry'` (requires Supabase migration already applied in BWMACRO).
- `getTelemetryMetrics()` counts telemetry rows only, not balance debits.

## Test plan
- [ ] CI green
- [ ] After deploy: `GET /api/usage` shows ~half prior call counts for active keys; costs unchanged
- [ ] Admin Usage (BWMACRO deploy): Lisa `ticker-returns` rows show ~$0.005 each, not $0.0000 duplicates


Made with [Cursor](https://cursor.com)