### PR TITLE
feat(audit): API audit suite (route drift + live schema check + orchestrator)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,6 @@ bwmacro-src/
 # migrations: BWMACRO/supabase/ (private). Do not commit SQL or CLI state here.
 supabase/
 .gstack/
+
+# API audit run outputs (scripts/audit + api_audits.sh)
+audit-reports/

--- a/api_audits.sh
+++ b/api_audits.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+#
+# api_audits.sh — run the full RiskModels API audit suite and write reports.
+#
+# Steps (static first, then live):
+#   1. openapi-yaml    OPENAPI_SPEC.yaml parses
+#   2. cli-openapi     CLI-covered routes ⊆ OpenAPI spec        (scripts/cli-openapi-check.mjs)
+#   3. route-drift     spec paths ↔ app/ route handlers          (scripts/audit/openapi_route_drift.py --strict)
+#   4. schema-selftest the response-schema validator has teeth   (scripts/audit/live_schema_check.py --self-test)
+#   5. smoke-endpoints hit every endpoint live                   (sdk/scripts/smoke_v3_all_endpoints.py)
+#   6. schema-check    validate live 2xx bodies vs schemas       (consumes step 5's smoke_report.json)
+#
+# Reports are written to audit-reports/<timestamp>/. Exit is nonzero if any
+# step fails (SKIP does not fail).
+#
+# Env / flags:
+#   AUDIT_SKIP_LIVE=1   run only the static audits (no API key / no billing)
+#   SKIP_EXPENSIVE=0    include snapshots/PDFs/batch in the smoke (default: 1, skipped — they bill)
+#   SMOKE_WRITE_PDF=1   also emit the smoke PDF report (default: 0)
+#   RISKMODELS_API_KEY  used by the live steps; auto-loaded from .env / .env.local if unset
+#
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$ROOT"
+
+# Resolve a Python with the SDK + audit deps (shared BWMACRO venv preferred).
+PY=""
+for c in "../BWMACRO/.venv/bin/python" ".venv/bin/python" "$(command -v python3 || true)"; do
+  [ -n "$c" ] && [ -x "$c" ] && PY="$c" && break
+done
+[ -z "$PY" ] && { echo "ERROR: no python interpreter found (need ../BWMACRO/.venv or .venv)"; exit 2; }
+
+TS="$(date +%Y%m%d_%H%M%S)"
+OUT="audit-reports/$TS"
+mkdir -p "$OUT"
+
+NAMES=(); CODES=()
+record() { NAMES+=("$1"); CODES+=("$2"); }
+step() {  # step <name> <cmd...>
+  local name="$1"; shift
+  echo; echo "──────── $name ────────"
+  "$@"
+  local code=$?
+  record "$name" "$code"
+}
+
+echo "RiskModels API audits → $OUT"
+
+# ---- static audits (no API key) -----------------------------------------
+step "openapi-yaml" "$PY" -c "import yaml; yaml.safe_load(open('OPENAPI_SPEC.yaml')); print('OPENAPI_SPEC.yaml parses OK')"
+
+if command -v node >/dev/null 2>&1; then
+  step "cli-openapi" node scripts/cli-openapi-check.mjs
+else
+  echo "skip cli-openapi (node not found)"; record "cli-openapi" "skip"
+fi
+
+step "route-drift" "$PY" scripts/audit/openapi_route_drift.py --strict --out-dir "$OUT"
+
+step "schema-selftest" "$PY" scripts/audit/live_schema_check.py --self-test
+
+# ---- live audits (need an API key; cost money) ---------------------------
+if [ "${AUDIT_SKIP_LIVE:-0}" = "1" ]; then
+  echo; echo "AUDIT_SKIP_LIVE=1 — skipping live smoke + schema check."
+  record "smoke-endpoints" "skip"; record "schema-check" "skip"
+else
+  HAS_KEY="$("$PY" -c "import sys,os; sys.path.insert(0,'sdk/scripts'); import smoke_v3_all_endpoints as s; s.load_env_files(); print('1' if os.environ.get('RISKMODELS_API_KEY') else '0')" 2>/dev/null || echo 0)"
+  if [ "$HAS_KEY" != "1" ]; then
+    echo; echo "No RISKMODELS_API_KEY found (env or .env/.env.local) — skipping live steps. Set AUDIT_SKIP_LIVE=1 to silence."
+    record "smoke-endpoints" "skip"; record "schema-check" "skip"
+  else
+    export SMOKE_REPORT_DIR="$OUT/smoke"
+    export SMOKE_JSON_BODY_MAX="${SMOKE_JSON_BODY_MAX:-200000}"  # fuller bodies → fewer truncation skips
+    export SKIP_EXPENSIVE="${SKIP_EXPENSIVE:-1}"                 # snapshots/PDFs/batch bill — opt-in
+    export SMOKE_WRITE_PDF="${SMOKE_WRITE_PDF:-0}"
+    step "smoke-endpoints" "$PY" sdk/scripts/smoke_v3_all_endpoints.py
+    if [ -f "$OUT/smoke/smoke_report.json" ]; then
+      # Reporting only (no --strict): schema drift is surfaced + written to
+      # schema_check.json but does not fail the gate (often spec staleness).
+      # Add --strict to enforce once the spec/responses are reconciled.
+      step "schema-check" "$PY" scripts/audit/live_schema_check.py \
+        --smoke-report "$OUT/smoke/smoke_report.json" --out-dir "$OUT"
+    else
+      echo "smoke_report.json not found — skipping schema-check"; record "schema-check" "skip"
+    fi
+  fi
+fi
+
+# ---- summary ------------------------------------------------------------
+echo; echo "════════ API AUDIT SUMMARY ($TS) ════════"
+fail=0
+for i in "${!NAMES[@]}"; do
+  c="${CODES[$i]}"
+  case "$c" in
+    0)        s="PASS" ;;
+    skip)     s="SKIP" ;;
+    *)        s="FAIL"; fail=1 ;;
+  esac
+  printf "  %-18s %s\n" "${NAMES[$i]}" "$s"
+done
+echo "Reports: $OUT/"
+[ "$fail" = "0" ] && echo "Overall: PASS" || echo "Overall: FAIL"
+exit "$fail"

