### PR TITLE
fix(license): gate raw EODHD fields on /api/data/security-history (Exhibit B(e))

### DIFF
--- a/app/api/data/security-history/[symbol]/route.ts
+++ b/app/api/data/security-history/[symbol]/route.ts
@@ -8,6 +8,10 @@ import {
 } from "@/lib/dal/risk-engine-v3";
 import { getRiskMetadata } from "@/lib/dal/risk-metadata";
 import { buildMetadataBody } from "@/lib/dal/response-headers";
+import {
+  isGatewayAuthenticated,
+  requestsRawRestricted,
+} from "@/lib/data-license";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -49,6 +53,22 @@ export async function GET(
   }
 
   const keys = keysParam.split(",").map((k) => k.trim()).filter(Boolean);
+
+  // EODHD Exhibit B(e): raw fields (close price, market cap) may be served only
+  // within authenticated environments. Per-symbol here satisfies the per-call
+  // condition; gate on the service key. Derived keys stay public.
+  if (requestsRawRestricted(keys) && !isGatewayAuthenticated(request)) {
+    return NextResponse.json(
+      {
+        error:
+          "Raw fields (price_close, market_cap) require authentication. " +
+          "Use a billed endpoint (/api/metrics/:ticker, /api/ticker-returns) " +
+          "or omit these keys.",
+      },
+      { status: 403 },
+    );
+  }
+
   const periodicity = (sp.get("periodicity") ?? "daily") as V3Periodicity;
   const startDate = sp.get("start") ?? undefined;
   const endDate = sp.get("end") ?? undefined;

--- a/app/api/data/security-history/batch/route.ts
+++ b/app/api/data/security-history/batch/route.ts
@@ -8,6 +8,7 @@ import {
 } from "@/lib/dal/risk-engine-v3";
 import { getRiskMetadata } from "@/lib/dal/risk-metadata";
 import { buildMetadataBody } from "@/lib/dal/response-headers";
+import { requestsRawRestricted, stripRawRestricted } from "@/lib/data-license";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -83,10 +84,13 @@ export async function POST(request: NextRequest) {
       if (data) allRows.push(...data);
     }
 
-    // Key by symbol
+    // Key by symbol. EODHD Exhibit B(e)/(f): raw fields (close price, market
+    // cap) are permitted only per-symbol/per-call — never in a bulk batch — so
+    // strip them from every wide row here regardless of caller auth.
     const results: Record<string, unknown> = {};
     for (const row of allRows) {
-      results[(row as { symbol: string }).symbol] = row;
+      const r = row as Record<string, unknown> & { symbol: string };
+      results[r.symbol] = stripRawRestricted(r);
     }
 
     return NextResponse.json({ results });
@@ -100,6 +104,20 @@ export async function POST(request: NextRequest) {
         error: "keys array is required for history mode (or use latest: true)",
       },
       { status: 400 },
+    );
+  }
+
+  // EODHD Exhibit B(e)/(f): raw fields are permitted only per-symbol/per-call.
+  // A multi-symbol batch is bulk by definition, so raw keys are never allowed
+  // here — direct callers to the per-symbol endpoint. Derived keys are fine.
+  if (requestsRawRestricted(keys)) {
+    return NextResponse.json(
+      {
+        error:
+          "Raw fields (price_close, market_cap) are not available in batch " +
+          "requests. Fetch them per-symbol via GET /api/data/security-history/:symbol.",
+      },
+      { status: 403 },
     );
   }
 

--- a/app/api/data/security-history/latest/[symbol]/route.ts
+++ b/app/api/data/security-history/latest/[symbol]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { verifyGatewayAuth } from "@/lib/gateway-auth";
+import { isGatewayAuthenticated, stripRawRestricted } from "@/lib/data-license";
 
 export const dynamic = "force-dynamic";
 
@@ -52,6 +53,13 @@ export async function GET(
       { error: "No latest data found for symbol" },
       { status: 404 },
     );
+  }
+
+  // EODHD Exhibit B(e): raw fields (close price, market cap) only within
+  // authenticated environments. Per-symbol satisfies the per-call condition;
+  // unauthenticated callers get the derived columns with raw fields stripped.
+  if (!isGatewayAuthenticated(request)) {
+    return NextResponse.json(stripRawRestricted(data as Record<string, unknown>));
   }
 
   return NextResponse.json(data);

