### PR TITLE
fix(docs): clear fixed navbar so doc headings aren't clipped

### DIFF
--- a/app/docs/layout.tsx
+++ b/app/docs/layout.tsx
@@ -3,7 +3,7 @@ import DocsSidebar from '@/components/docs/DocsSidebar';
 export default function DocsLayout({ children }: { children: React.ReactNode }) {
   return (
     <div className="min-h-screen bg-zinc-950">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12 lg:py-16 lg:flex lg:gap-10">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-20 sm:pt-24 md:pt-28 lg:pt-32 pb-16 lg:flex lg:gap-10">
         <DocsSidebar />
         <div className="min-w-0 flex-1">{children}</div>
       </div>

--- a/components/docs/DocsSidebar.tsx
+++ b/components/docs/DocsSidebar.tsx
@@ -91,7 +91,7 @@ export default function DocsSidebar() {
 
       {/* Desktop: persistent rail */}
       <aside className="hidden lg:block w-60 shrink-0">
-        <div className="sticky top-28 max-h-[calc(100vh-8rem)] overflow-y-auto pr-2 pb-10">
+        <div className="sticky top-40 max-h-[calc(100vh-11rem)] overflow-y-auto pr-2 pb-10">
           <NavList pathname={pathname} />
         </div>
       </aside>


### PR DESCRIPTION
The fixed navbar is up to `h-36` (144px) on desktop, but global `<main>` only offsets `pt-16` (64px) and the docs layout added `py-12` — so doc-page H1s tucked under the header (see the clipped "Returns decomposition metrics" title).

- Docs container: breakpoint-aware top clearance `pt-20 sm:24 md:28 lg:32` (≈48px gap below the navbar at every width).
- Sticky sidebar moved to `top-40` so it doesn't slide under the header on scroll.

Verified desktop (1440) + mobile (390): headings now sit clear of the navbar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)