--- a/api_audits.sh
+++ b/api_audits.sh
@@ -58,6 +58,8 @@ fi
 
 step "route-drift" "$PY" scripts/audit/openapi_route_drift.py --strict --out-dir "$OUT"
 
+step "docs-conformity" "$PY" scripts/audit/docs_conformity.py --strict --out-dir "$OUT"
+
 step "schema-selftest" "$PY" scripts/audit/live_schema_check.py --self-test
 
 # ---- live audits (need an API key; cost money) ---------------------------

--- a/scripts/audit/README.md
+++ b/scripts/audit/README.md
@@ -16,6 +16,7 @@ Reports are written to `audit-reports/<timestamp>/` (gitignored).
 | `openapi-yaml` | `OPENAPI_SPEC.yaml` parses | no | yes |
 | `cli-openapi` | `scripts/cli-openapi-check.mjs` (CLI routes ⊆ spec) | no | yes |
 | `route-drift` | `scripts/audit/openapi_route_drift.py --strict` | no | yes (untracked) |
+| `docs-conformity` | `scripts/audit/docs_conformity.py --strict` | no | yes (untracked) |
 | `schema-selftest` | `scripts/audit/live_schema_check.py --self-test` | no | yes |
 | `smoke-endpoints` | `sdk/scripts/smoke_v3_all_endpoints.py` | **yes** | yes (critical only) |
 | `schema-check` | `scripts/audit/live_schema_check.py` (consumes smoke report) | no | no (reports) |
