### PR TITLE
fix(provision-free): bind free keys to a real auth user + tier=free (C.7)

### DIFF
--- a/app/api/auth/provision-free/route.ts
+++ b/app/api/auth/provision-free/route.ts
@@ -1,20 +1,26 @@
 /**
  * Free API Key Generation
  *
- * Generate a free API key with limited usage for testing and development.
- * No payment required. No email required.
+ * Generate a free-tier API key for testing and development — no payment, no
+ * signup. The key is bound to an anonymous Supabase auth user (required: the
+ * agent_accounts.user_id / agent_api_keys.user_id columns are UUID FKs to
+ * auth.users), and the account is created with tier='free' so the billing
+ * middleware skips the balance check (see lib/agent/billing-middleware.ts —
+ * the balance gate is `costUsd > 0 && tier !== 'free'`). Usage is capped at
+ * FREE_TIER_LIMITS by checkFreeTierLimit().
  *
  * POST /api/auth/provision-free
- * Body: {
- *   agent_name: string,
- *   purpose?: string (optional)
- * }
+ * Body: { agent_name: string, purpose?: string, referral_code?: string }
  */
 
 import { NextRequest, NextResponse } from "next/server";
+import { randomUUID } from "crypto";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { generateApiKey } from "@/lib/agent/api-keys";
-import { findActiveAffiliateByCode, MAX_REFERRAL_CODE_LEN } from "@/lib/agent/affiliate";
+import {
+  findActiveAffiliateByCode,
+  MAX_REFERRAL_CODE_LEN,
+} from "@/lib/agent/affiliate";
 
 export const dynamic = "force-dynamic";
 
@@ -24,6 +30,17 @@ const FREE_TIER_LIMITS = {
   QUERIES_PER_MINUTE: 10,
   INITIAL_BALANCE: 0,
 };
