### PR TITLE
refactor(mcp): split hosted-only render tool out of the stdio bundle

### DIFF
--- a/lib/mcp/render-tool.ts
+++ b/lib/mcp/render-tool.ts
@@ -1,0 +1,83 @@
+import { z } from "zod";
+import {
+  renderArtifact,
+  WIRED_ARTIFACT_RENDER_MATRIX,
+} from "@/lib/artifacts/render-client";
+import {
+  textResult,
+  errorResult,
+  type McpLikeServer,
+} from "@/lib/mcp/tools/riskmodels-tools";
+
+/**
+ * Hosted-only MCP tool — deliberately kept OUT of `lib/mcp/tools/`.
+ *
+ * The standalone stdio build (`mcp/tsconfig.json` includes
+ * `../lib/mcp/tools/**`) must NOT compile this file: `render-client` →
+ * `gcp-id-token` authenticates to GCP Cloud Run, which a public
+ * `npx @riskmodels/mcp` user has no credentials for. So `riskmodels_render_artifact`
+ * is registered only by the hosted server (`lib/mcp/server.ts`); the stdio
+ * server (`mcp/src/server.ts`) never imports this module.
+ */
+export function registerRiskModelsRenderTool(server: McpLikeServer): void {
+  server.registerTool(
+    "riskmodels_render_artifact",
+    {
+      title: "RiskModels Artifact Registry Render",
+      description:
+        "Render a deterministic registry artifact (fund, filer, or client portfolio). Returns JSON chart/table/narrative or base64 PNG/SVG. Same contract as riskmodels.net workspace fetchArtifact.",
+      annotations: { readOnlyHint: true },
+      inputSchema: {
+        slug: z.string().min(1).describe("Artifact slug, e.g. top_holdings_erm_stacked"),
+        version: z.string().optional().describe("Version tag, default v1"),
+        subject_id: z
+          .string()
+          .min(1)
+          .describe("BW-FUND-…, BW-FILER-…, or BW-PORTFOLIO-…"),
+        as_of: z
+          .string()
+          .optional()
+          .describe("YYYY-MM-DD or latest; filers need explicit filing period end"),
+        format: z
+          .enum(["json", "png", "svg"])
+          .optional()
+          .describe("Output format, default json"),
+        subject_payload: z
+          .record(z.string(), z.unknown())
+          .optional()
+          .describe("Required for BW-PORTFOLIO-*: { positions: [{ ticker, weight }] }"),
+      },
+    },
+    async ({ slug, version, subject_id, as_of, format, subject_payload }) => {
+      try {
+        const result = await renderArtifact({
+          slug,
+          version,
+          subject_id,
+          as_of,
+          format,
+          subject_payload: subject_payload ?? null,
+        });
+        if (!result.ok) {
+          return textResult({
+            error: result.error,
+            status: result.status,
+            detail: result.detail,
+            wired_slugs: WIRED_ARTIFACT_RENDER_MATRIX,
+          });
+        }
+        return textResult({
+          slug,
+          subject_id,
+          format: result.format,
+          resolved_as_of: result.resolved_as_of,
+          gcs_path: result.gcs_path,
+          receipt_id: result.receipt_id,
+          artifact: result.data,
+        });
+      } catch (error) {
+        return errorResult(error);
+      }
+    },
+  );
+}

--- a/lib/mcp/server.ts
+++ b/lib/mcp/server.ts
@@ -8,7 +8,10 @@
  *
  * SOURCE OF TRUTH REMINDER: if you change tool schemas or handler logic,
  * mirror the edit to `mcp/src/server.ts` so the stdio binary stays in sync.
- * The lists (9 SDK-backed tools from registerRiskModelsTools, 5 resources) must match exactly.
+ * The shared list is 8 SDK-backed tools from `registerRiskModelsTools` + 5
+ * resources. The hosted server ALSO registers `riskmodels_render_artifact` via
+ * `registerRiskModelsRenderTool` — that one is hosted-only (needs GCP Cloud Run
+ * auth) and is intentionally NOT in the stdio binary.
  */
 
 import { readFileSync, existsSync } from "fs";
