### PR TITLE
feat(audit): migration-drift check + weekly audit deployment with email

### DIFF
--- a/.github/workflows/weekly-audit.yml
+++ b/.github/workflows/weekly-audit.yml
@@ -1,0 +1,101 @@
+# Weekly API audit → email digest to the audit recipient.
+#
+# Runs the full audit suite (api_audits.sh): OpenAPI/spec ↔ handlers, docs ↔ spec,
+# live response-schema validation, migration drift, and the live endpoint smoke.
+# Emails the PASS/FAIL + findings to conrad@bwmacro.com every Saturday morning.
+#
+# Required GitHub repo secrets (Settings → Secrets and variables → Actions):
+#   TEST_API_SECRET            live RiskModels API key (for the endpoint smoke; reused from smoke-test.yml)
+#   SUPABASE_URL               prod Supabase URL (for migration-drift schema read)
+#   SUPABASE_SERVICE_ROLE_KEY  prod Supabase service-role key (read-only use here)
+#   RESEND_API_KEY             Resend key (sends the email)
+#   BWMACRO_REPO_TOKEN         PAT with read access to BlueWaterCorp/BWMACRO (for supabase/migrations)
+# Optional:
+#   RESEND_FROM_EMAIL          verified sender (defaults to "RiskModels <service@riskmodels.app>")
+#   vars.AUDIT_EMAIL_TO        recipient override (defaults to conrad@bwmacro.com)
+#
+# If BWMACRO_REPO_TOKEN / Supabase secrets are absent, migration-drift SKIPs (the
+# email shows it as SKIPPED — never a false green). Email always sends, including
+# on failure; the job is marked failed afterward so the Actions run still goes red.
+
+name: Weekly API Audit
+
+on:
+  schedule:
+    - cron: '0 13 * * 6'   # Saturday 13:00 UTC (~9am ET, drifts with DST)
+  workflow_dispatch:        # manual run for testing
+
+concurrency:
+  group: weekly-audit
+  cancel-in-progress: false
+
+jobs:
+  audit:
+    name: API audit + email
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      RISKMODELS_API_KEY: ${{ secrets.TEST_API_SECRET }}
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+      RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+      RESEND_FROM_EMAIL: ${{ secrets.RESEND_FROM_EMAIL }}
+      AUDIT_EMAIL_TO: ${{ vars.AUDIT_EMAIL_TO || 'conrad@bwmacro.com' }}
+      AUDIT_MIGRATIONS_DIR: BWMACRO/supabase/migrations
+      SKIP_EXPENSIVE: '1'     # don't bill snapshots/PDFs/batch in the weekly run
+      SMOKE_WRITE_PDF: '0'
+
+    steps:
+      - uses: actions/checkout@v6
+
+      # Migrations live in BWMACRO; check them out for migration-drift. Non-fatal:
+      # if the token is missing, migration-drift skips and the email says so.
+      - name: Check out BWMACRO migrations
+        uses: actions/checkout@v6
+        continue-on-error: true
+        with:
+          repository: BlueWaterCorp/BWMACRO
+          token: ${{ secrets.BWMACRO_REPO_TOKEN }}
+          path: BWMACRO
+          sparse-checkout: supabase/migrations
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install audit deps
+        run: pip install --quiet httpx jsonschema pyyaml
+
+      - name: Run audit suite
+        run: |
+          chmod +x api_audits.sh
+          set +e
+          ./api_audits.sh
+          echo "AUDIT_EXIT=$?" >> "$GITHUB_ENV"
+          echo "REPORT_DIR=$(ls -dt audit-reports/* | head -1)" >> "$GITHUB_ENV"
+
+      - name: Upload reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: audit-reports
+          path: audit-reports/
+          if-no-files-found: warn
+
+      - name: Email audit digest
+        if: always()
+        run: |
+          if [ -z "${REPORT_DIR:-}" ] || [ ! -d "$REPORT_DIR" ]; then
+            echo "No report dir — audit crashed before writing output; skipping email."
+            exit 0
+          fi
+          python3 scripts/audit/send_audit_email.py --report-dir "$REPORT_DIR"
+
+      - name: Reflect audit status in the run
+        if: always()
+        run: '[ "${AUDIT_EXIT:-1}" = "0" ] || { echo "Audit reported failures (see email/artifact)"; exit 1; }'