+
+// Anti-abuse: this endpoint is unauthenticated and creates a real auth user +
+// free key per request. Cap provisions per source IP per rolling 24h so it
+// can't be spammed into unlimited free accounts.
+const MAX_FREE_KEYS_PER_IP_PER_DAY = 3;
+
+function clientIp(request: NextRequest): string {
+  const xff = request.headers.get("x-forwarded-for");
+  if (xff) return xff.split(",")[0]!.trim();
+  return request.headers.get("x-real-ip") || "unknown";
+}
 
 export async function POST(request: NextRequest) {
   const startTime = Date.now();
@@ -39,7 +56,11 @@ export async function POST(request: NextRequest) {
       referralCodeRaw = null;
     }
 
-    if (!agent_name || typeof agent_name !== "string" || agent_name.trim().length < 3) {
+    if (
+      !agent_name ||
+      typeof agent_name !== "string" ||
+      agent_name.trim().length < 3
+    ) {
       return NextResponse.json(
         {
           error: "Invalid agent_name",
@@ -51,26 +72,94 @@ export async function POST(request: NextRequest) {
     }
 
     const supabase = createAdminClient();
+    const ip = clientIp(request);
 
-    // Generate user_id for free tier
-    const freeUserId = `free_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+    // --- Anti-abuse: per-IP daily cap (best-effort; skipped if IP unknown) ---
+    if (ip !== "unknown") {
+      const since = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+      const { count } = await supabase
+        .from("agent_accounts")
+        .select("id", { count: "exact", head: true })
+        .eq("signup_attribution->>provisioned_via", "provision-free")
+        .eq("signup_attribution->>ip", ip)
+        .gte("created_at", since);
+      if ((count ?? 0) >= MAX_FREE_KEYS_PER_IP_PER_DAY) {
+        return NextResponse.json(
+          {
+            error: "Rate limit exceeded",
+            message:
+              "Too many free keys from this IP in the last 24h. Create a free $20-credit key at https://riskmodels.app/get-key instead.",
+            _agent: { latency_ms: Date.now() - startTime },
+          },
+          { status: 429 },
+        );
+      }
+    }
+
+    // --- Create a real anonymous auth user (FK target for the account/key) ---
+    const syntheticEmail = `agent-free+${randomUUID()}@noreply.riskmodels.app`;
+    const { data: createdUser, error: userError } =
+      await supabase.auth.admin.createUser({
+        email: syntheticEmail,
+        email_confirm: true,
+        user_metadata: {
+          free_tier: true,
+          agent_name,
+          provisioned_via: "provision-free",
+        },
+      });
+    if (userError || !createdUser?.user) {
+      console.error("[Provision-Free] Auth user creation error:", userError);
+      return NextResponse.json(
+        {
+          error: "Failed to create account",
+          message: userError?.message || "Could not create free-tier user",
+          _agent: { latency_ms: Date.now() - startTime },
+        },
+        { status: 500 },
+      );
+    }
+    const freeUserId = createdUser.user.id; // real UUID — satisfies the FK
+
+    // Best-effort cleanup so a failed insert doesn't orphan the auth user.
+    const rollbackUser = async () => {
+      await supabase.auth.admin.deleteUser(freeUserId).catch(() => {});
+    };
 
     // Generate API key
     const { plainKey, hashedKey, prefix } = generateApiKey();
 
-    // Create free tier account
-    const { error: accountError } = await supabase.from("agent_accounts").insert({
-      user_id: freeUserId,
-      agent_id: `free_${agent_name.toLowerCase().replace(/\s+/g, "_")}`,
-      agent_name,
-      contact_email: null,
-      balance_usd: FREE_TIER_LIMITS.INITIAL_BALANCE,
-      status: "active",
-      created_at: new Date().toISOString(),
-    });
+    const affiliate = await findActiveAffiliateByCode(supabase, referralCodeRaw);
+    const referralCodeForRow = affiliate
+      ? affiliate.referral_code
+      : referralCodeRaw;
+    const referredByAffiliateId = affiliate?.id ?? null;
+
+    // agent_id is UNIQUE NOT NULL — include the uuid so concurrent calls with
+    // the same agent_name don't collide.
+    const agentId = `free_${agent_name
+      .toLowerCase()
+      .replace(/\s+/g, "_")
+      .slice(0, 40)}_${freeUserId.slice(0, 12)}`;
+
+    // Create free tier account (tier='free' is what bypasses the balance gate)
+    const { error: accountError } = await supabase
+      .from("agent_accounts")
+      .insert({
+        user_id: freeUserId,
+        agent_id: agentId,
+        agent_name,
+        contact_email: syntheticEmail,
+        balance_usd: FREE_TIER_LIMITS.INITIAL_BALANCE,
+        tier: "free",
+        status: "active",
+        signup_attribution: { provisioned_via: "provision-free", ip, purpose },
+        created_at: new Date().toISOString(),
+      });
 
     if (accountError) {
       console.error("[Provision-Free] Account creation error:", accountError);
+      await rollbackUser();
       return NextResponse.json(
         {
           error: "Failed to create account",
@@ -80,12 +169,6 @@ export async function POST(request: NextRequest) {
         { status: 500 },
       );
     }
-
-    /** Referral attribution: synthetic free_* user_ids never produce real spend, but we still
-     *  record the code so the admin dashboard can see top-of-funnel volume per affiliate. */
-    const affiliate = await findActiveAffiliateByCode(supabase, referralCodeRaw);
-    const referralCodeForRow = affiliate ? affiliate.referral_code : referralCodeRaw;
-    const referredByAffiliateId = affiliate?.id ?? null;
 
     // Store hashed API key
     const { error: keyError } = await supabase.from("agent_api_keys").insert({
@@ -101,6 +184,7 @@ export async function POST(request: NextRequest) {
 
     if (keyError) {
       console.error("[Provision-Free] Key storage error:", keyError);
+      await rollbackUser();
       return NextResponse.json(
         {
           error: "Failed to store API key",
@@ -111,7 +195,8 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Track free tier usage
+    // Track free tier usage (free_tier_usage.user_id is TEXT — a uuid string
+    // fits; checkFreeTierLimit also auto-creates this row, so it is non-fatal).
     const { error: usageError } = await supabase.from("free_tier_usage").insert({
       user_id: freeUserId,
       queries_today: 0,


### PR DESCRIPTION
Fixes **C.7** — `POST /api/auth/provision-free` 500s on every call, so the anonymous free-tier key path (advertised in `llms.txt` as the MAG7 smoke-test path) is fully broken.

## Root cause
- `agent_accounts.user_id` / `agent_api_keys.user_id` are `UUID REFERENCES auth.users(id)` — the old `user_id = 'free_<ts>_<rand>'` string failed the uuid type, and any synthetic uuid would fail the FK.
- The insert never set `tier: 'free'`, so even a valid account defaults to `'paid'` → 402 on `$0` balance.
- `free_tier_usage` was designed for TEXT `free_xxx` ids while accounts require real `auth.users` UUIDs — incompatible halves.

## Fix
- Create an **anonymous Supabase auth user** (`auth.admin.createUser`) → real uuid that satisfies the FK.
- Create `agent_accounts` with **`tier: 'free'`** → billing middleware skips the balance gate (`costUsd > 0 && tier !== 'free'`); the 100/day free-tier limit governs instead.
- `free_tier_usage.user_id` is TEXT and accepts the uuid string.
- Best-effort **auth-user rollback** if a later insert fails (no orphans); unique `agent_id` (includes the uuid).
- **Anti-abuse:** per-IP daily cap (`MAX_FREE_KEYS_PER_IP_PER_DAY = 3`) since the endpoint is unauthenticated and now mints a real auth user per call; over the cap → 429 pointing to `/get-key`.

## Verification (cannot run locally — needs Supabase)
On the Vercel preview for this PR:
1. `POST /api/auth/provision-free {"agent_name":"smoke-test"}` → expect a `rm_agent_live_…` key.
2. Call a MAG7 tool with that key → expect **200 at `$0`** (no 402, no 429).

I'll run this against the preview once it's up and report results here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)