--- a/lib/data-license.ts
+++ b/lib/data-license.ts
@@ -1,0 +1,61 @@
+/**
+ * EODHD data-license policy — Exhibit B of the Data Services Agreement.
+ * (RiskModels_IP/docs/licensing/EODHD_Agreement_v3_Complete_DocuSign.pdf)
+ *
+ * Exhibit B in brief:
+ *   B(c)/(d) — Derived Data (betas, returns, hedge ratios, factor exposures,
+ *     volatility, attribution, …) may be redistributed freely via our own API.
+ *     The entire V3 metric dictionary EXCEPT the two raw fields below is Derived.
+ *   B(e)     — The raw fields "end-of-day close price" and "market capitalization"
+ *     may be displayed ONLY (1) within authenticated environments, (2) on a
+ *     per-symbol, per-request basis, ancillary to Derived outputs, and (4) behind
+ *     anti-bulk safeguards. B(f) confirms per-symbol/per-call delivery of these
+ *     fields is NOT "raw or bulk form" redistribution.
+ *   B(b)/(i) — No raw/bulk resale; no fake-derived (rounding, rename, ±constant).
+ *
+ * Encoding for the /api/data/security-history surface (the internal data gateway):
+ *   - The raw fields require the gateway service key (the authenticated, first-party
+ *     environment). Unauthenticated callers get derived data only. External
+ *     authenticated users reach raw close/mktcap through the billed endpoints
+ *     (/api/metrics/:ticker scalar, /api/ticker-returns per-symbol).
+ *   - Raw fields are NEVER served in a multi-symbol (bulk) batch request, because
+ *     B(e)/(f) permit raw fields only "per-symbol, per-call".
+ */
+
+import { type NextRequest } from "next/server";
+
+/** Raw EODHD fields restricted by Exhibit B(e). Everything else is Derived Data. */
+export const RAW_RESTRICTED_KEYS = new Set<string>(["price_close", "market_cap"]);
+
+/** True if any requested metric key is a raw, license-restricted field. */
+export function requestsRawRestricted(keys: readonly string[]): boolean {
+  return keys.some((k) => RAW_RESTRICTED_KEYS.has(k.trim()));
+}
+
+/**
+ * True when the request carries the valid gateway service key — i.e. an
+ * authenticated, first-party environment per Exhibit B(e) condition (1).
+ *
+ * When no service key is configured (local/dev), treat as authenticated so the
+ * dev experience is unchanged. Production always sets RISKMODELS_API_SERVICE_KEY.
+ * This mirrors the pass-through behavior of `verifyGatewayAuth` when `!key`.
+ */
+export function isGatewayAuthenticated(request: NextRequest): boolean {
+  const key = process.env.RISKMODELS_API_SERVICE_KEY;
+  if (!key) return true;
+  const authHeader = request.headers.get("authorization");
+  if (!authHeader) return false;
+  const token = authHeader.replace(/^Bearer\s+/i, "").trim();
+  return token === key;
+}
+
+/**
+ * Drop raw, license-restricted columns from a wide `security_history_latest`
+ * row. Used when serving the wide row to an unauthenticated caller, or in any
+ * bulk (multi-symbol) context where raw fields are not permitted at all.
+ */
+export function stripRawRestricted<T extends Record<string, unknown>>(row: T): T {
+  const out = { ...row };
+  for (const k of RAW_RESTRICTED_KEYS) delete (out as Record<string, unknown>)[k];
+  return out;
+}