--- a/api_audits.sh
+++ b/api_audits.sh
@@ -60,6 +60,10 @@ step "route-drift" "$PY" scripts/audit/openapi_route_drift.py --strict --out-dir
 
 step "docs-conformity" "$PY" scripts/audit/docs_conformity.py --strict --out-dir "$OUT"
 
+# Migration drift skips internally (exit 0) if BWMACRO migrations or Supabase
+# creds aren't present — the email step reports it as SKIPPED, never false-green.
+step "migration-drift" "$PY" scripts/audit/migration_drift.py --out-dir "$OUT"
+
 step "schema-selftest" "$PY" scripts/audit/live_schema_check.py --self-test
 
 # ---- live audits (need an API key; cost money) ---------------------------
@@ -92,6 +96,7 @@ fi
 # ---- summary ------------------------------------------------------------
 echo; echo "════════ API AUDIT SUMMARY ($TS) ════════"
 fail=0
+steps_json=""
 for i in "${!NAMES[@]}"; do
   c="${CODES[$i]}"
   case "$c" in
@@ -100,7 +105,14 @@ for i in "${!NAMES[@]}"; do
     *)        s="FAIL"; fail=1 ;;
   esac
   printf "  %-18s %s\n" "${NAMES[$i]}" "$s"
+  steps_json="${steps_json}{\"name\":\"${NAMES[$i]}\",\"status\":\"$s\"},"
 done
+overall=$([ "$fail" = "0" ] && echo PASS || echo FAIL)
 echo "Reports: $OUT/"
-[ "$fail" = "0" ] && echo "Overall: PASS" || echo "Overall: FAIL"
+echo "Overall: $overall"
+
+# Machine-readable summary for the email/notification step.
+printf '{"timestamp":"%s","overall":"%s","reports_dir":"%s","steps":[%s]}\n' \
+  "$TS" "$overall" "$OUT" "${steps_json%,}" > "$OUT/summary.json"
+
 exit "$fail"

--- a/scripts/audit/README.md
+++ b/scripts/audit/README.md
@@ -17,9 +17,31 @@ Reports are written to `audit-reports/<timestamp>/` (gitignored).
 | `cli-openapi` | `scripts/cli-openapi-check.mjs` (CLI routes ⊆ spec) | no | yes |
 | `route-drift` | `scripts/audit/openapi_route_drift.py --strict` | no | yes (untracked) |
 | `docs-conformity` | `scripts/audit/docs_conformity.py --strict` | no | yes (untracked) |
+| `migration-drift` | `scripts/audit/migration_drift.py` | prod schema read | no (reports; SKIPs without creds) |
 | `schema-selftest` | `scripts/audit/live_schema_check.py --self-test` | no | yes |
 | `smoke-endpoints` | `sdk/scripts/smoke_v3_all_endpoints.py` | **yes** | yes (critical only) |
 | `schema-check` | `scripts/audit/live_schema_check.py` (consumes smoke report) | no | no (reports) |
