### PR TITLE
feat(agents): agent-native surface — manifest, /status, /feedback, response meta

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -46,6 +46,7 @@ paths = [
   '''app/api-reference/''',
   '''app/docs/''',
   '''app/get-key/''',
+  '''app/for-agents/''',
   '''OPENAPI_SPEC\.yaml$''',
   '''\.md$''',
   '''\.mdx$''',

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,29 @@
 All notable changes to the RiskModels API surface and public assets.
 
 
+## [0.4.0] — 2026-06-05
+
+### Added
+
+- **`GET /api/status`** — Public, aggregate, privacy-safe service reliability: measured latency percentiles (p50/p95/p99) and a 5xx-only success rate over a window (`?window_hours`, default 24, max 720), plus a per-capability breakdown. Aggregated from `billing_events` request telemetry (the same source `/api/health` uses); metered 4xx (auth/payment/rate-limit) are excluded from both latency and success_rate so a flood of fast 401s can't make the service look faster or less reliable than it is. No revenue or user fields exposed. Capability `status-metrics` (free). Distinct from `/api/metrics/{ticker}` (risk metrics) and `/api/health` (current up/degraded/down state).
+- **`POST /api/feedback`** — Trust-loop endpoint: an agent or human flags a result by its `_agent.request_id` with `rating` (up/down), `category`, and/or a ≤4000-char `comment`. Authenticated, free (no metering). Writes to `public.feedback_events` (service-role). Returns `503` until the BWMACRO migration is applied; `201` once live. Capability `feedback` (free).
+- **`/for-agents` page** — Human approval surface for risk/compliance teams evaluating the API for their agent fleets: discovery artifacts, onboarding/auth flow, pricing at a glance, and trust/compliance signals. Linked from the docs sidebar (Agents group).
+- **Response `_agent.latency_ms` + `_agent.provenance`** — The billing middleware now injects the measured total latency (previously header-only) and a methodology/provenance URL into every JSON success body (non-JSON, errors, and arrays untouched). Many agent HTTP clients drop headers; the body is the durable carrier.
+- **Enriched `/.well-known/agent-manifest.json`** — Added `reproducibility` (point-in-time from 2006, deterministic, live model_version/data_as_of/universe_size, methodology + validation-manifest URLs), `pricing` summary, `discovery` cross-links, `reliability` (→ `/api/status`), `onboarding`, and `feedback` blocks. Version stamped `3.0.0-agent`. `agentic-disclosure.json` gained `reproducibility` + `audit` blocks.
+- **Agent integration docs — "Compose & chain"** — Worked decompose → hedge → portfolio-snapshot → execution flow, with the schema/citeability/idempotency properties that make chaining safe.
+- **OpenAPI** — `/status` and `/feedback` added under the Utility tag (`x-pricing` cost 0); `public/openapi.json` + `mcp/data/openapi.json` regenerated.
+
+### Fixed
+
+- **Methodology/provenance URL** — `_metadata.wiki_uri` (and the new `_agent.provenance`) pointed at `riskmodels.net/docs/methodology` (404); corrected to `riskmodels.app/docs/methodology` (200). Single source of truth: `METHODOLOGY_URL` in `lib/constants.ts`.
+- **Landing latency badge** — Softened the unbacked "Sub-120 ms" hero claim to "Low-latency" (no asserted SLA without a measured production p95).
+
+### Cross-repo
+
+- **BWMACRO** — `supabase/migrations/20260605120000_feedback_events.sql` (mirrored to `Risk_Models/riskmodels_com/supabase/migrations/`). Must be applied to the Supabase project before `POST /api/feedback` returns 201.
+- **RM_ORG (riskmodels.org)** — `GET /.well-known/methodology.json` machine-readable methodology + validation manifest (verbatim published claims only); the API manifest's `reproducibility.validation_manifest_url` points at it.
+
+
 ## [0.3.9] — 2026-05-27
 
 ### Added

--- a/OPENAPI_SPEC.yaml
+++ b/OPENAPI_SPEC.yaml
@@ -6573,6 +6573,131 @@ paths:
                         type: boolean
                         description: True when newest_teo is older than roughly three trading days.
 
+  /status:
+    get:
+      summary: Aggregate service reliability metrics
+      description: >
+        Measured latency percentiles (p50/p95/p99) and a 5xx-only success rate over a window,
+        aggregated across all capabilities from request telemetry, plus a per-capability breakdown.
+        Numbers are observed from real traffic, not asserted SLAs. Metered 4xx
+        (auth/payment/rate-limit) are excluded from both latency and success_rate. Free, no auth required.
+      operationId: getStatus
+      tags: [Utility]
+      parameters:
+        - name: window_hours
+          in: query
+          required: false
+          description: Lookback window in hours (default 24, max 720).
+          schema:
+            type: integer
+            default: 24
+            minimum: 1
+            maximum: 720
+      x-pricing:
+        capability_id: status-metrics
+        tier: baseline
+        model: per_request
+        cost_usd: 0
+        currency: USD
+        billing_code: status_metrics
+      security: []
+      responses:
+        "200":
+          description: Reliability metrics for the window.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  window_hours:
+                    type: integer
+                  measured_through:
+                    type: string
+                    format: date-time
+                  sample_size:
+                    type: integer
+                    description: Service-relevant events in window (4xx excluded).
+                  latency_ms:
+                    type: object
+                    nullable: true
+                    description: Server-measured processing latency (excludes network); null if no traffic.
+                    properties:
+                      p50:
+                        type: number
+                      p95:
+                        type: number
+                      p99:
+                        type: number
+                      avg:
+                        type: number
+                  success_rate:
+                    type: number
+                    nullable: true
+                    description: Fraction of service-relevant events that did not 5xx; null if no traffic.
+                  by_capability:
+                    type: object
+                    additionalProperties: true
+                  note:
+                    type: string
+
+  /feedback:
+    post:
+      summary: Submit feedback on an API result
+      description: >
+        Flag a specific result by its _agent.request_id with a rating / category / correction note.
+        Trust-loop signal for offline data-quality and docs triage; no output changes at request time.
+        Authenticated, free (no metering). Provide at least one of rating, category, or comment.
+      operationId: postFeedback
+      tags: [Utility]
+      x-pricing:
+        capability_id: feedback
+        tier: baseline
+        model: per_request
+        cost_usd: 0
+        currency: USD
+        billing_code: feedback
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                request_id:
+                  type: string
+                  description: The _agent.request_id / X-Request-ID of the call being rated. Nullable for general feedback.
+                capability_id:
+                  type: string
+                rating:
+                  type: string
+                  enum: [up, down]
+                category:
+                  type: string
+                  enum: [data_quality, incorrect_result, latency, docs, feature_request, other]
+                comment:
+                  type: string
+                  maxLength: 4000
+      responses:
+        "201":
+          description: Feedback recorded.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  feedback_id:
+                    type: string
+                  message:
+                    type: string
+        "400":
+          description: Invalid or empty feedback (no rating/category/comment, bad enum, or comment too long).
+        "401":
+          description: Missing or invalid API key.
+        "503":
+          description: Feedback store temporarily unavailable (retry).
+
   /balance:
     get:
       summary: Account balance and rate limits

--- a/app/.well-known/agent-manifest.json/route.ts
+++ b/app/.well-known/agent-manifest.json/route.ts
@@ -2,16 +2,25 @@ import { NextResponse } from "next/server";
 import { readFileSync, existsSync } from "fs";
 import { join } from "path";
 import { getAppUrl } from "@/lib/app-url";
+import { getRiskMetadata } from "@/lib/dal/risk-metadata";
 
 export const dynamic = "force-dynamic";
 
 const DATA_DIR = join(process.cwd(), "mcp", "data");
 
+/** Earliest point-in-time coverage of the ERM3 history (see OPENAPI_SPEC.yaml info block). */
+const POINT_IN_TIME_FROM = "2006-01-04";
+
 /**
  * GET /.well-known/agent-manifest.json — agent discovery (MCP resource + installers).
+ *
+ * Single fetch an agent can read to decide whether and how to route to us:
+ * what we do, where the schemas/pricing/disclosure live, and the
+ * reproducibility guarantees that matter for quant/finance use.
  */
 export async function GET() {
   const base = getAppUrl().replace(/\/$/, "");
+
   let capabilities: unknown[] | undefined;
   const capPath = join(DATA_DIR, "capabilities.json");
   if (existsSync(capPath)) {
@@ -21,16 +30,90 @@ export async function GET() {
       capabilities = undefined;
     }
   }
+
+  // Live provenance — model version, data recency, universe size, methodology URL.
+  // Never let a metadata hiccup break the discovery artifact.
+  let modelVersion: string | undefined;
+  let dataAsOf: string | undefined;
+  let universeSize: number | undefined;
+  let methodologyUrl = `${base}/docs/methodology`;
+  try {
+    const meta = await getRiskMetadata();
+    modelVersion = meta.model_version;
+    dataAsOf = meta.data_as_of;
+    universeSize = meta.universe_size;
+    if (meta.wiki_uri) methodologyUrl = meta.wiki_uri;
+  } catch {
+    /* fall back to static links below */
+  }
+
   const payload = {
     service: {
       name: "RiskModels",
-      version: "2.0.0-agent",
+      version: "3.0.0-agent",
+      description:
+        "Factor risk decomposition (L1/L2/L3 explained risk), ETF hedge ratios, and portfolio risk snapshots for ~3,000 US equities.",
       base_url: base,
       openapi_url: `${base}/openapi.json`,
       mcp_sse_url: `${base}/api/mcp/sse`,
     },
+    // One-fetch cross-links to every other discovery / trust artifact.
+    discovery: {
+      openapi_url: `${base}/openapi.json`,
+      mcp_manifest_url: `${base}/.well-known/mcp.json`,
+      ai_plugin_url: `${base}/.well-known/ai-plugin.json`,
+      disclosure_url: `${base}/.well-known/agentic-disclosure.json`,
+      llms_txt_url: `${base}/llms.txt`,
+      for_agents_url: `${base}/for-agents`,
+      docs_url: `${base}/docs/agent-integration`,
+    },
+    // Why a quant/finance agent can trust and cite a call.
+    reproducibility: {
+      deterministic: true,
+      point_in_time_from: POINT_IN_TIME_FROM,
+      model_version: modelVersion ?? null,
+      data_as_of: dataAsOf ?? null,
+      universe_size: universeSize ?? null,
+      methodology_url: methodologyUrl,
+      // Structured, citeable validation claims (model identity, OOS validation, ±0.1% replication).
+      validation_manifest_url: "https://riskmodels.org/.well-known/methodology.json",
+      replay: "Send an Idempotency-Key header on POST requests for safe, no-double-charge retries.",
+      provenance_fields:
+        "Every response carries _metadata.model_version / data_as_of / factor_set_id and _agent.request_id for audit.",
+    },
+    // Metered, pay-per-call. Authoritative per-endpoint rates live in the OpenAPI x-pricing blocks.
+    pricing: {
+      model: "per_request",
+      currency: "USD",
+      metered_header: "X-API-Cost-USD",
+      cost_in_body: "_agent.cost_usd",
+      free_credits_usd: 20,
+      pricing_url: `${base}/pricing`,
+      per_endpoint_rates: `${base}/openapi.json (x-pricing extension per path)`,
+    },
+    // Real-time health is published; aggregate latency/uptime SLAs are intentionally not
+    // asserted here until measured (see GET /api/health).
+    reliability: {
+      health_url: `${base}/api/health`,
+      status_values: ["up", "degraded", "down"],
+      // Measured latency percentiles + success rate from real traffic (no asserted SLA).
+      metrics_url: `${base}/api/status`,
+    },
+    // How an agent self-provisions and authenticates.
+    onboarding: {
+      auth: "Bearer token (rm_agent_* / rm_user_*)",
+      provision_free_url: `${base}/api/auth/provision-free`,
+      create_key_url: `${base}/api/agent-keys`,
+    },
+    // Trust loop: flag a result by its _agent.request_id to improve future output.
+    feedback: {
+      submit_url: `${base}/api/feedback`,
+      method: "POST",
+      fields: "request_id?, capability_id?, rating (up|down)?, category?, comment?",
+    },
     capabilities: capabilities ?? [],
   };
+
   return NextResponse.json(payload, {
     headers: {
       "Content-Type": "application/json",

--- a/app/.well-known/agentic-disclosure.json/route.ts
+++ b/app/.well-known/agentic-disclosure.json/route.ts
@@ -31,6 +31,17 @@ export async function GET() {
         notes: "See site Terms and Privacy Policy for authoritative commitments.",
         frameworks_aspirational: ["GDPR-oriented practices", "SOC2 roadmap"],
       },
+      reproducibility: {
+        point_in_time_from: "2006-01-04",
+        deterministic: true,
+        notes:
+          "Decompositions are point-in-time and replayable; outputs carry model_version, data_as_of, and factor_set_id for citation in regulated workflows (13F, fund attribution).",
+      },
+      audit: {
+        request_correlation: "Every response carries _agent.request_id (also the X-Request-ID header).",
+        billing_trail: "Each metered call writes a billing event keyed by request_id.",
+        idempotency: "POST requests accept an Idempotency-Key header for safe, auditable retries.",
+      },
       security: {
         authentication: "API keys (rm_agent_* / rm_user_*) and OAuth for the portal",
         links: {

--- a/app/api/feedback/route.ts
+++ b/app/api/feedback/route.ts
@@ -1,0 +1,165 @@
+/**
+ * Feedback API
+ *
+ * Lets an agent (or human) flag a specific API result by its request_id with a
+ * rating / category / correction note. Trust-loop signal: offline triage drives
+ * data-quality and docs fixes. Authenticated and free (no metering); abuse is
+ * bounded by key auth and a 4000-char comment cap.
+ *
+ * POST /api/feedback
+ *   { request_id?, capability_id?, rating?: 'up'|'down', category?, comment? }
+ *
+ * Writes to public.feedback_events (service-role). See BWMACRO migration
+ * 20260605120000_feedback_events.sql.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { extractApiKey, validateApiKey } from "@/lib/agent/api-keys";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { generateRequestId } from "@/lib/agent/telemetry";
+import { METHODOLOGY_URL } from "@/lib/constants";
+
+export const dynamic = "force-dynamic";
+
+const MAX_COMMENT = 4000;
+const RATINGS = new Set(["up", "down"]);
+const CATEGORIES = new Set([
+  "data_quality",
+  "incorrect_result",
+  "latency",
+  "docs",
+  "feature_request",
+  "other",
+]);
+
+export async function POST(req: NextRequest) {
+  const startTime = Date.now();
+  const requestId = generateRequestId();
+  const agent = () => ({
+    request_id: requestId,
+    latency_ms: Date.now() - startTime,
+    provenance: METHODOLOGY_URL,
+  });
+
+  // 1. Authenticate (no metering — feedback is free).
+  const key = extractApiKey(req);
+  const validation = key ? await validateApiKey(key) : null;
+  if (!validation?.valid || !validation.userId) {
+    return NextResponse.json(
+      {
+        error: "Unauthorized",
+        message: "A valid API key is required to submit feedback.",
+        _agent: { ...agent(), action: "authenticate", authenticate_url: "/api/auth/provision-free" },
+      },
+      { status: 401 },
+    );
+  }
+
+  // 2. Parse + validate body.
+  let body: Record<string, unknown>;
+  try {
+    body = (await req.json()) as Record<string, unknown>;
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid JSON body", _agent: agent() },
+      { status: 400 },
+    );
+  }
+
+  const request_id =
+    typeof body.request_id === "string" ? body.request_id.slice(0, 128) : null;
+  const capability_id =
+    typeof body.capability_id === "string" ? body.capability_id.slice(0, 128) : null;
+  const rating = typeof body.rating === "string" ? body.rating : null;
+  const category = typeof body.category === "string" ? body.category : null;
+  const comment = typeof body.comment === "string" ? body.comment.trim() : null;
+
+  if (rating !== null && !RATINGS.has(rating)) {
+    return NextResponse.json(
+      { error: "Invalid rating", message: "rating must be 'up' or 'down'.", _agent: agent() },
+      { status: 400 },
+    );
+  }
+  if (category !== null && !CATEGORIES.has(category)) {
+    return NextResponse.json(
+      {
+        error: "Invalid category",
+        message: `category must be one of: ${[...CATEGORIES].join(", ")}.`,
+        _agent: agent(),
+      },
+      { status: 400 },
+    );
+  }
+  if (comment !== null && comment.length > MAX_COMMENT) {
+    return NextResponse.json(
+      { error: "Comment too long", message: `comment must be <= ${MAX_COMMENT} chars.`, _agent: agent() },
+      { status: 400 },
+    );
+  }
+  // Require at least one substantive signal.
+  if (!rating && !category && !comment) {
+    return NextResponse.json(
+      {
+        error: "Empty feedback",
+        message: "Provide at least one of: rating, category, comment.",
+        _agent: agent(),
+      },
+      { status: 400 },
+    );
+  }
+
+  // 3. Persist via service-role client.
+  try {
+    const admin = createAdminClient();
+    const { data, error } = await admin
+      .from("feedback_events")
+      .insert({
+        user_id: validation.userId,
+        request_id,
+        capability_id,
+        rating,
+        category,
+        comment: comment || null,
+        metadata: {
+          user_agent: req.headers.get("user-agent"),
+          ip_address: req.headers.get("x-forwarded-for") || "unknown",
+          referer: req.headers.get("referer"),
+        },
+      })
+      .select("id")
+      .single();
+
+    if (error) {
+      // Most likely cause before the migration is pushed: relation does not exist.
+      console.error("[Feedback] insert failed:", error.message);
+      return NextResponse.json(
+        {
+          error: "Feedback store unavailable",
+          message: "Could not record feedback right now. Please retry shortly.",
+          _agent: { ...agent(), action: "retry" },
+        },
+        { status: 503, headers: { "Cache-Control": "no-store" } },
+      );
+    }
+
+    return NextResponse.json(
+      {
+        ok: true,
+        feedback_id: data.id,
+        message: "Thanks — feedback recorded.",
+        _agent: agent(),
+      },
+      { status: 201, headers: { "Cache-Control": "no-store" } },
+    );
+  } catch (err) {
+    console.error("[Feedback] unexpected error:", err);
+    return NextResponse.json(
+      {
+        error: "Feedback store unavailable",
+        message: "Could not record feedback right now. Please retry shortly.",
+        _agent: { ...agent(), action: "retry" },
+      },
+      { status: 503, headers: { "Cache-Control": "no-store" } },
+    );
+  }
+}

--- a/app/api/status/route.ts
+++ b/app/api/status/route.ts
@@ -1,0 +1,54 @@
+/**
+ * Reliability Metrics Endpoint
+ *
+ * Public, aggregate, privacy-safe service reliability for agents that route on
+ * measured performance: latency percentiles (p50/p95/p99) and a 5xx-only
+ * success rate over a window, plus a per-capability breakdown.
+ *
+ * Distinct from /api/health (current up/degraded/down state) and from
+ * /api/metrics/{ticker} (risk metrics for a security). Numbers here are
+ * measured from real traffic — nothing is asserted that isn't observed.
+ *
+ * GET /api/status?window_hours=24
+ */
+
+import { NextResponse } from "next/server";
+import { getServiceReliability } from "@/lib/agent/telemetry";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(req: Request) {
+  const param = Number(new URL(req.url).searchParams.get("window_hours"));
+  // Clamp to a sane range; default 24h. Max 30 days.
+  const windowHours =
+    Number.isFinite(param) && param > 0 ? Math.min(param, 720) : 24;
+
+  try {
+    const reliability = await getServiceReliability(windowHours);
+    return NextResponse.json(reliability, {
+      headers: {
+        "Content-Type": "application/json",
+        "Cache-Control": "public, max-age=60, s-maxage=60",
+        "Access-Control-Allow-Origin": "*",
+      },
+    });
+  } catch (error) {
+    console.error("[Status] Failed to compute reliability metrics:", error);
+    return NextResponse.json(
+      { error: "Failed to compute reliability metrics" },
+      { status: 503, headers: { "Cache-Control": "no-store" } },
+    );
+  }
+}
+
+export async function OPTIONS() {
+  return new NextResponse(null, {
+    status: 204,
+    headers: {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "GET, OPTIONS",
+      "Access-Control-Allow-Headers": "Content-Type",
+      "Access-Control-Max-Age": "86400",
+    },
+  });
+}

--- a/app/for-agents/page.tsx
+++ b/app/for-agents/page.tsx
@@ -1,0 +1,216 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import {
+  Boxes,
+  FileJson,
+  GitBranch,
+  KeyRound,
+  Plug,
+  ScrollText,
+  ShieldCheck,
+  Zap,
+} from 'lucide-react';
+import CodeBlock from '@/components/CodeBlock';
+
+export const metadata: Metadata = {
+  title: 'For AI Agents — RiskModels',
+  description:
+    'Everything an agent (or the risk/compliance team approving it) needs to discover, trust, and call RiskModels: machine-readable manifests, pricing in-protocol, point-in-time reproducibility, and self-serve auth.',
+};
+
+type LinkCard = {
+  title: string;
+  href: string;
+  desc: string;
+  icon: React.ComponentType<{ size?: number; className?: string }>;
+};
+
+const DISCOVERY: LinkCard[] = [
+  {
+    title: 'Capability manifest',
+    href: '/.well-known/agent-manifest.json',
+    desc: 'One fetch: capabilities, pricing, reproducibility, and cross-links to every other artifact.',
+    icon: FileJson,
+  },
+  {
+    title: 'OpenAPI spec',
+    href: '/openapi.json',
+    desc: 'Full REST contract with per-endpoint x-pricing extensions.',
+    icon: ScrollText,
+  },
+  {
+    title: 'MCP server',
+    href: '/.well-known/mcp.json',
+    desc: 'Streamable-HTTP MCP endpoint with discovery + live-data tools.',
+    icon: Plug,
+  },
+  {
+    title: 'llms.txt',
+    href: '/llms.txt',
+    desc: 'Crawler-friendly summary, including a shared demo key when the host enables one.',
+    icon: Boxes,
+  },
+];
+
+const TRUST: { title: string; body: string; icon: React.ComponentType<{ size?: number; className?: string }> }[] = [
+  {
+    title: 'Point-in-time & reproducible',
+    body: 'Decompositions are deterministic and replayable back to 2006-01-04. Every response carries model_version, data_as_of, and factor_set_id so any number can be cited and re-derived.',
+    icon: GitBranch,
+  },
+  {
+    title: 'Auditable & disclosed',
+    body: 'request_id correlates response → billing event. Data handling, retention, and training policy are published machine-readably at /.well-known/agentic-disclosure.json.',
+    icon: ShieldCheck,
+  },
+  {
+    title: 'Cost in the protocol',
+    body: 'Every call returns _agent.cost_usd in the body and X-API-Cost-USD in headers. Pay-per-call, $20 free credits, no subscription. HTTP 402 when balance runs low — never a surprise.',
+    icon: Zap,
+  },
+];
+
+const PROVISION_CODE = `# 1. Self-provision free starter credits (no human in the loop)
+curl -X POST https://riskmodels.app/api/auth/provision-free
+
+# 2. Call any endpoint with the Bearer token you receive
+curl -X POST https://riskmodels.app/api/decompose \\
+  -H "Authorization: Bearer rm_agent_..." \\
+  -H "Content-Type: application/json" \\
+  -d '{"ticker":"NVDA"}'
+
+# 3. Retry safely — same Idempotency-Key never double-charges
+#    -H "Idempotency-Key: <uuid>"`;
+
+const TOOLDEF_CODE = `# Emit ready-to-paste tool definitions for your agent framework
+npm install -g riskmodels@latest
+riskmodels manifest --format anthropic   # or: openai | zed`;
+
+export default function ForAgentsPage() {
+  return (
+    <div className="mx-auto min-h-screen w-full max-w-[90rem] overflow-x-hidden bg-zinc-950">
+      {/* Hero */}
+      <section className="border-b border-zinc-800 px-4 pb-14 pt-16 sm:px-6 sm:pt-20 lg:px-8">
+        <div className="mx-auto max-w-3xl text-center">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-zinc-500">
+            For AI agents
+          </p>
+          <h1 className="mt-3 text-4xl font-bold tracking-tight text-white sm:text-5xl">
+            Specialized risk intelligence, one call away
+          </h1>
+          <p className="mt-4 text-base leading-relaxed text-zinc-400 sm:text-lg">
+            Precise L1/L2/L3 factor decomposition and ETF hedge ratios for ~3,000 US equities — JSON-native,
+            metered, and reproducible. An agent calls it in one shot instead of reasoning from training data.
+          </p>
+          <p className="mx-auto mt-5 max-w-2xl rounded-lg border border-emerald-500/25 bg-emerald-950/35 px-4 py-3 text-left text-sm leading-relaxed text-emerald-100/90">
+            <strong className="text-emerald-200">Approving us for your agent fleet?</strong> This page is the
+            one-pager for risk &amp; compliance teams — discovery artifacts, data policy, reproducibility
+            guarantees, and pricing are all linked below and published machine-readably.
+          </p>
+        </div>
+      </section>
+
+      {/* Why call vs. self-compute */}
+      <section className="border-b border-zinc-800 px-4 py-14 sm:px-6 lg:px-8">
+        <div className="mx-auto max-w-3xl">
+          <h2 className="text-2xl font-semibold text-white">Why call us instead of reasoning</h2>
+          <p className="mt-3 text-sm leading-relaxed text-zinc-400">
+            A general model approximating a factor decomposition from training data is slow, expensive, and
+            unauditable. A single RiskModels call returns the exact, current four-layer attribution and the ETF
+            hedge map — with a model version and data date you can cite. Live processing latency and service
+            health are published at{' '}
+            <Link className="font-mono text-emerald-300 underline underline-offset-2 hover:text-emerald-200" href="/api/health">
+              /api/health
+            </Link>
+            .
+          </p>
+        </div>
+      </section>
+
+      {/* Discovery */}
+      <section className="border-b border-zinc-800 px-4 py-14 sm:px-6 lg:px-8">
+        <div className="mx-auto max-w-5xl">
+          <h2 className="text-2xl font-semibold text-white">Discover us programmatically</h2>
+          <p className="mt-2 text-sm text-zinc-400">Four machine-readable entry points. Start with the manifest — it links to the rest.</p>
+          <div className="mt-8 grid gap-5 md:grid-cols-2">
+            {DISCOVERY.map(({ title, href, desc, icon: Icon }) => (
+              <Link
+                key={href}
+                href={href}
+                className="group flex flex-col rounded-2xl border border-white/10 bg-white/[0.03] p-6 transition hover:border-emerald-500/30 hover:bg-white/[0.05]"
+              >
+                <div className="mb-4 flex items-center gap-3">
+                  <span className="inline-flex rounded-xl border border-emerald-500/20 bg-emerald-500/10 p-2 text-emerald-400">
+                    <Icon size={18} />
+                  </span>
+                  <h3 className="text-lg font-semibold text-white">{title}</h3>
+                </div>
+                <p className="text-sm leading-relaxed text-zinc-400">{desc}</p>
+                <span className="mt-4 font-mono text-xs text-emerald-400/80 group-hover:text-emerald-300">{href} →</span>
+              </Link>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Onboard */}
+      <section className="border-b border-zinc-800 px-4 py-14 sm:px-6 lg:px-8">
+        <div className="mx-auto max-w-3xl">
+          <div className="mb-5 flex items-center gap-3">
+            <span className="inline-flex rounded-xl border border-emerald-500/20 bg-emerald-500/10 p-2 text-emerald-400">
+              <KeyRound size={18} />
+            </span>
+            <h2 className="text-2xl font-semibold text-white">Onboard without a human</h2>
+          </div>
+          <p className="mb-6 text-sm leading-relaxed text-zinc-400">
+            An agent goes from never-heard-of-us to first paid call in three requests. Bearer auth
+            (<code className="rounded bg-black/35 px-1 font-mono">rm_agent_*</code> /{' '}
+            <code className="rounded bg-black/35 px-1 font-mono">rm_user_*</code>), idempotent retries, and metered
+            pricing. Full key management lives at{' '}
+            <Link className="text-emerald-300 underline underline-offset-2 hover:text-emerald-200" href="/get-key">
+              get a key
+            </Link>{' '}
+            and{' '}
+            <Link className="text-emerald-300 underline underline-offset-2 hover:text-emerald-200" href="/pricing">
+              pricing
+            </Link>
+            .
+          </p>
+          <CodeBlock code={PROVISION_CODE} language="bash" filename="onboard" />
+          <p className="mb-3 mt-8 text-sm text-zinc-400">Generate tool definitions for your framework:</p>
+          <CodeBlock code={TOOLDEF_CODE} language="bash" filename="tool-defs" />
+        </div>
+      </section>
+
+      {/* Trust */}
+      <section className="px-4 py-14 sm:px-6 lg:px-8">
+        <div className="mx-auto max-w-5xl">
+          <h2 className="text-2xl font-semibold text-white">Trust &amp; compliance signals</h2>
+          <p className="mt-2 text-sm text-zinc-400">
+            Built for regulated workflows — 13F structure, fund attribution, portfolio risk.
+          </p>
+          <div className="mt-8 grid gap-5 md:grid-cols-3">
+            {TRUST.map(({ title, body, icon: Icon }) => (
+              <div key={title} className="flex flex-col rounded-2xl border border-white/10 bg-white/[0.03] p-6">
+                <div className="mb-4 flex items-center gap-3">
+                  <span className="inline-flex rounded-xl border border-emerald-500/20 bg-emerald-500/10 p-2 text-emerald-400">
+                    <Icon size={18} />
+                  </span>
+                  <h3 className="text-base font-semibold text-white">{title}</h3>
+                </div>
+                <p className="text-sm leading-relaxed text-zinc-400">{body}</p>
+              </div>
+            ))}
+          </div>
+
+          <div className="mx-auto mt-12 flex max-w-2xl flex-wrap justify-center gap-x-6 gap-y-2 text-center text-xs text-zinc-500">
+            <Link className="hover:text-zinc-300" href="/.well-known/agentic-disclosure.json">Agentic disclosure</Link>
+            <Link className="hover:text-zinc-300" href="/docs/methodology">Methodology</Link>
+            <Link className="hover:text-zinc-300" href="/docs/agent-integration">Agent integration guide</Link>
+            <Link className="hover:text-zinc-300" href="/api-reference">OpenAPI reference</Link>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/components/landing/HeroLanding.tsx
+++ b/components/landing/HeroLanding.tsx
@@ -47,7 +47,7 @@ export default function HeroLanding() {
             ERM3 (Equity Risk Model v3)
           </span>
           <span className="inline-flex items-center gap-1.5 rounded-full border border-zinc-700 bg-zinc-900/60 px-2.5 py-1 font-mono uppercase tracking-[0.18em] text-zinc-400">
-            Sub-120 ms
+            Low-latency
           </span>
           <span className="inline-flex items-center gap-1.5 rounded-full border border-zinc-700 bg-zinc-900/60 px-2.5 py-1 font-mono uppercase tracking-[0.18em] text-zinc-400">
             Agent-callable

--- a/content/docs/agent-integration.mdx
+++ b/content/docs/agent-integration.mdx
@@ -113,6 +113,38 @@ Restart your editor after saving. See the [MCP server README](https://github.com
 
 ---
 
+## Compose & chain
+
+RiskModels is one specialized link in an agent's tool chain. Outputs are stable JSON designed to feed the next call — yours or another provider's.
+
+**A typical risk-then-act flow:**
+
+1. **Decompose** a position into its four factor layers and ETF hedge map.
+
+   ```bash
+   curl -X POST https://riskmodels.app/api/decompose \
+     -H "Authorization: Bearer $RISKMODELS_API_KEY" \
+     -H "Content-Type: application/json" \
+     -d '{"ticker":"NVDA"}'
+   ```
+
+   The response `hedge` object is `{ ETF: ratio }` — e.g. `{ "SPY": 0.85, "XLK": 0.15 }`. Those ETF tickers and ratios are the join key to the next step.
+
+2. **Scale to a dollar position.** Feed the same ticker + your notional to `riskmodels_hedge_position` (MCP) or `POST /api/hedge-basket/{ticker}` to turn ratios into share/dollar legs.
+
+3. **Roll up to a portfolio.** Pass a holdings list to `POST /api/portfolio/risk-snapshot` to get variance decomposition and diversification metrics across names — then hand the aggregated hedge legs to an **execution / brokerage API** to actually trade them.
+
+**Why this chains cleanly:**
+
+- **Stable schemas.** Every response shape is published at [`/openapi.json`](/openapi.json) and the per-response JSON schemas (`riskmodels_get_schema` / `riskmodels:///schemas/{path}`). Validate before wiring a downstream call.
+- **Citeable outputs.** `_metadata.model_version` + `data_as_of` and `_agent.request_id` travel with each result, so a downstream tool (or an auditor) can trace exactly which inputs produced an action.
+- **Idempotent steps.** Send an `Idempotency-Key` on POSTs so a retried chain step never double-charges or double-acts.
+- **Cost & latency in-band.** `_agent.cost_usd` and `_agent.latency_ms` let an orchestrating agent budget a multi-call plan before running it.
+
+Discover the full tool set in one fetch: [`/.well-known/agent-manifest.json`](/.well-known/agent-manifest.json). See [For agents](/for-agents) for the onboarding and trust overview.
+
+---
+
 ## Related
 
 <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mt-6 not-prose">

--- a/lib/agent/billing-middleware.ts
+++ b/lib/agent/billing-middleware.ts
@@ -31,6 +31,63 @@ import {
   idempotencyFingerprint,
   setIdempotentResponse,
 } from "./idempotency-cache";
+import { METHODOLOGY_URL } from "@/lib/constants";
+
+/**
+ * Inject agent-facing meta into a JSON success body: the measured total
+ * `latency_ms` (only known here, after the handler returns), a `provenance`
+ * link, and `request_id` if the route didn't already set one.
+ *
+ * Header values (X-Response-Latency-Ms etc.) are also set, but many agent
+ * HTTP clients drop headers — the body is the durable carrier. No-ops for
+ * non-JSON (PDF/PNG/CSV/SSE), errors (status >= 400), and non-object bodies.
+ */
+export async function injectAgentMeta(
+  response: NextResponse,
+  opts: { latencyMs: number; requestId?: string },
+): Promise<NextResponse> {
+  const contentType = response.headers.get("content-type") || "";
+  if (!contentType.includes("application/json") || response.status >= 400) {
+    return response;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = await response.clone().json();
+  } catch {
+    return response;
+  }
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return response;
+  }
+
+  const body = parsed as Record<string, unknown>;
+  const existingAgent =
+    body._agent && typeof body._agent === "object" && !Array.isArray(body._agent)
+      ? (body._agent as Record<string, unknown>)
+      : {};
+
+  body._agent = {
+    ...existingAgent,
+    ...(existingAgent.request_id === undefined && opts.requestId
+      ? { request_id: opts.requestId }
+      : {}),
+    latency_ms: opts.latencyMs,
+    ...(existingAgent.provenance === undefined
+      ? { provenance: METHODOLOGY_URL }
+      : {}),
+  };
+
+  // Body length changed — let the platform recompute Content-Length.
+  const headers = new Headers(response.headers);
+  headers.delete("content-length");
+
+  return new NextResponse(JSON.stringify(body), {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
 
 /**
  * Check if user has exceeded their monthly spend cap
@@ -763,16 +820,20 @@ export function withBilling(
         // Silently skip if we can't fetch spend cap data
       }
 
+      // Inject measured latency / provenance into the JSON body. Done before
+      // the idempotency store so replays return the identical enriched body.
+      const finalResponse = await injectAgentMeta(response, { latencyMs, requestId });
+
       if (
         idempotencyFingerprintVal &&
         userId &&
         req.method === "POST" &&
-        response.status < 500
+        finalResponse.status < 500
       ) {
         try {
-          const bodyText = await response.clone().text();
+          const bodyText = await finalResponse.clone().text();
           const headers: Record<string, string> = {};
-          response.headers.forEach((v, k) => {
+          finalResponse.headers.forEach((v, k) => {
             const kl = k.toLowerCase();
             if (
               kl.startsWith("x-") ||
@@ -783,7 +844,7 @@ export function withBilling(
             }
           });
           await setIdempotentResponse(userId, idempotencyFingerprintVal, {
-            status: response.status,
+            status: finalResponse.status,
             body: bodyText,
             headers,
           });
@@ -792,7 +853,7 @@ export function withBilling(
         }
       }
 
-      return response;
+      return finalResponse;
     } catch (error) {
       const latencyMs = Date.now() - startTime;
 
@@ -847,7 +908,7 @@ export function withBillingHeaders(
         response.headers.set("X-Pricing-Tier", capability.pricing.tier);
       }
 
-      return response;
+      return await injectAgentMeta(response, { latencyMs, requestId });
     } catch (error) {
       throw error;
     }
@@ -983,5 +1044,5 @@ export async function finalizeBilling(
     res.headers.set("X-Pricing-Tier", capMeta.pricing.tier);
   }
 
-  return res;
+  return await injectAgentMeta(res, { latencyMs, requestId: context.requestId });
 }

--- a/lib/agent/telemetry.ts
+++ b/lib/agent/telemetry.ts
@@ -396,6 +396,155 @@ export async function getTelemetryMetrics(
   };
 }
 
+/** Nearest-rank percentile of a pre-sorted array; clamps index to bounds. */
+function percentileOf(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  const idx = Math.min(sorted.length - 1, Math.floor((p / 100) * sorted.length));
+  return sorted[idx];
+}
+
+export interface ServiceReliability {
+  window_hours: number;
+  /** ISO timestamp the window ends at (i.e. when this was computed). */
+  measured_through: string;
+  /** Service-relevant events in window (4xx client errors excluded). */
+  sample_size: number;
+  /** Server-measured processing latency (excludes network), or null if no traffic. */
+  latency_ms: { p50: number; p95: number; p99: number; avg: number } | null;
+  /** Fraction of service-relevant events that did not 5xx, or null if no traffic. */
+  success_rate: number | null;
+  by_capability: Record<
+    string,
+    { sample_size: number; p95_ms: number; success_rate: number }
+  >;
+  note: string;
+}
+
+/** A request-telemetry row from billing_events (latency_ms IS NOT NULL). */
+export type ReliabilityEvent = {
+  capability_id: string;
+  success: boolean;
+  latency_ms: number;
+  metadata?: { status_code?: number } | null;
+};
+
+const RELIABILITY_NOTE =
+  "Server-measured processing latency (excludes network round-trip). success_rate counts only 5xx/thrown errors as failures; metered 4xx (auth/payment/rate-limit) are expected and excluded.";
+
+/**
+ * Pure aggregation of telemetry rows into reliability metrics. Separated from
+ * the DB fetch so the percentile math and the 4xx-exclusion rule are unit-
+ * testable without mocking Supabase.
+ */
+export function aggregateReliability(
+  events: ReliabilityEvent[],
+  windowHours: number,
+  measuredThroughISO: string,
+): ServiceReliability {
+  if (events.length === 0) {
+    return {
+      window_hours: windowHours,
+      measured_through: measuredThroughISO,
+      sample_size: 0,
+      latency_ms: null,
+      success_rate: null,
+      by_capability: {},
+      note: "No measured traffic in window yet. " + RELIABILITY_NOTE,
+    };
+  }
+
+  const isClientError = (e: ReliabilityEvent): boolean => {
+    const sc = e?.metadata?.status_code;
+    return typeof sc === "number" && sc >= 400 && sc < 500;
+  };
+  const round4 = (n: number) => Math.round(n * 10000) / 10000;
+  const sortedLatencies = (evs: ReliabilityEvent[]) =>
+    evs
+      .map((e) => e.latency_ms)
+      .filter((n: unknown): n is number => typeof n === "number")
+      .sort((a, b) => a - b);
+
+  // Latency is measured over service-relevant events only — same filter as
+  // success_rate. Including the fast 4xx (401/402/429) probes would deflate the
+  // percentiles and make real work look faster than it is.
+  const serviceEvents = events.filter((e) => !isClientError(e));
+  const allLatencies = sortedLatencies(serviceEvents);
+  const serverFailures = serviceEvents.filter((e) => !e.success).length;
+  const successRate =
+    serviceEvents.length > 0
+      ? round4((serviceEvents.length - serverFailures) / serviceEvents.length)
+      : null;
+
+  const groups: Record<string, ReliabilityEvent[]> = {};
+  for (const e of events) (groups[e.capability_id] ??= []).push(e);
+
+  const byCapability: ServiceReliability["by_capability"] = {};
+  for (const [cap, evs] of Object.entries(groups)) {
+    const svc = evs.filter((e) => !isClientError(e));
+    const lat = sortedLatencies(svc);
+    const fails = svc.filter((e) => !e.success).length;
+    byCapability[cap] = {
+      sample_size: svc.length,
+      p95_ms: percentileOf(lat, 95),
+      success_rate: svc.length ? round4((svc.length - fails) / svc.length) : 1,
+    };
+  }
+
+  return {
+    window_hours: windowHours,
+    measured_through: measuredThroughISO,
+    sample_size: serviceEvents.length,
+    latency_ms: allLatencies.length
+      ? {
+          p50: percentileOf(allLatencies, 50),
+          p95: percentileOf(allLatencies, 95),
+          p99: percentileOf(allLatencies, 99),
+          avg: Math.round(
+            allLatencies.reduce((a, b) => a + b, 0) / allLatencies.length,
+          ),
+        }
+      : null,
+    success_rate: successRate,
+    by_capability: byCapability,
+    note: RELIABILITY_NOTE,
+  };
+}
+
+/**
+ * Aggregate, privacy-safe reliability metrics across ALL capabilities for the
+ * public /api/status endpoint. No revenue, no user identifiers — only measured
+ * latency percentiles and a 5xx-only success rate (metered 4xx are expected
+ * outcomes of a paid API, not failures; same reasoning as getHealthStatus).
+ *
+ * Reads request-telemetry rows from billing_events (latency_ms IS NOT NULL),
+ * the same source the health endpoint uses.
+ */
+export async function getServiceReliability(
+  windowHours = 24,
+): Promise<ServiceReliability> {
+  const measuredThrough = new Date();
+  const since = new Date(
+    measuredThrough.getTime() - windowHours * 60 * 60 * 1000,
+  ).toISOString();
+
+  const { data: events, error } = await applyTelemetryFilters(
+    createAdminClient()
+      .from("billing_events")
+      .select("capability_id, success, latency_ms, metadata")
+      .gte("created_at", since),
+  );
+
+  if (error || !events) {
+    return aggregateReliability([], windowHours, measuredThrough.toISOString());
+  }
+
+  return aggregateReliability(
+    events as ReliabilityEvent[],
+    windowHours,
+    measuredThrough.toISOString(),
+  );
+}
+
 /**
  * Generate request ID for tracking
  */

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,1 +1,4 @@
 export const RISK_MODEL_VERSION = "3.0";
+
+/** Canonical methodology / provenance URL surfaced to agents (response _agent.provenance, _metadata.wiki_uri). */
+export const METHODOLOGY_URL = "https://riskmodels.app/docs/methodology";

--- a/lib/dal/response-headers.ts
+++ b/lib/dal/response-headers.ts
@@ -76,6 +76,14 @@ export const EMPTY_HISTORY_DATA_WARNING =
 export type AgentBodyInput = {
   request_id: string;
   cost_usd?: number;
+  /**
+   * Server-measured processing latency in ms. Usually left unset here: the
+   * billing middleware injects the authoritative total into `_agent.latency_ms`
+   * after the handler returns (see injectAgentMeta in billing-middleware.ts).
+   */
+  latency_ms?: number;
+  /** Methodology / provenance URL; middleware fills this when omitted. */
+  provenance?: string;
 };
 
 /** Build _agent block for JSON history endpoints (mirrors batch/analyze shape). */
@@ -83,6 +91,8 @@ export function buildAgentBody(agent: AgentBodyInput): Record<string, unknown> {
   return {
     request_id: agent.request_id,
     ...(agent.cost_usd !== undefined ? { cost_usd: agent.cost_usd } : {}),
+    ...(agent.latency_ms !== undefined ? { latency_ms: agent.latency_ms } : {}),
+    ...(agent.provenance !== undefined ? { provenance: agent.provenance } : {}),
   };
 }
 

--- a/lib/dal/risk-metadata.ts
+++ b/lib/dal/risk-metadata.ts
@@ -7,7 +7,7 @@
  */
 
 import { createAdminClient } from "@/lib/supabase/admin";
-import { RISK_MODEL_VERSION } from "@/lib/constants";
+import { RISK_MODEL_VERSION, METHODOLOGY_URL } from "@/lib/constants";
 
 const L3_FACTORS = [
   "SPY", "XLK", "XLF", "XLV", "XLE", "XLI",
@@ -54,7 +54,7 @@ export async function getRiskMetadata(): Promise<RiskMetadata> {
     data_as_of: dataAsOf,
     factor_set_id: "SPY_uni_mc_3000",
     universe_size: universeCount ?? 0,
-    wiki_uri: "https://riskmodels.net/docs/methodology",
+    wiki_uri: METHODOLOGY_URL,
     factors: L3_FACTORS,
   };
 

--- a/lib/docs-nav.ts
+++ b/lib/docs-nav.ts
@@ -51,6 +51,7 @@ export const DOCS_NAV: DocsNavGroup[] = [
   {
     title: 'Agents',
     items: [
+      { href: '/for-agents', label: 'For agents' },
       { href: '/docs/agent-integration', label: 'Agent integration' },
       { href: '/llms.txt', label: 'llms.txt', external: true },
     ],

--- a/mcp/data/openapi.json
+++ b/mcp/data/openapi.json
@@ -9639,6 +9639,186 @@
         }
       }
     },
+    "/status": {
+      "get": {
+        "summary": "Aggregate service reliability metrics",
+        "description": "Measured latency percentiles (p50/p95/p99) and a 5xx-only success rate over a window, aggregated across all capabilities from request telemetry, plus a per-capability breakdown. Numbers are observed from real traffic, not asserted SLAs. Metered 4xx (auth/payment/rate-limit) are excluded from both latency and success_rate. Free, no auth required.\n",
+        "operationId": "getStatus",
+        "tags": [
+          "Utility"
+        ],
+        "parameters": [
+          {
+            "name": "window_hours",
+            "in": "query",
+            "required": false,
+            "description": "Lookback window in hours (default 24, max 720).",
+            "schema": {
+              "type": "integer",
+              "default": 24,
+              "minimum": 1,
+              "maximum": 720
+            }
+          }
+        ],
+        "x-pricing": {
+          "capability_id": "status-metrics",
+          "tier": "baseline",
+          "model": "per_request",
+          "cost_usd": 0,
+          "currency": "USD",
+          "billing_code": "status_metrics"
+        },
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Reliability metrics for the window.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "window_hours": {
+                      "type": "integer"
+                    },
+                    "measured_through": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "sample_size": {
+                      "type": "integer",
+                      "description": "Service-relevant events in window (4xx excluded)."
+                    },
+                    "latency_ms": {
+                      "type": "object",
+                      "nullable": true,
+                      "description": "Server-measured processing latency (excludes network); null if no traffic.",
+                      "properties": {
+                        "p50": {
+                          "type": "number"
+                        },
+                        "p95": {
+                          "type": "number"
+                        },
+                        "p99": {
+                          "type": "number"
+                        },
+                        "avg": {
+                          "type": "number"
+                        }
+                      }
+                    },
+                    "success_rate": {
+                      "type": "number",
+                      "nullable": true,
+                      "description": "Fraction of service-relevant events that did not 5xx; null if no traffic."
+                    },
+                    "by_capability": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "note": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/feedback": {
+      "post": {
+        "summary": "Submit feedback on an API result",
+        "description": "Flag a specific result by its _agent.request_id with a rating / category / correction note. Trust-loop signal for offline data-quality and docs triage; no output changes at request time. Authenticated, free (no metering). Provide at least one of rating, category, or comment.\n",
+        "operationId": "postFeedback",
+        "tags": [
+          "Utility"
+        ],
+        "x-pricing": {
+          "capability_id": "feedback",
+          "tier": "baseline",
+          "model": "per_request",
+          "cost_usd": 0,
+          "currency": "USD",
+          "billing_code": "feedback"
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "request_id": {
+                    "type": "string",
+                    "description": "The _agent.request_id / X-Request-ID of the call being rated. Nullable for general feedback."
+                  },
+                  "capability_id": {
+                    "type": "string"
+                  },
+                  "rating": {
+                    "type": "string",
+                    "enum": [
+                      "up",
+                      "down"
+                    ]
+                  },
+                  "category": {
+                    "type": "string",
+                    "enum": [
+                      "data_quality",
+                      "incorrect_result",
+                      "latency",
+                      "docs",
+                      "feature_request",
+                      "other"
+                    ]
+                  },
+                  "comment": {
+                    "type": "string",
+                    "maxLength": 4000
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Feedback recorded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "feedback_id": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or empty feedback (no rating/category/comment, bad enum, or comment too long)."
+          },
+          "401": {
+            "description": "Missing or invalid API key."
+          },
+          "503": {
+            "description": "Feedback store temporarily unavailable (retry)."
+          }
+        }
+      }
+    },
     "/balance": {
       "get": {
         "summary": "Account balance and rate limits",

--- a/tests/inject-agent-meta.test.ts
+++ b/tests/inject-agent-meta.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { NextResponse } from "next/server";
+import { injectAgentMeta } from "@/lib/agent/billing-middleware";
+import { buildAgentBody } from "@/lib/dal/response-headers";
+import { METHODOLOGY_URL } from "@/lib/constants";
+
+describe("injectAgentMeta", () => {
+  it("adds latency_ms, provenance and request_id to a JSON success body", async () => {
+    const res = NextResponse.json({ ticker: "AAPL", _agent: { cost_usd: 0.02 } });
+    const out = await injectAgentMeta(res, { latencyMs: 87, requestId: "req_123" });
+    const body = await out.json();
+    expect(body._agent.latency_ms).toBe(87);
+    expect(body._agent.provenance).toBe(METHODOLOGY_URL);
+    expect(body._agent.request_id).toBe("req_123");
+    expect(body._agent.cost_usd).toBe(0.02); // preserved
+    expect(body.ticker).toBe("AAPL"); // payload untouched
+  });
+
+  it("creates an _agent block when the body has none", async () => {
+    const res = NextResponse.json({ data: [1, 2, 3] });
+    const out = await injectAgentMeta(res, { latencyMs: 12, requestId: "req_x" });
+    const body = await out.json();
+    expect(body._agent.latency_ms).toBe(12);
+    expect(body._agent.provenance).toBe(METHODOLOGY_URL);
+  });
+
+  it("does not clobber a route-provided request_id or provenance", async () => {
+    const res = NextResponse.json({
+      _agent: { request_id: "route_req", provenance: "https://custom/method" },
+    });
+    const out = await injectAgentMeta(res, { latencyMs: 5, requestId: "mw_req" });
+    const body = await out.json();
+    expect(body._agent.request_id).toBe("route_req");
+    expect(body._agent.provenance).toBe("https://custom/method");
+    expect(body._agent.latency_ms).toBe(5); // latency is always the measured value
+  });
+
+  it("leaves error (>=400) responses untouched", async () => {
+    const res = NextResponse.json({ error: "Payment Required" }, { status: 402 });
+    const out = await injectAgentMeta(res, { latencyMs: 99 });
+    const body = await out.json();
+    expect(body._agent).toBeUndefined();
+  });
+
+  it("leaves non-JSON responses untouched", async () => {
+    const res = new NextResponse("PDFBYTES", {
+      status: 200,
+      headers: { "content-type": "application/pdf" },
+    });
+    const out = await injectAgentMeta(res, { latencyMs: 99 });
+    expect(await out.text()).toBe("PDFBYTES");
+  });
+
+  it("leaves JSON array bodies untouched (no object to attach _agent to)", async () => {
+    const res = NextResponse.json([1, 2, 3]);
+    const out = await injectAgentMeta(res, { latencyMs: 99 });
+    expect(await out.json()).toEqual([1, 2, 3]);
+  });
+});
+
+describe("buildAgentBody", () => {
+  it("omits latency_ms / provenance unless provided", () => {
+    expect(buildAgentBody({ request_id: "r", cost_usd: 0.01 })).toEqual({
+      request_id: "r",
+      cost_usd: 0.01,
+    });
+  });
+
+  it("includes latency_ms / provenance when provided", () => {
+    expect(
+      buildAgentBody({ request_id: "r", latency_ms: 42, provenance: "u" }),
+    ).toEqual({ request_id: "r", latency_ms: 42, provenance: "u" });
+  });
+});

--- a/tests/service-reliability.test.ts
+++ b/tests/service-reliability.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import {
+  aggregateReliability,
+  type ReliabilityEvent,
+} from "@/lib/agent/telemetry";
+
+const ISO = "2026-06-05T00:00:00.000Z";
+
+function ev(
+  capability_id: string,
+  latency_ms: number,
+  success: boolean,
+  status_code?: number,
+): ReliabilityEvent {
+  return { capability_id, latency_ms, success, metadata: { status_code } };
+}
+
+describe("aggregateReliability", () => {
+  it("returns nulls and a note when there is no traffic", () => {
+    const r = aggregateReliability([], 24, ISO);
+    expect(r.sample_size).toBe(0);
+    expect(r.latency_ms).toBeNull();
+    expect(r.success_rate).toBeNull();
+    expect(r.by_capability).toEqual({});
+    expect(r.note).toContain("No measured traffic");
+  });
+
+  it("computes nearest-rank percentiles over all latencies", () => {
+    // latencies 10..100 (10 values), sorted
+    const events = Array.from({ length: 10 }, (_, i) =>
+      ev("decompose", (i + 1) * 10, true, 200),
+    );
+    const r = aggregateReliability(events, 24, ISO);
+    expect(r.latency_ms).not.toBeNull();
+    // floor(0.5*10)=5 -> index 5 -> 60; p95 floor(0.95*10)=9 -> 100; p99 clamps to 100
+    expect(r.latency_ms!.p50).toBe(60);
+    expect(r.latency_ms!.p95).toBe(100);
+    expect(r.latency_ms!.p99).toBe(100);
+    expect(r.latency_ms!.avg).toBe(55);
+  });
+
+  it("excludes 4xx from success_rate but counts 5xx as failures", () => {
+    const events = [
+      ev("metrics", 20, true, 200),
+      ev("metrics", 20, true, 200),
+      ev("metrics", 5, false, 401), // client error -> excluded entirely
+      ev("metrics", 5, false, 402), // client error -> excluded entirely
+      ev("metrics", 30, false, 500), // server failure -> counts against
+    ];
+    const r = aggregateReliability(events, 24, ISO);
+    // service-relevant = 3 (two 200s + one 500). failures = 1. rate = 2/3.
+    expect(r.sample_size).toBe(3);
+    expect(r.success_rate).toBeCloseTo(0.6667, 4);
+    // latency percentiles exclude the fast 4xx rows (same filter as success_rate)
+    expect(r.latency_ms!.avg).toBe(Math.round((20 + 20 + 30) / 3));
+  });
+
+  it("breaks down per capability without leaking revenue or user fields", () => {
+    const events = [
+      ev("decompose", 100, true, 200),
+      ev("decompose", 200, false, 500),
+      ev("lstar", 50, true, 200),
+    ];
+    const r = aggregateReliability(events, 24, ISO);
+    expect(Object.keys(r.by_capability).sort()).toEqual(["decompose", "lstar"]);
+    expect(r.by_capability.decompose.sample_size).toBe(2);
+    expect(r.by_capability.decompose.success_rate).toBe(0.5);
+    expect(r.by_capability.lstar.success_rate).toBe(1);
+    // shape is exactly {sample_size, p95_ms, success_rate} — nothing else
+    expect(Object.keys(r.by_capability.lstar).sort()).toEqual([
+      "p95_ms",
+      "sample_size",
+      "success_rate",
+    ]);
+  });
+
+  it("treats a capability of only client errors as 100% (no service failures)", () => {
+    const events = [ev("chat", 5, false, 429), ev("chat", 5, false, 401)];
+    const r = aggregateReliability(events, 24, ISO);
+    expect(r.by_capability.chat.sample_size).toBe(0);
+    expect(r.by_capability.chat.success_rate).toBe(1);
+    expect(r.by_capability.chat.p95_ms).toBe(0); // no service events → no published latency
+    expect(r.latency_ms).toBeNull(); // all 4xx → no service latency to report
+    expect(r.success_rate).toBeNull(); // no service-relevant events at all
+  });
+});


### PR DESCRIPTION
Makes the API more agent-native by surfacing what already exists in machine-readable form and closing real gaps. Most of the pasted go-to-market playbook was already shipped; this PR is the gap closure.

## Added
- **`GET /api/status`** — public, aggregate reliability: measured p50/p95/p99 latency + 5xx-only success rate over a window, per-capability. 4xx excluded so probes can't skew it. No revenue/user fields.
- **`POST /api/feedback`** — trust-loop endpoint; writes `public.feedback_events` (graceful 503 until the BWMACRO migration is applied, 201 once live).
- **`/for-agents`** human-approval page + docs sidebar entry; **"Compose & chain"** docs section.
- **`_agent.latency_ms` + `provenance`** injected into every JSON response body (header-only latency was dropped by many agent clients).
- Enriched `/.well-known/agent-manifest.json` (reproducibility, pricing, discovery, reliability→`/api/status`, onboarding, feedback) + `agentic-disclosure.json` (audit/reproducibility).
- OpenAPI: `/status` + `/feedback` (json mirrors regenerated); CHANGELOG 0.4.0.

## Fixed
- Methodology/provenance URL `riskmodels.net` (404) → `riskmodels.app` (200); single source `METHODOLOGY_URL`.
- Softened unbacked "Sub-120 ms" hero badge → "Low-latency".

## Verification
362 tests pass · 0 type errors · `next build` clean · `/status` + `/feedback` (incl. 201 against live DB) verified.

## Cross-repo (separate PRs)
- BWMACRO: `feedback_events` migration (apply before `/api/feedback` returns 201).
- RM_ORG: `/.well-known/methodology.json` (manifest's `validation_manifest_url` points at it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)