@@ -24,6 +27,7 @@ import {
   registerRiskModelsTools,
   registerRiskModelsWhitepaperResources,
 } from "@/lib/mcp/tools/riskmodels-tools";
+import { registerRiskModelsRenderTool } from "@/lib/mcp/render-tool";
 
 const DATA_DIR = join(process.cwd(), "mcp", "data");
 
@@ -297,6 +301,9 @@ export function createMcpServer(opts: McpServerOptions): McpServer {
   // --- Tools ---
 
   registerRiskModelsTools(sdk, server);
+  // Hosted-only: the render tool needs GCP Cloud Run auth, so it lives outside
+  // lib/mcp/tools/ and is not compiled into the public stdio package.
+  registerRiskModelsRenderTool(server);
 
   server.registerTool(
     "riskmodels_list_endpoints",

--- a/lib/mcp/tools/riskmodels-tools.ts
+++ b/lib/mcp/tools/riskmodels-tools.ts
@@ -2,19 +2,15 @@ import { readFileSync } from "fs";
 import { join } from "path";
 import { RiskModelsClient, type PositionInput, type WhitepaperExampleId } from "@riskmodels/sdk";
 import { z } from "zod";
-import {
-  renderArtifact,
-  WIRED_ARTIFACT_RENDER_MATRIX,
-} from "@/lib/artifacts/render-client";
 
 type McpContent = { type: "text"; text: string };
-type McpToolResult = { content: McpContent[] };
+export type McpToolResult = { content: McpContent[] };
 type McpPromptResult = {
   description?: string;
   messages: Array<{ role: "user" | "assistant"; content: McpContent }>;
 };
 
-type McpLikeServer = {
+export type McpLikeServer = {
   registerTool: (name: string, config: Record<string, unknown>, handler: (args: any) => Promise<McpToolResult>) => void;
   registerResource: (
     name: string,
@@ -65,7 +61,7 @@ const WHITEPAPER_RESOURCES = [
 const CHART_INSTRUCTION =
   "If chart_data is present, render the suggested_chart. Use grouped bars for comparisons and bars for single-stock decomposition. Always explain the result in plain English.";
 
-function textResult(payload: unknown): McpToolResult {
+export function textResult(payload: unknown): McpToolResult {
   return {
     content: [
       {
@@ -85,7 +81,7 @@ function textResult(payload: unknown): McpToolResult {
   };
 }
 
-function errorResult(error: unknown): McpToolResult {
+export function errorResult(error: unknown): McpToolResult {
   return textResult({
     error: error instanceof Error ? error.message : String(error),
   });
@@ -299,67 +295,6 @@ export function registerRiskModelsTools(
     async ({ positions }) => {
       try {
         return textResult(await sdk.portfolioDecompose(positions as PositionInput[]));
-      } catch (error) {
-        return errorResult(error);
-      }
-    },
-  );
-
-  server.registerTool(
-    "riskmodels_render_artifact",
-    {
-      title: "RiskModels Artifact Registry Render",
-      annotations: { readOnlyHint: true },
-      description:
-        "Render a deterministic registry artifact (fund, filer, or client portfolio). Returns JSON chart/table/narrative or base64 PNG/SVG. Same contract as riskmodels.net workspace fetchArtifact.",
-      inputSchema: {
-        slug: z.string().min(1).describe("Artifact slug, e.g. top_holdings_erm_stacked"),
-        version: z.string().optional().describe("Version tag, default v1"),
-        subject_id: z
-          .string()
-          .min(1)
-          .describe("BW-FUND-…, BW-FILER-…, or BW-PORTFOLIO-…"),
-        as_of: z
-          .string()
-          .optional()
-          .describe("YYYY-MM-DD or latest; filers need explicit filing period end"),
-        format: z
-          .enum(["json", "png", "svg"])
-          .optional()
-          .describe("Output format, default json"),
-        subject_payload: z
-          .record(z.string(), z.unknown())
-          .optional()
-          .describe("Required for BW-PORTFOLIO-*: { positions: [{ ticker, weight }] }"),
-      },
-    },
-    async ({ slug, version, subject_id, as_of, format, subject_payload }) => {
-      try {
-        const result = await renderArtifact({
-          slug,
-          version,
-          subject_id,
-          as_of,
-          format,
-          subject_payload: subject_payload ?? null,
-        });
-        if (!result.ok) {
-          return textResult({
-            error: result.error,
-            status: result.status,
-            detail: result.detail,
-            wired_slugs: WIRED_ARTIFACT_RENDER_MATRIX,
-          });
-        }
-        return textResult({
-          slug,
-          subject_id,
-          format: result.format,
-          resolved_as_of: result.resolved_as_of,
-          gcs_path: result.gcs_path,
-          receipt_id: result.receipt_id,
-          artifact: result.data,
-        });
       } catch (error) {
         return errorResult(error);
       }

--- a/tests/onboarding-upgrade.test.ts
+++ b/tests/onboarding-upgrade.test.ts
@@ -229,9 +229,11 @@ describe("RiskModels MCP live-paper tools", () => {
       "riskmodels_analyze_portfolio",
       "riskmodels_hedge_portfolio",
       "riskmodels_portfolio_decompose",
-      "riskmodels_render_artifact",
       "riskmodels_whitepaper_example",
     ]);
+    // riskmodels_render_artifact is hosted-only — registered separately via
+    // registerRiskModelsRenderTool (needs GCP Cloud Run auth), intentionally
+    // NOT in the shared/stdio tool set.
 
     const result = await tools.get("riskmodels_decompose")?.({ ticker: "NVDA" });
     const payload = JSON.parse(result?.content[0].text ?? "{}");


### PR DESCRIPTION
Unbreaks `cd mcp && npm run build` so the `npx @riskmodels/mcp` stdio package can be republished and re-added to the Official MCP Registry listing.

## Problem
The standalone stdio build has been broken since PR #99. `lib/mcp/tools/riskmodels-tools.ts` — compiled into the stdio bundle via `mcp/tsconfig.json`'s `include: ["../lib/mcp/tools/**"]` — imported `@/lib/artifacts/render-client → @/lib/artifacts/gcp-id-token`. Standalone `tsc` can't resolve the `@/` alias, and the `riskmodels_render_artifact` tool authenticates to **GCP Cloud Run** anyway — unusable for a public `npx` user.

## Fix
- Moved `riskmodels_render_artifact` into **`lib/mcp/render-tool.ts`** (outside `lib/mcp/tools/`, so the stdio tsconfig glob doesn't compile it).
- Hosted server (`lib/mcp/server.ts`) registers it separately via `registerRiskModelsRenderTool(server)` → the **remote keeps all 15 tools**.
- The stdio package now exposes the 8 SDK data tools (+ its own discovery/whitepaper) and **builds clean**.
- Exported the shared `textResult`/`errorResult` helpers + `McpLikeServer`/`McpToolResult` types from `riskmodels-tools.ts`.

## Verified
- `cd mcp && npm run build` → **exit 0** (was failing)
- hosted `tsc --noEmit` → **0 errors**; `next lint` → clean
- stdio `dist/` has no `render-client`/`gcp-id-token` references

## Follow-on (separate, additive — needs npm auth)
Republish `@riskmodels/mcp` (the `file:` SDK dep → `^0.1.2` swap is in `mcp/PUBLISHING.md`) and add the `packages[]` block back to `mcp/server.json`, then `mcp-publisher publish`. Additive — does not disturb the live remote listing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)