+
+The orchestrator writes `audit-reports/<ts>/summary.json` (per-check PASS/FAIL/SKIP)
+for the email step.
+
+## Migration drift
+
+**`migration_drift.py`** — parses `BWMACRO/supabase/migrations` (`CREATE TABLE` /
+`ALTER … ADD COLUMN`) and diffs against the live prod schema (PostgREST OpenAPI).
+Catches the recurring "column declared in a migration but never applied to prod"
+failure (C.7 `tier`, C.9 `stripe_payment_method_id`). Reads `$AUDIT_MIGRATIONS_DIR`
+(default `../BWMACRO/supabase/migrations`) + `SUPABASE_URL` / `SUPABASE_SERVICE_ROLE_KEY`;
+SKIPs (exit 0, written to the report) if either is missing.
+
+## Weekly deployment + email
+
+`.github/workflows/weekly-audit.yml` runs the suite every **Saturday 13:00 UTC**
+(+ `workflow_dispatch` for manual runs) and emails the digest to
+**conrad@bwmacro.com** via Resend (`scripts/audit/send_audit_email.py`). The email
+reports each check as PASS / FAIL / **SKIPPED** so a green digest can't hide a
+check that didn't run. Email sends on failure too (`if: always()`); the run is
+marked red afterward. Required secrets are documented at the top of the workflow.
 
 ## The two new audits
 

--- a/scripts/audit/docs_conformity_allowlist.json
+++ b/scripts/audit/docs_conformity_allowlist.json
@@ -3,10 +3,12 @@
     "/api/rankings"
   ],
   "known_issues": [
-    "/api/plaid/webhook"
+    "/api/plaid/webhook",
+    "/api/hedge-basket/{ticker}"
   ],
   "_notes": {
     "/api/rankings": "Prose shorthand in rankings-screen.mdx ('replaces N per-ticker /rankings round-trips') referring to /rankings/{ticker} generically — not a literal endpoint claim.",
-    "/api/plaid/webhook": "DEFECT (tracked, backlog C): plaid-holdings.mdx:94 documents POST /api/plaid/webhook but there is no app/api/plaid/webhook/route.ts and it is not in the OpenAPI spec. Either implement the receiver, add it to the spec, or correct the doc if Plaid webhooks are handled outside app/api (e.g. a Supabase edge function)."
+    "/api/plaid/webhook": "DEFECT (tracked, backlog C): plaid-holdings.mdx:94 documents POST /api/plaid/webhook but there is no app/api/plaid/webhook/route.ts and it is not in the OpenAPI spec. Either implement the receiver, add it to the spec, or correct the doc if Plaid webhooks are handled outside app/api (e.g. a Supabase edge function).",
+    "/api/hedge-basket/{ticker}": "DOC/SPEC GAP (tracked, backlog C.11): agent-integration.mdx documents /api/hedge-basket/{ticker} and a handler exists (app/api/hedge-basket/[ticker]/route.ts), but it is not in the OpenAPI spec (committed openapi.json). Add it to the spec so docs, handler, and spec agree."
   }
 }

