### PR TITLE
fix(pricing): align docs prices to compute-graded schedule; search free

### DIFF
--- a/content/docs/api.mdx
+++ b/content/docs/api.mdx
@@ -371,7 +371,7 @@ For the mathematical detail behind L1/L2/L3 decomposition and hedge construction
         <td className="py-3 px-3 font-mono text-xs text-zinc-300">/api/metrics/{'{ticker}'}</td>
         <td className="py-3 px-3">GET</td>
         <td className="py-3 px-3">Latest snapshot: HR/ER fields (semantic columns in SDK), vol, Sharpe, sector, market cap</td>
-        <td className="py-3 px-3 text-zinc-500">{'$'}0.005/call</td>
+        <td className="py-3 px-3 text-zinc-500">{'$'}0.001/call</td>
         <td className="py-3 px-3"><CopyPythonSnippet code='from riskmodels import RiskModelsClient; RiskModelsClient.from_env().get_metrics("NVDA", as_dataframe=True)' /></td>
       </tr>
       <tr id="decompose" className="border-b border-zinc-800 align-top">
@@ -392,7 +392,7 @@ For the mathematical detail behind L1/L2/L3 decomposition and hedge construction
         <td className="py-3 px-3 font-mono text-xs text-zinc-300">/api/l3-decomposition</td>
         <td className="py-3 px-3">GET</td>
         <td className="py-3 px-3">Monthly historical HR/ER time series</td>
-        <td className="py-3 px-3 text-zinc-500">$0.005/call</td>
+        <td className="py-3 px-3 text-zinc-500">{'$'}0.02/call</td>
         <td className="py-3 px-3"><CopyPythonSnippet code='from riskmodels import RiskModelsClient; RiskModelsClient.from_env().get_l3_decomposition("NVDA")' /></td>
       </tr>
       <tr className="border-b border-zinc-800 align-top">
@@ -405,8 +405,8 @@ For the mathematical detail behind L1/L2/L3 decomposition and hedge construction
       <tr className="border-b border-zinc-800 align-top">
         <td className="py-3 px-3 font-mono text-xs text-zinc-300">/api/batch/analyze</td>
         <td className="py-3 px-3">POST</td>
-        <td className="py-3 px-3">Multi-ticker batch up to 100, 25% cheaper per position</td>
-        <td className="py-3 px-3 text-zinc-500">$0.002/position</td>
+        <td className="py-3 px-3">Multi-ticker batch up to 100 (returns + full metrics per position)</td>
+        <td className="py-3 px-3 text-zinc-500">{'$'}0.005/position</td>
         <td className="py-3 px-3"><CopyPythonSnippet code='from riskmodels import RiskModelsClient; RiskModelsClient.from_env().batch_analyze(["NVDA","AAPL"], ["returns","full_metrics"], years=2)' /></td>
       </tr>
       <tr className="border-b border-zinc-800 align-top">
@@ -427,7 +427,7 @@ For the mathematical detail behind L1/L2/L3 decomposition and hedge construction
         <td className="py-3 px-3 font-mono text-xs text-zinc-300">/api/rankings/screen</td>
         <td className="py-3 px-3">POST</td>
         <td className="py-3 px-3">Server-side percentile / decile / sector filters over the full ds_rankings cross-section. Returns up to 500 rows sorted by <code className="text-zinc-400 bg-zinc-950 px-1 rounded text-[10px]">rank_ordinal</code>. Stat-arb cross-section, one call.</td>
-        <td className="py-3 px-3 text-zinc-500">{'$'}0.02/call</td>
+        <td className="py-3 px-3 text-zinc-500">{'$'}0.05/call</td>
         <td className="py-3 px-3"><CopyPythonSnippet code='from riskmodels import RiskModelsClient; RiskModelsClient.from_env().screen_rankings(metric="subsector_residual", cohort="subsector", window="21d", min_percentile=95)' /></td>
       </tr>
       <tr className="border-b border-zinc-800 align-top">

--- a/lib/agent/capabilities.ts
+++ b/lib/agent/capabilities.ts
@@ -491,7 +491,7 @@ export const CAPABILITIES: Capability[] = [
     pricing: {
       model: "per_request",
       tier: "baseline",
-      cost_usd: 0.001,
+      cost_usd: 0,
       currency: "USD",
       billing_code: "ticker_search_v2",
     },

--- a/lib/api-reference-data.ts
+++ b/lib/api-reference-data.ts
@@ -220,7 +220,7 @@ export const ENDPOINT_GROUPS: EndpointGroup[] = [
         method: 'post',
         summary: 'Universe-wide rank screen',
         description:
-          'Server-side percentile / decile / sector filters over the full ds_rankings cross-section at one teo (default latest). Replaces N per-ticker /rankings calls. Returns up to 500 rows sorted by rank_ordinal (1 = best, rank_percentile 100 = best). Cost: $0.02/call.',
+          'Server-side percentile / decile / sector filters over the full ds_rankings cross-section at one teo (default latest). Replaces N per-ticker /rankings calls. Returns up to 500 rows sorted by rank_ordinal (1 = best, rank_percentile 100 = best). Cost: $0.05/call.',
         operationId: 'postRankingsScreen',
         tag: 'Risk Metrics',
         params: [


### PR DESCRIPTION
Fresh value assessment of all 55 priced endpoints, then fixed the cost mismatches the audit flagged.

## Assessment
`lib/agent/capabilities.ts` (which `x-pricing` + billing derive from) is already a coherent **compute-graded** schedule — exactly the "charge more for heavier derived data" principle:

renders/PDFs **$0.25** → cross-section scans **$0.05** → derived single-ticker series (lstar, l3-decomp, returns-decomp) **$0.02** → data reads **$0.005** → light lookups **$0.001** → search/health **$0**.

So capabilities.ts is the source of truth; the **docs table was the stale side**.

## Fixes (docs → match the schedule)
| Endpoint | Was (docs) | Now | Why |
|---|---|---|---|
| `/metrics/{ticker}` | $0.005 | **$0.001** | light single-row (its own prose already said $0.001) |
| `/l3-decomposition` | $0.005 | **$0.02** | heavy historical HR/ER series |
| `/batch/analyze` | $0.002/pos | **$0.005/pos** | returns + full metrics per position |
| `/rankings/screen` | $0.02 | **$0.05** | full cross-section scan |

Also fixed the same `/rankings/screen` drift in `lib/api-reference-data.ts` ($0.02 → $0.05).

## Pricing decision: `/tickers` (search) → free
Search is the lightest op **and** a discovery driver. `capabilities.ts` already called it "free" in prose while charging $0.001, and the route is public/uncharged. Set `ticker-search` `cost_usd: 0` in `capabilities.ts` (SoT); `x-pricing` syncs on next `build:openapi`.

Result: **docs-conformity cost mismatches 0** (was 5). No `openapi.json` edits here (it has unrelated WIP) — it regenerates from `capabilities.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)