### PR TITLE
chore(sdk): bump riskmodels-py 0.3.7 → 0.3.9 + sync SDK_VERSION constant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to the RiskModels API surface and public assets.
 
 
+## [0.3.9] — 2026-05-27
+
+### Added
+
+- **`POST /api/signals/residual-reversion/basket`** — User-defined ticker list aggregated to a single Phase D L3 residual-reversion signal. 1–500 tickers; equal-weight default + optional `weights[]` aligned to tickers + optional `signal_quality_min_quintile` (1–5) gate (Phase B: gross Sharpe lifts from ~0.79 universe-wide to ~1.28 within quintile 5). Returns weighted aggregate + decile / quality-quintile histograms + per-member rows. Trust contract: tickers absent from `ds_erm3_residual_signal` are silently dropped (upstream mask is SSOT); `coverage.missing_tickers` surfaces the gap. Capability `residual-signal-basket` ($0.02/request); OpenAPI + MCP capabilities synced.
+- **`GET /api/universe/{name}/members`** — Active membership of a named universe (`uni_mc_50/500/1000/3000` or `uni_dv_*`) at one teo (latest by default). Active = monthly `universe_mask` AND daily `validity` gate — same dual-gate the ERM3 pipeline applies to produce its output zarrs. Path label validated against the `KNOWN_UNIVERSES` registry (mirror of `erm3.partitions.KNOWN_UNIVERSES`); unknown labels return 400. Response carries `members[{symbol, ticker}]` + `counts {active, in_universe_mask, inactive_from_validity}` + a `mask_as_of` month-end stamp (so callers can disambiguate mask-driven vs validity-driven membership changes). Capability `universe-members` ($0.005/request).
+- **`POST /api/portfolio/risk-snapshot` — `lstar_variance_decomposition` block** — Parallel Lstar-aware attribution alongside the existing fixed-L3 `variance_decomposition`. For each holding, picks the ER at the cascade depth `lstar_level` dispatched to (L1 → market+residual; L2 → +sector; L3 → +subsector) and weights across the book. Names with `lstar_level=null` are dropped — `weight_covered` and `dropped_count` on the block surface the coverage gap. Per-row payloads now include `lstar_rr` + `lstar_level` columns. Same call shape; same billing; existing fixed-L3 block unchanged so existing callers don't break.
+- **Python SDK — `get_residual_signal_basket()`** — Wraps `POST /signals/residual-reversion/basket`; returns the aggregate + coverage + per-member rows. `get_universe_members()` wraps `GET /universe/{name}/members`.
+- **`SDK_VERSION` constant fix** — `sdk/riskmodels/capabilities.py` was stamping `0.3.0` in `client.discover()` output despite the package being at 0.3.7+ on disk. Now bumped to `0.3.9` to match `pyproject.toml`; future bumps should keep both in sync.
+
+
 ## [0.3.8] — 2026-05-27
 
 ### Added

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "riskmodels-py"
-version = "0.3.7"
+version = "0.3.9"
 description = "Python SDK for the RiskModels API — decompose US equities into market/sector/subsector/residual variance shares and ETF hedge ratios"
 readme = "README.md"
 license = { text = "Proprietary" }

--- a/sdk/riskmodels/capabilities.py
+++ b/sdk/riskmodels/capabilities.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from .contributors import SDK_CONTRIBUTORS
 
-SDK_VERSION = "0.3.0"
+SDK_VERSION = "0.3.9"
 
 _RANKING_METRICS = [
     "mkt_cap",


### PR DESCRIPTION
## Summary

Prep commit for the PyPI publish of **riskmodels-py 0.3.9**. Three batches of unreleased SDK work since the last PyPI release (0.3.5):

- **0.3.6** — lstar deploy: `get_lstar()` enhancements, `residual_return` series
- **0.3.7** — Tier-1 endpoint methods: `get_returns_decomposition()`, `get_industry_panel()`, `screen_rankings()`, `batch_lstar()` + `batch_lstar_to_dataframes()`
- **0.3.9** — Bundle A methods: `get_residual_signal_basket()`, `get_universe_members()`. Plus the `/snapshot` Lstar-aware attribution shape that clients can now read on the existing endpoint.

Skipping 0.3.8 to keep the SDK version aligned with the API portal CHANGELOG (which uses 0.3.8 for the rankings/screen + batch/lstar fix-ups — those are folded into this 0.3.9 release on the SDK side).

## Three file changes

| File | Change |
|---|---|
| `sdk/pyproject.toml` | `version = "0.3.7"` → `"0.3.9"` |
| `sdk/riskmodels/capabilities.py` | `SDK_VERSION = "0.3.0"` → `"0.3.9"` — the constant had been stale since the 0.3.x line started; `client.discover()` was misreporting the version to agent callers. |
| `CHANGELOG.md` | New `[0.3.9]` entry covering R.5 + R.8 + R.6 (which landed in #116 without a CHANGELOG bump). |

## After this merges

You run the publish manually (needs `TWINE_PASSWORD` from Doppler — I can't):

```bash
doppler run -p erm3 -c prd -- bash sdk/scripts/publish_pypi.sh --build
```

Followed by:

```bash
pip install --upgrade riskmodels-py
python -c "import riskmodels; print(riskmodels.__version__)"   # → 0.3.9
```

## Test plan

- [x] `SDK_VERSION` import returns `"0.3.9"`
- [x] `pyproject.toml [project].version` returns `"0.3.9"`
- [x] `pytest` from `sdk/` — 411 pass
- [ ] Post-publish: `pip install --upgrade riskmodels-py && pip show riskmodels-py | grep Version` → `0.3.9`

🤖 Generated with [Claude Code](https://claude.com/claude-code)