@@ -38,6 +39,14 @@ smoke run against their OpenAPI response schemas (`$ref`s inlined, OpenAPI-3.0
 (validated / skipped) so a green run can't hide "checked nothing". Reporting by
 default; add `--strict` to enforce once spec and responses are reconciled.
 `--self-test` proves the validator flags a broken body.
+
+**`docs_conformity.py`** — static. Checks the hand-maintained MDX docs
+(`content/docs/*.mdx`) against the spec: every `/api/...` path mentioned in the
+docs must match an OpenAPI path template (concrete values like `/api/metrics/AAPL`
+match `/metrics/{ticker}`), and every internal `/docs/<slug>` link must resolve
+to an MDX file. Endpoint-table costs are compared to `x-pricing.cost_usd` and
+reported. Acceptable prose mentions and tracked defects live in
+`docs_conformity_allowlist.json` (`phantom_ok` / `known_issues`).
 
 ## Adding a new documented endpoint
 

--- a/scripts/audit/README.md
+++ b/scripts/audit/README.md
@@ -1,0 +1,45 @@
+# API audit suite
+
+Run everything:
+
+```bash
+./api_audits.sh                 # static + live (needs an API key; bills a little)
+AUDIT_SKIP_LIVE=1 ./api_audits.sh   # static only (CI / no key / no billing)
+```
+
+Reports are written to `audit-reports/<timestamp>/` (gitignored).
+
+## What runs
+
+| Step | Script | Network | Fails the gate? |
+|------|--------|---------|-----------------|
+| `openapi-yaml` | `OPENAPI_SPEC.yaml` parses | no | yes |
+| `cli-openapi` | `scripts/cli-openapi-check.mjs` (CLI routes ⊆ spec) | no | yes |
+| `route-drift` | `scripts/audit/openapi_route_drift.py --strict` | no | yes (untracked) |
+| `schema-selftest` | `scripts/audit/live_schema_check.py --self-test` | no | yes |
+| `smoke-endpoints` | `sdk/scripts/smoke_v3_all_endpoints.py` | **yes** | yes (critical only) |
+| `schema-check` | `scripts/audit/live_schema_check.py` (consumes smoke report) | no | no (reports) |
+
+## The two new audits
+
+**`openapi_route_drift.py`** — static. Compares every OpenAPI path against the
+Next.js `app/**/route.ts` handlers (params normalized to `{}`, leading `/api`
+stripped, `next.config` rewrites/redirects honored). Reports:
+- documented paths with **no** handler → fails `--strict`;
+- handlers with **no** spec entry → informational;
+- a cross-reference matrix (`route_drift.json`).
+
+Known-but-tracked gaps live in `drift_allowlist.json` (`known_issues`): reported
+every run, but they don't fail the gate, so the gate still catches *new* drift.
+
+**`live_schema_check.py`** — validates the live JSON 2xx bodies captured by the
+smoke run against their OpenAPI response schemas (`$ref`s inlined, OpenAPI-3.0
+`nullable` honored, permissive on extra fields). Prints a coverage headline
+(validated / skipped) so a green run can't hide "checked nothing". Reporting by
+default; add `--strict` to enforce once spec and responses are reconciled.
+`--self-test` proves the validator flags a broken body.
+
+## Adding a new documented endpoint
+
+Register it in `lib/docs-nav.ts` (for docs) and ship an `app/api/.../route.ts`;
+`route-drift --strict` fails if a documented path has no handler.

--- a/scripts/audit/docs_conformity.py
+++ b/scripts/audit/docs_conformity.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""Static audit: the human-facing docs (content/docs/*.mdx) vs the OpenAPI spec.
+
+The MDX docs are hand-maintained — the /docs/api endpoint table, curl examples,
+and cross-links drift from the actual API without anything noticing. This checks
+them, no network:
+
+  HARD (fail --strict):
+    * every /api/... path mentioned in the docs matches an OpenAPI path template
+      (concrete example values like /api/metrics/AAPL match /metrics/{ticker});
+      catches typo'd / renamed / phantom endpoints
+    * every internal /docs/<slug> link resolves to a content/docs/<slug>.mdx file
+      (catches broken doc-to-doc links after a docs refactor)
+
+  REPORT (informational):
+    * endpoint-table cost vs the spec's x-pricing.cost_usd
+    * method in the table vs the spec
+    * coverage — spec paths never mentioned anywhere in the docs
+
+Usage:
+  python scripts/audit/docs_conformity.py [--out-dir DIR] [--strict]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+OPENAPI_PATH = REPO_ROOT / "mcp" / "data" / "openapi.json"
+DOCS_DIR = REPO_ROOT / "content" / "docs"
+ALLOWLIST_PATH = Path(__file__).resolve().parent / "docs_conformity_allowlist.json"
+
+_API_PATH = re.compile(r"/api/[A-Za-z0-9_./{}\-]+")
+# /docs/<slug> as a leaf doc route — NOT /docs/readme/x.png (asset) or /docs/api.mdx
+_DOCS_LINK = re.compile(r"/docs/([a-z0-9][a-z0-9\-]*)(?![A-Za-z0-9\-/.])")
+_METHOD = re.compile(r"\b(GET|POST|PUT|PATCH|DELETE)\b")
+_COST = re.compile(r"\$\s*([0-9]+(?:\.[0-9]+)?)")
+
+
+def split_segs(p: str) -> list[str]:
+    return [s for s in p.strip("/").split("/") if s]
+
+
+def is_param(seg: str) -> bool:
+    return seg.startswith("{") and seg.endswith("}")
+
+
+def unescape_mdx(text: str) -> str:
+    """Render JSX string expressions to literal text: {'{ticker}'} -> {ticker},
+    {'$'} -> $, {"x"} -> x."""
+    text = re.sub(r"\{'([^']*)'\}", r"\1", text)
+    text = re.sub(r'\{"([^"]*)"\}', r"\1", text)
+    return text
+
+
+def strip_tags(html: str) -> str:
+    return re.sub(r"\s+", " ", re.sub(r"<[^>]+>", " ", html)).strip()
+
+
+def normalize_doc_path(p: str) -> list[str]:
+    p = p.split("?")[0].split("#")[0].rstrip(").,;:'\"`")
+    if p == "/api" or p.startswith("/api/"):
+        p = p[len("/api") :] or "/"
+    return split_segs(p)
+
+
+def load_spec() -> tuple[dict[int, list[tuple[str, list[str]]]], dict[tuple[str, str], dict[str, Any]]]:
+    """(segment_count -> [(original_path, segments)], (path, METHOD) -> x-pricing)."""
+    spec = json.loads(OPENAPI_PATH.read_text())
+    by_count: dict[int, list[tuple[str, list[str]]]] = {}
+    pricing: dict[tuple[str, str], dict[str, Any]] = {}
+    for p, ops in (spec.get("paths") or {}).items():
+        segs = split_segs(p)
+        by_count.setdefault(len(segs), []).append((p, segs))
+        for m, op in ops.items():
+            if m.upper() in ("GET", "POST", "PUT", "PATCH", "DELETE") and isinstance(op, dict):
+                pricing[(p, m.upper())] = op.get("x-pricing") or {}
+    return by_count, pricing
+
+
+def match_spec(doc_path: str, by_count: dict[int, list[tuple[str, list[str]]]]) -> str | None:
+    """Original spec path whose template matches this doc path (params = wildcard)."""
+    segs = normalize_doc_path(doc_path)
+    for original, tsegs in by_count.get(len(segs), []):
+        if all(is_param(t) or t == s for t, s in zip(tsegs, segs)):
+            return original
+    return None
+
+
+def spec_cost(original: str, pricing: dict[tuple[str, str], dict[str, Any]]) -> float | None:
+    for mm in ("GET", "POST", "PUT", "PATCH", "DELETE"):
+        pr = pricing.get((original, mm))
+        if pr and "cost_usd" in pr:
+            return float(pr["cost_usd"])
+    return None
+
+
+def _norm_join(p: str) -> str:
+    return "/" + "/".join(normalize_doc_path(p))
+
+
+def load_allowlist() -> tuple[set[str], set[str]]:
+    """(phantom_ok, known_issues) as normalized path strings."""
+    if not ALLOWLIST_PATH.exists():
+        return set(), set()
+    data = json.loads(ALLOWLIST_PATH.read_text())
+    return (
+        {_norm_join(p) for p in (data.get("phantom_ok") or [])},
+        {_norm_join(p) for p in (data.get("known_issues") or [])},
+    )
+
+
+def extract_table_rows(text: str) -> list[dict[str, Any]]:
+    rows = []
+    for tr in re.findall(r"<tr\b.*?</tr>", text, re.S):
+        cells = [strip_tags(td) for td in re.findall(r"<td\b.*?</td>", tr, re.S)]
+        path_cell = next((c for c in cells if _API_PATH.search(c)), None)
+        if not path_cell:
+            continue
+        rows.append(
+            {
+                "paths": _API_PATH.findall(path_cell),
+                "methods": [m for c in cells if c != path_cell for m in _METHOD.findall(c)],
+                "cost": next((c for c in cells if "$" in c or "Free" in c), ""),
+            }
+        )
+    return rows
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--out-dir", type=Path, default=None)
+    ap.add_argument("--strict", action="store_true")
+    args = ap.parse_args()
+
+    by_count, pricing = load_spec()
+    all_originals = {p for lst in by_count.values() for (p, _) in lst}
+    mdx_files = sorted(DOCS_DIR.glob("*.mdx"))
+    doc_slugs = {f.stem for f in mdx_files}
+    phantom_ok, known_issue_keys = load_allowlist()
+
+    matched: set[str] = set()
+    phantom: list[dict[str, str]] = []
+    known_issues: list[dict[str, str]] = []
+    broken_links: list[dict[str, str]] = []
+    cost_mismatch: list[dict[str, Any]] = []
+    method_mismatch: list[dict[str, Any]] = []
+
+    for f in mdx_files:
+        raw = unescape_mdx(f.read_text())
+        rel = str(f.relative_to(REPO_ROOT))
+
+        seen_phantom: set[str] = set()
+        for m in _API_PATH.findall(raw):
+            original = match_spec(m, by_count)
+            if original:
+                matched.add(original)
+                continue
+            norm = "/" + "/".join(normalize_doc_path(m))
+            if norm in phantom_ok or norm in seen_phantom:
+                continue
+            seen_phantom.add(norm)
+            if norm in known_issue_keys:
+                known_issues.append({"file": rel, "path": m})
+            else:
+                phantom.append({"file": rel, "path": m})
+
+        for slug in sorted(set(_DOCS_LINK.findall(raw))):
+            if slug not in doc_slugs:
+                broken_links.append({"file": rel, "link": f"/docs/{slug}"})
+
+        for row in extract_table_rows(raw):
+            for i, p in enumerate(row["paths"]):
+                original = match_spec(p, by_count)
+                if not original:
+                    continue
+                method = row["methods"][i] if i < len(row["methods"]) else (row["methods"][0] if row["methods"] else None)
+                if method and (original, method.upper()) not in pricing:
+                    have = sorted({mm for (pp, mm) in pricing if pp == original})
+                    method_mismatch.append({"file": rel, "path": p, "doc_method": method.upper(), "spec_methods": have})
+                sc = spec_cost(original, pricing)
+                cost = row["cost"]
+                if sc is None or not cost:
+                    continue
+                if "free" in cost.lower():
+                    doc_cost = 0.0
+                else:
+                    nums = [float(x) for x in _COST.findall(cost)]
+                    if not nums:
+                        continue
+                    doc_cost = nums[0]  # range "a–b" → low end
+                if abs(sc - doc_cost) > 1e-9:
+                    cost_mismatch.append({"file": rel, "path": p, "doc_cost": cost.strip(), "spec_cost_usd": sc})
+
+    coverage_gap = sorted(all_originals - matched)
+
+    report = {
+        "summary": {
+            "mdx_files": len(mdx_files),
+            "phantom_paths": len(phantom),
+            "known_issues": len(known_issues),
+            "broken_docs_links": len(broken_links),
+            "cost_mismatches": len(cost_mismatch),
+            "method_mismatches": len(method_mismatch),
+            "undocumented_spec_paths": len(coverage_gap),
+        },
+        "phantom_paths": phantom,
+        "known_issues": known_issues,
+        "broken_docs_links": broken_links,
+        "cost_mismatches": cost_mismatch,
+        "method_mismatches": method_mismatch,
+        "undocumented_spec_paths": coverage_gap,
+    }
+
+    print(f"Docs scanned: {len(mdx_files)} mdx files")
+    print(f"Phantom /api paths (in docs, not in spec, untracked): {len(phantom)}")
+    for x in phantom:
+        print(f"  ✗ {x['path']}  ({x['file']})")
+    if known_issues:
+        print(f"Known issues (tracked, non-blocking): {len(known_issues)}")
+        for x in known_issues:
+            print(f"  ⚠ {x['path']}  ({x['file']})")
+    print(f"Broken /docs links: {len(broken_links)}")
+    for x in broken_links:
+        print(f"  ✗ {x['link']}  ({x['file']})")
+    print(f"Cost mismatches (report): {len(cost_mismatch)}")
+    for x in cost_mismatch:
+        print(f"  · {x['path']}: docs {x['doc_cost']} vs spec ${x['spec_cost_usd']}")
+    print(f"Method mismatches (report): {len(method_mismatch)}")
+    for x in method_mismatch:
+        print(f"  · {x['path']}: docs {x['doc_method']} vs spec {x['spec_methods']}")
+    print(f"Spec paths not mentioned in docs (report): {len(coverage_gap)}")
+
+    if args.out_dir:
+        args.out_dir.mkdir(parents=True, exist_ok=True)
+        (args.out_dir / "docs_conformity.json").write_text(json.dumps(report, indent=2))
+        print(f"\nWrote {args.out_dir / 'docs_conformity.json'}")
+
+    hard = len(phantom) + len(broken_links)
+    if args.strict and hard:
+        print(f"\nFAIL: {len(phantom)} phantom path(s), {len(broken_links)} broken doc link(s).", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/audit/docs_conformity_allowlist.json
+++ b/scripts/audit/docs_conformity_allowlist.json
@@ -1,0 +1,12 @@
+{
+  "phantom_ok": [
+    "/api/rankings"
+  ],
+  "known_issues": [
+    "/api/plaid/webhook"
+  ],
+  "_notes": {
+    "/api/rankings": "Prose shorthand in rankings-screen.mdx ('replaces N per-ticker /rankings round-trips') referring to /rankings/{ticker} generically — not a literal endpoint claim.",
+    "/api/plaid/webhook": "DEFECT (tracked, backlog C): plaid-holdings.mdx:94 documents POST /api/plaid/webhook but there is no app/api/plaid/webhook/route.ts and it is not in the OpenAPI spec. Either implement the receiver, add it to the spec, or correct the doc if Plaid webhooks are handled outside app/api (e.g. a Supabase edge function)."
+  }
+}

--- a/scripts/audit/drift_allowlist.json
+++ b/scripts/audit/drift_allowlist.json
@@ -1,0 +1,10 @@
+{
+  "missing_ok": [],
+  "undocumented_ok": [],
+  "known_issues": [
+    "/auth/token"
+  ],
+  "_notes": {
+    "/auth/token": "DEFECT (tracked, backlog C): documented as 'Generate OAuth2 Access Token' on server https://riskmodels.app/api, and the SDK posts here (sdk/riskmodels/auth.py:66), but production returns HTTP 404 (no app/api/auth/token/route.ts; the catch-all returns JSON 404). OAuth2 client-credentials auth appears broken; only API-key auth works. Listed as known_issues so the strict gate flags NEW drift while this stays tracked. Remove once a handler ships or the spec is corrected."
+  }
+}

--- a/scripts/audit/live_schema_check.py
+++ b/scripts/audit/live_schema_check.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""Validate captured live API responses against their OpenAPI response schemas.
+
+Offline: consumes a ``smoke_report.json`` produced by
+``sdk/scripts/smoke_v3_all_endpoints.py`` (which already hit every endpoint),
+so there is no second round of billable API calls. For each JSON 2xx response
+it looks up the operation's 2xx ``application/json`` schema and validates the
+body against it.
+
+OpenAPI 3.0 dialect handling: ``nullable: true`` is translated to "also allow
+null" before validation; unknown keywords (``example``, ``discriminator``) are
+ignored by jsonschema. Validation is permissive on extra properties (OpenAPI
+schemas rarely set ``additionalProperties: false``), so findings are real
+shape violations: a missing required field or a wrong type on a present field.
+
+Coverage is reported as a headline (validated / skipped / total) so a green run
+can't hide "checked nothing" — a high truncation-skip rate means the audit is
+hollow, bump SMOKE_JSON_BODY_MAX upstream.
+
+Usage:
+  python scripts/audit/live_schema_check.py --smoke-report PATH [--out-dir DIR] [--strict]
+  python scripts/audit/live_schema_check.py --self-test   # prove the validator has teeth
+
+Exit codes: 0 = no violations (or non-strict); 1 = --strict and violations;
+2 = could not load inputs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+OPENAPI_PATH = REPO_ROOT / "mcp" / "data" / "openapi.json"
+
+
+def _resolve_pointer(spec: dict[str, Any], ref: str) -> Any:
+    """Resolve an intra-document JSON pointer like '#/components/schemas/X'."""
+    if not ref.startswith("#/"):
+        raise KeyError(f"unsupported $ref: {ref}")
+    node: Any = spec
+    for seg in ref[2:].split("/"):
+        seg = seg.replace("~1", "/").replace("~0", "~")
+        node = node[seg]
+    return node
+
+
+def inline_refs(node: Any, spec: dict[str, Any], seen: tuple[str, ...] = ()) -> Any:
+    """Inline '#/...' $refs into a self-contained schema. A $ref repeated on the
+    current resolution path (a cycle) collapses to '{}' (permissive) so deep or
+    recursive component graphs can't loop forever."""
+    if isinstance(node, dict):
+        ref = node.get("$ref")
+        if isinstance(ref, str) and ref.startswith("#/"):
+            if ref in seen:
+                return {}
+            return inline_refs(_resolve_pointer(spec, ref), spec, seen + (ref,))
+        return {k: inline_refs(v, spec, seen) for k, v in node.items()}
+    if isinstance(node, list):
+        return [inline_refs(v, spec, seen) for v in node]
+    return node
+
+
+def normalize_openapi_dialect(node: Any) -> Any:
+    """Recursively translate OpenAPI-3.0 ``nullable`` into JSON-Schema null-union
+    so a documented-nullable field doesn't produce a false type violation."""
+    if isinstance(node, dict):
+        node = {k: normalize_openapi_dialect(v) for k, v in node.items()}
+        if node.pop("nullable", False):
+            t = node.get("type")
+            if isinstance(t, str):
+                node["type"] = [t, "null"]
+            elif isinstance(t, list) and "null" not in t:
+                node["type"] = [*t, "null"]
+            else:
+                # no concrete type (e.g. only $ref/anyOf) — widen with anyOf
+                inner = {k: v for k, v in node.items()}
+                node = {"anyOf": [inner, {"type": "null"}]}
+        return node
+    if isinstance(node, list):
+        return [normalize_openapi_dialect(v) for v in node]
+    return node
+
+
+def compile_schema(raw_schema: Any, spec: dict[str, Any]) -> Any:
+    """Inline $refs then translate OpenAPI-3.0 nullable → a self-contained,
+    validatable JSON Schema."""
+    return normalize_openapi_dialect(inline_refs(copy.deepcopy(raw_schema), spec))
+
+
+def response_schema(spec: dict[str, Any], path: str, method: str, status: int | None) -> Any:
+    op = (spec.get("paths") or {}).get(path, {}).get(method.lower())
+    if not op:
+        return None
+    responses = op.get("responses") or {}
+    candidates = [str(status), "2XX", "200", "201", "default"]
+    resp = next((responses[c] for c in candidates if c in responses), None)
+    if resp is None:
+        # any 2xx
+        resp = next((v for k, v in responses.items() if k.startswith("2")), None)
+    if not resp:
+        return None
+    content = (resp.get("content") or {}).get("application/json") or {}
+    return content.get("schema")
+
+
+def validate_report(smoke_report: Path, *, strict: bool, out_dir: Path | None) -> int:
+    try:
+        payload = json.loads(smoke_report.read_text())
+        spec = json.loads(OPENAPI_PATH.read_text())
+    except Exception as e:  # noqa: BLE001
+        print(f"could not load inputs: {e}", file=sys.stderr)
+        return 2
+
+    calls = payload.get("calls") or []
+    total_json_2xx = 0
+    validated = 0
+    skipped_no_schema = 0
+    skipped_truncated = 0
+    findings: list[dict[str, Any]] = []
+
+    for c in calls:
+        status = c.get("status")
+        if c.get("body_kind") != "json" or not (status and 200 <= int(status) < 300):
+            continue
+        total_json_2xx += 1
+        path = c.get("path_template") or ""
+        method = c.get("method") or "get"
+        raw_schema = response_schema(spec, path, method, status)
+        if not raw_schema:
+            skipped_no_schema += 1
+            continue
+        try:
+            body = json.loads(c.get("body_text") or "")
+        except Exception:  # truncated / unparseable
+            skipped_truncated += 1
+            continue
+        validator = Draft202012Validator(compile_schema(raw_schema, spec))
+        errors = sorted(validator.iter_errors(body), key=lambda e: list(e.path))
+        validated += 1
+        if errors:
+            findings.append(
+                {
+                    "method": method,
+                    "path": path,
+                    "status": status,
+                    "errors": [
+                        {"loc": "/".join(str(p) for p in e.path) or "<root>", "msg": e.message}
+                        for e in errors[:8]
+                    ],
+                    "error_count": len(errors),
+                }
+            )
+
+    report = {
+        "summary": {
+            "json_2xx_responses": total_json_2xx,
+            "validated": validated,
+            "skipped_no_schema": skipped_no_schema,
+            "skipped_truncated": skipped_truncated,
+            "endpoints_with_violations": len(findings),
+        },
+        "findings": findings,
+    }
+
+    print(
+        f"Schema check: validated {validated} / skipped {skipped_no_schema} (no schema) "
+        f"+ {skipped_truncated} (truncated) of {total_json_2xx} JSON 2xx responses"
+    )
+    if skipped_truncated:
+        print(
+            f"  note: {skipped_truncated} body(ies) were truncated/unparseable — "
+            "raise SMOKE_JSON_BODY_MAX for fuller coverage"
+        )
+    print(f"Endpoints with schema violations: {len(findings)}")
+    for f in findings:
+        print(f"  ✗ {f['method'].upper()} {f['path']} ({f['error_count']} error(s))")
+        for e in f["errors"][:3]:
+            print(f"      {e['loc']}: {e['msg'][:140]}")
+
+    if out_dir:
+        out_dir.mkdir(parents=True, exist_ok=True)
+        (out_dir / "schema_check.json").write_text(json.dumps(report, indent=2))
+        print(f"\nWrote {out_dir / 'schema_check.json'}")
+
+    if strict and findings:
+        print(f"\nFAIL: {len(findings)} endpoint(s) violated their response schema.", file=sys.stderr)
+        return 1
+    return 0
+
+
+def self_test() -> int:
+    """Prove the validator flags a deliberately-broken body (not green-but-hollow)."""
+    schema = {
+        "type": "object",
+        "required": ["ticker"],
+        "properties": {"ticker": {"type": "string"}, "n": {"type": "integer", "nullable": True}},
+    }
+    v = Draft202012Validator(normalize_openapi_dialect(schema))
+    missing = list(v.iter_errors({}))                 # required field absent
+    wrong = list(v.iter_errors({"ticker": 5}))        # wrong type
+    nullable_ok = list(v.iter_errors({"ticker": "X", "n": None}))  # nullable honored
+    good = list(v.iter_errors({"ticker": "X", "n": 3}))
+    ok = (len(missing) == 1 and len(wrong) == 1 and not nullable_ok and not good)
+    print("self-test:", "PASS" if ok else "FAIL",
+          f"(missing={len(missing)} wrongtype={len(wrong)} nullable_err={len(nullable_ok)} good_err={len(good)})")
+    return 0 if ok else 1
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--smoke-report", type=Path, help="path to smoke_report.json")
+    ap.add_argument("--out-dir", type=Path, default=None)
+    ap.add_argument("--strict", action="store_true")
+    ap.add_argument("--self-test", action="store_true", help="validate the validator and exit")
+    args = ap.parse_args()
+
+    if args.self_test:
+        return self_test()
+    if not args.smoke_report or not args.smoke_report.exists():
+        print("--smoke-report PATH is required (and must exist)", file=sys.stderr)
+        return 2
+    return validate_report(args.smoke_report, strict=args.strict, out_dir=args.out_dir)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/audit/openapi_route_drift.py
+++ b/scripts/audit/openapi_route_drift.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Static audit: OpenAPI paths vs Next.js `app/` route handlers.
+
+Two directions of drift, no network:
+
+  * documented (spec) paths with **no** implementing `route.ts` and not served
+    by a `next.config.mjs` rewrite/redirect — the promise-breaking direction
+    (hard-fails under ``--strict``). A documented endpoint that 404s is worse
+    than an undocumented one.
+  * implemented handlers with **no** OpenAPI documentation — informational
+    (lots of internal routes are intentionally undocumented).
+
+Also writes a cross-reference matrix: spec path -> handler file -> present in
+capabilities.json? -> present in the SDK capability registry?
+
+Matching is param-agnostic: every dynamic segment (`{ticker}` in the spec,
+`[ticker]` / `[...slug]` / `[[...slug]]` in the filesystem) is normalized to
+`{}`, so param-name differences (`[id]` vs `{bw_fund_id}`) don't create false
+drift. Handler paths have a leading `/api` stripped so they unify with the
+spec's `/api` server base (root-served paths like `/.well-known/*` stay as-is).
+
+Usage:
+  python scripts/audit/openapi_route_drift.py [--out-dir DIR] [--strict]
+
+Exit codes: 0 = no missing handlers (or non-strict); 1 = --strict and missing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+OPENAPI_PATH = REPO_ROOT / "mcp" / "data" / "openapi.json"
+APP_DIR = REPO_ROOT / "app"
+NEXT_CONFIG = REPO_ROOT / "next.config.mjs"
+CAPABILITIES_JSON = REPO_ROOT / "mcp" / "data" / "capabilities.json"
+SDK_CAPABILITIES = REPO_ROOT / "sdk" / "riskmodels" / "capabilities.py"
+ALLOWLIST_PATH = Path(__file__).resolve().parent / "drift_allowlist.json"
+
+_DYNAMIC_SEG = re.compile(r"^\[\[?\.{0,3}[^\]]+\]\]?$")  # [x] [...x] [[...x]]
+
+
+def normalize_key(path: str) -> str:
+    """Param-agnostic comparison key: every dynamic segment -> '{}'."""
+    segs = [s for s in path.strip("/").split("/") if s != ""]
+    out = []
+    for s in segs:
+        if (s.startswith("{") and s.endswith("}")) or _DYNAMIC_SEG.match(s):
+            out.append("{}")
+        else:
+            out.append(s)
+    return "/" + "/".join(out)
+
+
+def spec_paths() -> dict[str, str]:
+    """{normalized_key: original_spec_path}."""
+    spec = json.loads(OPENAPI_PATH.read_text())
+    return {normalize_key(p): p for p in (spec.get("paths") or {})}
+
+
+def _handler_url(route_file: Path) -> str | None:
+    """Derive the served URL path from an app/**/route.ts file, or None if the
+    route is excluded from routing (private `_dir`, parallel `@slot`)."""
+    rel = route_file.parent.relative_to(APP_DIR)
+    segs: list[str] = []
+    for part in rel.parts:
+        if part.startswith("_") or part.startswith("@"):
+            return None  # private folder / parallel slot — not a public URL
+        if part.startswith("(") and part.endswith(")"):
+            continue  # route group — invisible in the URL
+        segs.append(part)
+    url = "/" + "/".join(segs)
+    # Unify with the spec's /api server base; root-served paths keep their prefix.
+    if url == "/api" or url.startswith("/api/"):
+        url = url[len("/api") :] or "/"
+    return url
+
+
+def handler_paths() -> dict[str, list[str]]:
+    """{normalized_key: [repo-relative route.ts paths]} across all of app/."""
+    out: dict[str, list[str]] = {}
+    for route_file in sorted(APP_DIR.rglob("route.ts")):
+        url = _handler_url(route_file)
+        if url is None:
+            continue
+        key = normalize_key(url)
+        out.setdefault(key, []).append(str(route_file.relative_to(REPO_ROOT)))
+    return out
+
+
+def config_satisfied_keys() -> set[str]:
+    """Normalized keys served by a next.config rewrite/redirect source."""
+    keys: set[str] = set()
+    if not NEXT_CONFIG.exists():
+        return keys
+    text = NEXT_CONFIG.read_text()
+    for m in re.finditer(r"source:\s*'([^']+)'", text):
+        src = m.group(1)
+        # Next.js rewrite/redirect params: :file*, :path, :id -> dynamic
+        src = re.sub(r":[A-Za-z0-9_]+\*?", "{}", src)
+        keys.add(normalize_key(src))
+    return keys
+
+
+def load_allowlist() -> dict[str, list[str]]:
+    if ALLOWLIST_PATH.exists():
+        data = json.loads(ALLOWLIST_PATH.read_text())
+        return {
+            "missing_ok": list(data.get("missing_ok") or []),
+            "undocumented_ok": list(data.get("undocumented_ok") or []),
+            "known_issues": list(data.get("known_issues") or []),
+        }
+    return {"missing_ok": [], "undocumented_ok": [], "known_issues": []}
+
+
+def build_matrix(
+    spec: dict[str, str], handlers: dict[str, list[str]]
+) -> list[dict[str, Any]]:
+    cap_text = CAPABILITIES_JSON.read_text() if CAPABILITIES_JSON.exists() else ""
+    sdk_text = SDK_CAPABILITIES.read_text() if SDK_CAPABILITIES.exists() else ""
+    rows = []
+    for key, original in sorted(spec.items(), key=lambda kv: kv[1]):
+        files = handlers.get(key, [])
+        rows.append(
+            {
+                "spec_path": original,
+                "key": key,
+                "handler_files": files,
+                "implemented": bool(files),
+                "in_capabilities_json": original in cap_text,
+                "in_sdk_capabilities": original in sdk_text,
+            }
+        )
+    return rows
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--out-dir", type=Path, default=None)
+    ap.add_argument("--strict", action="store_true", help="exit 1 if any spec path lacks a handler")
+    args = ap.parse_args()
+
+    spec = spec_paths()
+    handlers = handler_paths()
+    config_keys = config_satisfied_keys()
+    allow = load_allowlist()
+    allow_missing = {normalize_key(p) for p in allow["missing_ok"]}
+    allow_undoc = {normalize_key(p) for p in allow["undocumented_ok"]}
+    known_issue_keys = {normalize_key(p) for p in allow["known_issues"]}
+
+    missing = []        # documented, no handler/rewrite, not tracked — blocks --strict
+    known_issues = []   # documented, no handler, but a tracked defect — reported, non-blocking
+    for key, original in sorted(spec.items(), key=lambda kv: kv[1]):
+        if key in handlers or key in config_keys or key in allow_missing:
+            continue
+        if key in known_issue_keys:
+            known_issues.append(original)
+        else:
+            missing.append(original)
+
+    spec_keys = set(spec)
+    undocumented = []  # handler with no spec path
+    for key, files in sorted(handlers.items()):
+        if key in spec_keys or key in allow_undoc:
+            continue
+        undocumented.append({"key": key, "files": files})
+
+    matrix = build_matrix(spec, handlers)
+
+    report = {
+        "summary": {
+            "spec_paths": len(spec),
+            "handler_routes": len(handlers),
+            "missing_handlers": len(missing),
+            "known_issues": len(known_issues),
+            "undocumented_handlers": len(undocumented),
+            "config_satisfied_keys": sorted(config_keys),
+        },
+        "missing_handlers": missing,
+        "known_issues": known_issues,
+        "undocumented_handlers": undocumented,
+        "cross_reference": matrix,
+    }
+
+    # ---- output -----------------------------------------------------------
+    print(f"OpenAPI paths: {len(spec)}  |  app/ route handlers: {len(handlers)}")
+    print(f"Documented-but-unimplemented (untracked): {len(missing)}")
+    for p in missing:
+        print(f"  ✗ {p}  (no route.ts, no rewrite/redirect)")
+    if known_issues:
+        print(f"Known issues (tracked, non-blocking): {len(known_issues)}")
+        for p in known_issues:
+            print(f"  ⚠ {p}  (tracked — see drift_allowlist.json)")
+    print(f"Undocumented handlers (informational): {len(undocumented)}")
+    for u in undocumented:
+        print(f"  · {u['key']}  ({u['files'][0]})")
+
+    if args.out_dir:
+        args.out_dir.mkdir(parents=True, exist_ok=True)
+        (args.out_dir / "route_drift.json").write_text(json.dumps(report, indent=2))
+        print(f"\nWrote {args.out_dir / 'route_drift.json'}")
+
+    if args.strict and missing:
+        print(f"\nFAIL: {len(missing)} documented path(s) have no handler.", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sdk/scripts/smoke_v3_all_endpoints.py
+++ b/sdk/scripts/smoke_v3_all_endpoints.py
@@ -44,6 +44,7 @@ OPENAPI_PATH = REPO_ROOT / "mcp" / "data" / "openapi.json"
 STOCK_TICKER = os.environ.get("STOCK_TICKER", "AAPL").upper()
 FUND_SEARCH = os.environ.get("FUND_SEARCH", "AGTHX").upper()
 STYLE_SLUG = os.environ.get("STYLE_SLUG", "large-growth")
+UNIVERSE_NAME = os.environ.get("UNIVERSE_NAME", "uni_mc_3000")
 BASE = os.environ.get("RISKMODELS_BASE_URL", "https://riskmodels.app/api").rstrip("/")
 SITE = os.environ.get("RISKMODELS_SITE_ORIGIN", "https://riskmodels.app").rstrip("/")
 _JSON_BODY_MAX = int(os.environ.get("SMOKE_JSON_BODY_MAX", "32000"))
@@ -147,6 +148,8 @@ def expand_path(path: str, *, stock: str, bw_fund_id: str, slug: str) -> str:
     out = out.replace("{bw_fund_id}", quote(bw_fund_id, safe=""))
     out = out.replace("{slug}", quote(slug, safe=""))
     out = out.replace("{cohort_type}", "fund")
+    out = out.replace("{name}", quote(UNIVERSE_NAME, safe=""))  # /universe/{name}/members
+    out = out.replace("{n}", "5")  # /residual-signal/decile/{n} — valid decile 1..10
     return out
 
 


### PR DESCRIPTION
Builds the two missing endpoint audits and a single runner that also drives the existing smoke. Closes the gaps identified in the audit-tooling review.

## New audits
- **`scripts/audit/openapi_route_drift.py`** (static) — every OpenAPI path vs every `app/**/route.ts` handler. Params normalized to `{}`, leading `/api` stripped, `next.config` rewrites/redirects honored. Fails `--strict` on documented-but-unimplemented paths, lists undocumented handlers, emits a cross-reference matrix. Tracked exceptions live in `drift_allowlist.json` (`known_issues`) so the gate still catches **new** drift.
- **`scripts/audit/live_schema_check.py`** — validates the live JSON 2xx bodies the smoke captured against their OpenAPI response schemas (`$ref`s inlined with a cycle guard, OpenAPI-3.0 `nullable` honored, permissive on extra fields). Prints a `validated / skipped` coverage headline so a green run can't hide "checked nothing"; `--self-test` proves it flags a broken body. Reporting by default; `--strict` to enforce.

## Orchestrator
`./api_audits.sh` runs: `openapi-yaml` → `cli-openapi-check` → `route-drift --strict` → `schema-selftest` → `smoke` → `schema-check`, writes `audit-reports/<ts>/`, prints a PASS/FAIL summary. `AUDIT_SKIP_LIVE=1` for static/CI; `SKIP_EXPENSIVE=1` default so the smoke doesn't bill for snapshots/PDFs/batch.

## First-run findings (already real)
- 🔴 **`/auth/token` 404 in prod** — documented OAuth2 token endpoint, SDK posts there (`sdk/riskmodels/auth.py:66`), no handler. Tracked in `drift_allowlist.json` + backlog.
- 🔴 **`/user/billing-config` → 500** (smoke).
- 🟡 schema drift: `/metrics/{ticker}` omits required `display`; `/funds/snapshot/{bw_fund_id}` `hedge` shape mismatch.

Also: smoke `expand_path` now substitutes `{name}`/`{n}` so those endpoints stop failing on the literal `%7Bname%7D` placeholder. Remaining smoke harness gaps (13F filer-id resolution, ETF-ticker endpoints, required-body endpoints) are noted for follow-up — deliberately not expanded here.

Deferred (stated cut): param-mutation / edge-case fuzzing (audit gap #5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)