--- a/tests/data-license.test.ts
+++ b/tests/data-license.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { NextRequest } from "next/server";
+import {
+  RAW_RESTRICTED_KEYS,
+  isGatewayAuthenticated,
+  requestsRawRestricted,
+  stripRawRestricted,
+} from "@/lib/data-license";
+
+/**
+ * Codifies the EODHD Exhibit B(e) policy enforced on /api/data/security-history.
+ * If these expectations change, confirm against the signed agreement
+ * (RiskModels_IP/docs/licensing/EODHD_Agreement_v3_Complete_DocuSign.pdf).
+ */
+
+function reqWithAuth(authHeader: string | null): NextRequest {
+  return {
+    headers: { get: (k: string) => (k.toLowerCase() === "authorization" ? authHeader : null) },
+  } as unknown as NextRequest;
+}
+
+describe("EODHD data-license policy", () => {
+  it("restricts exactly the two raw EODHD fields", () => {
+    expect([...RAW_RESTRICTED_KEYS].sort()).toEqual(["market_cap", "price_close"]);
+  });
+
+  it("flags requests that include raw fields", () => {
+    expect(requestsRawRestricted(["l1_mkt_hr", "price_close"])).toBe(true);
+    expect(requestsRawRestricted(["market_cap"])).toBe(true);
+    expect(requestsRawRestricted([" price_close "])).toBe(true); // tolerates whitespace
+  });
+
+  it("treats derived-only requests as unrestricted", () => {
+    expect(requestsRawRestricted(["l1_mkt_hr", "returns_gross", "lstar_rr"])).toBe(false);
+    expect(requestsRawRestricted([])).toBe(false);
+  });
+
+  it("strips raw fields but keeps derived columns", () => {
+    const row = { symbol: "AAPL", price_close: 200, market_cap: 3e12, l1_mkt_hr: 0.9 };
+    expect(stripRawRestricted(row)).toEqual({ symbol: "AAPL", l1_mkt_hr: 0.9 });
+  });
+
+  describe("isGatewayAuthenticated", () => {
+    const ORIG = process.env.RISKMODELS_API_SERVICE_KEY;
+    beforeEach(() => {
+      process.env.RISKMODELS_API_SERVICE_KEY = "svc-secret";
+    });
+    afterEach(() => {
+      if (ORIG === undefined) delete process.env.RISKMODELS_API_SERVICE_KEY;
+      else process.env.RISKMODELS_API_SERVICE_KEY = ORIG;
+    });
+
+    it("accepts the matching service key", () => {
+      expect(isGatewayAuthenticated(reqWithAuth("Bearer svc-secret"))).toBe(true);
+    });
+
+    it("rejects missing or wrong bearer", () => {
+      expect(isGatewayAuthenticated(reqWithAuth(null))).toBe(false);
+      expect(isGatewayAuthenticated(reqWithAuth("Bearer rm_agent_live_xyz"))).toBe(false);
+    });
+
+    it("passes through when no service key is configured (dev)", () => {
+      delete process.env.RISKMODELS_API_SERVICE_KEY;
+      expect(isGatewayAuthenticated(reqWithAuth(null))).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Why

The internal data gateway exposed raw EODHD fields (`price_close`, `market_cap`) **publicly**, in **500-symbol bulk batches**, with **no anti-bulk safeguards** — outside the limited-display conditions of the signed Data Services Agreement (`RiskModels_IP/docs/licensing/EODHD_Agreement_v3_Complete_DocuSign.pdf`, Exhibit B(e)), which permits these two raw fields only:
1. within **authenticated** environments, and
2. on a **per-symbol, per-call** basis.

All other V3 metric keys are **Derived Data** (Exhibit B(c)/(d)) and remain public + batchable. This was the only surface outside the terms we already hold — there is no redistribution tier to buy. Tracked as **H.69** in BWMACRO `MASTER_BACKLOG.md`.

## What

- **`lib/data-license.ts`** (new) — single-source policy: `RAW_RESTRICTED_KEYS = {price_close, market_cap}`, `isGatewayAuthenticated()` (service key = authenticated env; passes through in dev when unset), `stripRawRestricted()`.
- **`security-history/:symbol`** — `403` on raw keys unless service-key authed (per-symbol satisfies the per-call condition); derived keys unchanged.
- **`security-history/batch`** — `403` on raw keys in history mode; strip raw cols from the wide `latest` mode (bulk never serves raw).
- **`security-history/latest/:symbol`** — strip raw cols for unauthenticated callers; full row to authed.

External authenticated users still reach raw close/mktcap through the billed endpoints (`/api/metrics/:ticker` scalar, `/api/ticker-returns` per-symbol).

## Not in scope (follow-up)

Exhibit B(g) safeguards — edge rate-limit / anti-scrape on the data gateway and CSV/parquet exports (platform-level).

## Tests

- 7 new in `tests/data-license.test.ts` — all green.
- `security-history-guard` green.
- Typecheck clean (only pre-existing `.next/types` docs errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)