--- a/scripts/audit/migration_drift.py
+++ b/scripts/audit/migration_drift.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Static-ish audit: Supabase migrations vs the live prod schema.
+
+Same method as BWMACRO/supabase/MIGRATION_DRIFT_AUDIT.md: parse the migration
+SQL (CREATE TABLE / ALTER … ADD COLUMN) and diff against the live schema exposed
+by PostgREST's OpenAPI document. Catches the recurring "column declared in a
+migration but never applied to prod" failure mode (C.7 `tier`, C.9
+`stripe_payment_method_id`) before it breaks a feature for a customer.
+
+Reads migrations from $AUDIT_MIGRATIONS_DIR, else ../BWMACRO/supabase/migrations.
+Reads prod via SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY (or SUPABASE_SERVICE_KEY).
+If either the migrations dir or the creds are missing it SKIPS (exit 0) with a
+clear note — a weekly run must show "skipped", never a false green.
+
+Caveats (carried from the audit doc — treat findings as leads, not verdicts):
+  * Only public / API-exposed objects are visible via PostgREST. Functions,
+    triggers, RLS policies, indexes, enums, and RLS-hidden tables are NOT checked.
+  * A rename looks like drop+create here; a "missing" object may have been
+    dropped by a later migration this parser didn't resolve.
+
+Usage:
+  python scripts/audit/migration_drift.py [--out-dir DIR] [--strict]
+
+Exit: 0 = no drift / skipped; 1 = --strict and drift found; 2 = error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+import httpx
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_MIGRATIONS = REPO_ROOT.parent / "BWMACRO" / "supabase" / "migrations"
+
+# SQL keywords the table-name regex can false-positive on (per the audit doc).
+_TABLE_NOISE = {"as", "if", "only", "exists"}
+
+_CREATE_TABLE = re.compile(
+    r"CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?[\"']?([A-Za-z0-9_.]+)[\"']?",
+    re.IGNORECASE,
+)
+_ALTER_TABLE = re.compile(
+    r"ALTER\s+TABLE\s+(?:IF\s+EXISTS\s+)?(?:ONLY\s+)?[\"']?([A-Za-z0-9_.]+)[\"']?(.*?);",
+    re.IGNORECASE | re.DOTALL,
+)
+_ADD_COLUMN = re.compile(
+    r"ADD\s+COLUMN\s+(?:IF\s+NOT\s+EXISTS\s+)?[\"']?([A-Za-z0-9_]+)[\"']?",
+    re.IGNORECASE,
+)
+
+
+def _bare(table: str) -> str:
+    return table.split(".")[-1].strip().lower()
+
+
+def parse_migrations(mig_dir: Path) -> tuple[set[str], dict[str, set[str]]]:
+    """(declared tables, {table: {columns declared via ALTER ADD COLUMN}})."""
+    tables: set[str] = set()
+    alter_cols: dict[str, set[str]] = {}
+    for sql_file in sorted(mig_dir.glob("*.sql")):
+        text = sql_file.read_text(errors="ignore")
+        for m in _CREATE_TABLE.finditer(text):
+            t = _bare(m.group(1))
+            if t and t not in _TABLE_NOISE:
+                tables.add(t)
+        for m in _ALTER_TABLE.finditer(text):
+            t = _bare(m.group(1))
+            if not t or t in _TABLE_NOISE:
+                continue
+            cols = {c.lower() for c in _ADD_COLUMN.findall(m.group(2))}
+            if cols:
+                alter_cols.setdefault(t, set()).update(cols)
+    return tables, alter_cols
+
+
+def fetch_prod_schema() -> dict[str, set[str]] | None:
+    """{table: {columns}} from the PostgREST OpenAPI doc, or None if no creds."""
+    url = os.environ.get("SUPABASE_URL") or os.environ.get("NEXT_PUBLIC_SUPABASE_URL")
+    key = (
+        os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
+        or os.environ.get("SUPABASE_SERVICE_KEY")
+        or os.environ.get("NEXT_PUBLIC_SUPABASE_ANON_KEY")
+    )
+    if not url or not key:
+        return None
+    r = httpx.get(
+        f"{url.rstrip('/')}/rest/v1/",
+        headers={"apikey": key, "Authorization": f"Bearer {key}"},
+        timeout=40,
+    )
+    r.raise_for_status()
+    spec = r.json()
+    defs = spec.get("definitions") or spec.get("components", {}).get("schemas", {})
+    return {t.lower(): set((d.get("properties") or {}).keys()) for t, d in defs.items()}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--out-dir", type=Path, default=None)
+    ap.add_argument("--strict", action="store_true")
+    args = ap.parse_args()
+
+    def _skip(reason: str) -> int:
+        print(f"SKIP migration-drift: {reason}")
+        if args.out_dir:
+            args.out_dir.mkdir(parents=True, exist_ok=True)
+            (args.out_dir / "migration_drift.json").write_text(
+                json.dumps({"summary": {"skipped": True, "reason": reason}}, indent=2)
+            )
+        return 0
+
+    mig_dir = Path(os.environ.get("AUDIT_MIGRATIONS_DIR") or DEFAULT_MIGRATIONS)
+    if not mig_dir.is_dir():
+        return _skip(f"migrations dir not found ({mig_dir}); set AUDIT_MIGRATIONS_DIR or check out BWMACRO")
+
+    try:
+        prod = fetch_prod_schema()
+    except Exception as e:  # noqa: BLE001
+        print(f"migration-drift error fetching prod schema: {e}", file=sys.stderr)
+        return 2
+    if prod is None:
+        return _skip("no SUPABASE_URL / service key in env")
+
+    tables, alter_cols = parse_migrations(mig_dir)
+
+    missing_tables = sorted(t for t in tables if t not in prod)
+    missing_columns = []  # [{table, column}]
+    for table, cols in sorted(alter_cols.items()):
+        if table not in prod:
+            continue  # table itself missing — reported above; column check moot
+        for col in sorted(cols):
+            if col not in prod[table]:
+                missing_columns.append({"table": table, "column": col})
+
+    report = {
+        "summary": {
+            "migrations_dir": str(mig_dir),
+            "declared_tables": len(tables),
+            "prod_tables": len(prod),
+            "missing_tables": len(missing_tables),
+            "missing_columns": len(missing_columns),
+        },
+        "missing_columns": missing_columns,
+        "missing_tables": missing_tables,
+        "caveats": [
+            "Only public/API-exposed objects visible via PostgREST.",
+            "Renames look like drop+create; treat findings as leads, not verdicts.",
+        ],
+    }
+
+    print(f"Migrations: {len(tables)} tables declared  |  prod exposes {len(prod)} tables")
+    print(f"Columns declared via ADD COLUMN but ABSENT from prod: {len(missing_columns)}")
+    for x in missing_columns:
+        print(f"  ✗ {x['table']}.{x['column']}")
+    print(f"Tables declared but ABSENT from prod (verify — may be renamed/dropped): {len(missing_tables)}")
+    for t in missing_tables:
+        print(f"  · {t}")
+
+    if args.out_dir:
+        args.out_dir.mkdir(parents=True, exist_ok=True)
+        (args.out_dir / "migration_drift.json").write_text(json.dumps(report, indent=2))
+        print(f"\nWrote {args.out_dir / 'migration_drift.json'}")
+
+    # Only ABSENT columns are high-confidence drift; missing tables are leads.
+    if args.strict and missing_columns:
+        print(f"\nFAIL: {len(missing_columns)} migration column(s) not applied to prod.", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/audit/send_audit_email.py
+++ b/scripts/audit/send_audit_email.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Email the API-audit result (summary + findings) via Resend.
+
+Reads a report dir produced by api_audits.sh (summary.json + per-check JSON) and
+sends a digest to the audit recipient. Reports each check as PASS / FAIL /
+SKIPPED so a green email can't hide a check that silently didn't run (e.g.
+migration-drift with no creds).
+
+Env:
+  RESEND_API_KEY     required to actually send
+  RESEND_FROM_EMAIL  verified sender (e.g. "RiskModels <service@riskmodels.app>")
+  AUDIT_EMAIL_TO     recipient (default conrad@bwmacro.com)
+
+Usage:
+  python scripts/audit/send_audit_email.py --report-dir audit-reports/<ts> [--dry-run]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+import httpx
+
+DEFAULT_TO = "conrad@bwmacro.com"
+
+
+def _load(p: Path):
+    try:
+        return json.loads(p.read_text())
+    except Exception:
+        return None
+
+
+def build_body(report_dir: Path) -> tuple[str, str, str]:
+    """(subject, text, html)."""
+    summary = _load(report_dir / "summary.json") or {"overall": "UNKNOWN", "steps": [], "timestamp": "?"}
+    drift = _load(report_dir / "migration_drift.json")
+    routes = _load(report_dir / "route_drift.json")
+    docs = _load(report_dir / "docs_conformity.json")
+    schema = _load(report_dir / "schema_check.json")
+
+    overall = summary.get("overall", "UNKNOWN")
+    ts = summary.get("timestamp", "?")
+
+    # Per-check status; override migration-drift to SKIPPED if it self-skipped.
+    rows = []
+    for step in summary.get("steps", []):
+        name, status = step.get("name", "?"), step.get("status", "?")
+        if name == "migration-drift" and drift and drift.get("summary", {}).get("skipped"):
+            status = "SKIP"
+        rows.append((name, status))
+
+    # Findings highlights (defensive — any file may be absent).
+    findings: list[str] = []
+    if routes:
+        s = routes.get("summary", {})
+        findings.append(f"route-drift: {s.get('missing_handlers', 0)} undocumented-untracked, "
+                        f"{s.get('known_issues', 0)} known issue(s), {s.get('undocumented_handlers', 0)} undocumented handlers")
+    if docs:
+        s = docs.get("summary", {})
+        findings.append(f"docs-conformity: {s.get('phantom_paths', 0)} phantom, "
+                        f"{s.get('cost_mismatches', 0)} cost mismatch(es), {s.get('known_issues', 0)} known issue(s)")
+    if schema:
+        s = schema.get("summary", {})
+        findings.append(f"schema-check: {s.get('endpoints_with_violations', 0)} endpoint(s) violating schema "
+                        f"(validated {s.get('validated', 0)}/{s.get('json_2xx_responses', 0)})")
+    if drift and not drift.get("summary", {}).get("skipped"):
+        s = drift.get("summary", {})
+        cols = drift.get("missing_columns", [])
+        findings.append(f"migration-drift: {s.get('missing_columns', 0)} unapplied column(s)"
+                        + (": " + ", ".join(f"{c['table']}.{c['column']}" for c in cols[:10]) if cols else "")
+                        + f"; {s.get('missing_tables', 0)} table lead(s)")
+    elif drift:
+        findings.append(f"migration-drift: SKIPPED ({drift.get('summary', {}).get('reason', 'no creds')})")
+
+    subject = f"[RiskModels API audit] {overall} — {ts}"
+
+    status_lines = "\n".join(f"  {n:<18} {s}" for n, s in rows)
+    finding_lines = "\n".join(f"  - {f}" for f in findings) or "  (no finding files)"
+    text = (
+        f"RiskModels API audit — {overall}  ({ts})\n\n"
+        f"Checks:\n{status_lines}\n\n"
+        f"Findings:\n{finding_lines}\n\n"
+        f"Full reports: {summary.get('reports_dir', report_dir)} (CI artifact)\n"
+    )
+
+    def badge(s: str) -> str:
+        color = {"PASS": "#16a34a", "FAIL": "#dc2626", "SKIP": "#d97706"}.get(s, "#71717a")
+        return f'<span style="color:{color};font-weight:600">{s}</span>'
+
+    overall_color = "#16a34a" if overall == "PASS" else "#dc2626"
+    rows_html = "".join(
+        f'<tr><td style="padding:2px 12px 2px 0;font-family:monospace">{n}</td>'
+        f'<td style="padding:2px 0">{badge(s)}</td></tr>'
+        for n, s in rows
+    )
+    findings_html = "".join(f"<li style='margin:2px 0'>{f}</li>" for f in findings) or "<li>(no finding files)</li>"
+    html = (
+        f'<div style="font-family:system-ui,sans-serif;max-width:640px">'
+        f'<h2 style="margin:0 0 4px">RiskModels API audit — '
+        f'<span style="color:{overall_color}">{overall}</span></h2>'
+        f'<p style="color:#71717a;margin:0 0 16px">{ts}</p>'
+        f'<table style="border-collapse:collapse;margin-bottom:16px">{rows_html}</table>'
+        f'<h3 style="margin:0 0 4px">Findings</h3><ul style="margin:0;padding-left:18px">{findings_html}</ul>'
+        f'<p style="color:#71717a;font-size:12px;margin-top:16px">Full reports in the workflow run artifact.</p>'
+        f"</div>"
+    )
+    return subject, text, html
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--report-dir", type=Path, required=True)
+    ap.add_argument("--to", default=os.environ.get("AUDIT_EMAIL_TO", DEFAULT_TO))
+    ap.add_argument("--dry-run", action="store_true", help="print the email, don't send")
+    args = ap.parse_args()
+
+    if not args.report_dir.is_dir():
+        print(f"report dir not found: {args.report_dir}", file=sys.stderr)
+        return 2
+
+    subject, text, html = build_body(args.report_dir)
+
+    if args.dry_run:
+        print(f"To: {args.to}\nSubject: {subject}\n\n{text}")
+        return 0
+
+    api_key = os.environ.get("RESEND_API_KEY")
+    # Same verified-sender fallback the admin app uses when RESEND_FROM_EMAIL is unset.
+    sender = os.environ.get("RESEND_FROM_EMAIL", "").strip() or "RiskModels <service@riskmodels.app>"
+    if not api_key:
+        print("ERROR: RESEND_API_KEY required to send (use --dry-run to preview).", file=sys.stderr)
+        return 2
+
+    r = httpx.post(
+        "https://api.resend.com/emails",
+        headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
+        json={"from": sender, "to": [args.to], "subject": subject, "text": text, "html": html},
+        timeout=30,
+    )
+    if r.status_code >= 300:
+        print(f"Resend error {r.status_code}: {r.text[:300]}", file=sys.stderr)
+        return 1
+    print(f"Sent audit email to {args.to} (id={r.json().get('id', '?')})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Adds the migration-drift check (the third drift class — C.7/C.9 schema drift) and a scheduled "audit deployment" that emails the result weekly.

## migration-drift (`scripts/audit/migration_drift.py`)
Parses `BWMACRO/supabase/migrations` (`CREATE TABLE` / `ALTER … ADD COLUMN`) and diffs against the live prod schema (PostgREST OpenAPI). Catches "column declared in a migration but never applied to prod" — the exact failure behind C.7 (`tier`) and C.9 (`stripe_payment_method_id`). Reads `$AUDIT_MIGRATIONS_DIR` + `SUPABASE_URL`/`SERVICE_ROLE`; **SKIPs** (written to the report) if either is missing. Wired into `api_audits.sh`, which now also writes `summary.json`.

**Verified locally:** confirms the 5 C.9 columns are now applied (0 column drift); 10 "table leads" reported as non-failing (renames / non-public schema, per the audit-doc caveats).

## Weekly deployment + email (`.github/workflows/weekly-audit.yml`)
Runs the full suite every **Saturday 13:00 UTC** (+ `workflow_dispatch`) and emails the digest to **conrad@bwmacro.com** via Resend (`scripts/audit/send_audit_email.py`).
- Email reports each check **PASS / FAIL / SKIPPED** (a green digest can't hide a check that didn't run).
- Sends on failure too (`if: always()`), then marks the run red.
- Uploads `audit-reports/` as an artifact.

**Verified locally:** a real test email was delivered to conrad@bwmacro.com (Resend id returned).

## Setup required before it runs (GitHub repo secrets)
`TEST_API_SECRET` (exists), `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, `RESEND_API_KEY`, `BWMACRO_REPO_TOKEN` (PAT to read BWMACRO migrations). Optional: `RESEND_FROM_EMAIL`, `vars.AUDIT_EMAIL_TO`. Documented in the workflow header. Without the BWMACRO token / Supabase secrets, migration-drift simply shows SKIPPED.

Also tracks `/api/hedge-basket/{ticker}` in `docs_conformity_allowlist.json` (documented + has a handler, but missing from the committed OpenAPI spec).

🤖 Generated with [Claude Code](https://claude.com/claude-code)