### PR TITLE
fix(license): anti-scrape rate limit on /api/data gateway (EODHD Exhibit B(g))

### DIFF
--- a/docs/legal/eodhd-data-license-safeguards.md
+++ b/docs/legal/eodhd-data-license-safeguards.md
@@ -1,0 +1,58 @@
+# EODHD data-license safeguards (Exhibit B compliance)
+
+Maps the controls in this repo to the signed **Data Services Agreement** with
+Unicorn Data Services SAS (EODHistoricalData), effective 2026-05-15.
+Master contract: `RiskModels_IP/docs/licensing/EODHD_Agreement_v3_Complete_DocuSign.pdf`.
+
+The agreement grants generous rights — derived analytics redistribution (B(c)/(d))
+and per-symbol, authenticated raw-field display (B(e)) — with **no separate
+redistribution tier**. The obligations we must actively enforce are the limited-
+display conditions (B(e)) and the anti-bulk safeguards (B(g)).
+
+## Restricted raw fields
+
+Only two fields are EODHD raw data under Exhibit B(e); everything else in the V3
+metric dictionary is Derived Data (free to redistribute under B(c)/(d)):
+
+| Field | Key |
+|---|---|
+| End-of-day close price | `price_close` |
+| Market capitalization | `market_cap` |
+
+Single source of truth: `lib/data-license.ts` (`RAW_RESTRICTED_KEYS`).
+
+## B(e) — Limited Display of Raw Fields (authenticated, per-symbol, ancillary)
+
+| Surface | Control | Where |
+|---|---|---|
+| `GET /api/data/security-history/:symbol` | Raw keys → `403` unless service-key authed (per-symbol satisfies per-call); derived keys public | `app/api/data/security-history/[symbol]/route.ts` |
+| `POST /api/data/security-history/batch` | Raw keys → `403` (bulk never serves raw); stripped from wide `latest` mode | `app/api/data/security-history/batch/route.ts` |
+| `GET /api/data/security-history/latest/:symbol` | Raw cols stripped for unauthenticated callers | `app/api/data/security-history/latest/[symbol]/route.ts` |
+| External authenticated raw access | Per-symbol via billed endpoints `/api/metrics/:ticker` (scalar), `/api/ticker-returns` (one symbol) | `withBilling` |
+
+Policy helpers: `lib/data-license.ts`. Tests: `tests/data-license.test.ts`.
+
+## B(g) — Safeguards against bulk download / systematic scraping / reconstruction
+
+**Technical:**
+
+| Layer | Control | Where |
+|---|---|---|
+| Billed API (`/api/*` via `withBilling`) | Per-API-key Upstash sliding-window rate limit (`429` + `Retry-After`); per-request metered cost (iteration is throttled *and* priced) | `lib/agent/billing-middleware.ts` |
+| Data gateway (`/api/data/*`, soft auth, no billing) | Per-IP Upstash sliding-window limit at the middleware chokepoint; service-key callers exempt; fails open | `lib/ratelimit/data-gateway-rate-limit.ts`, `middleware.ts` (`DATA_GATEWAY_RPM`, default 120/min) |
+| Raw-field surface | No multi-symbol raw export exists — raw is per-symbol only (B(e) gating above), so single-call dataset reconstruction is structurally impossible | see B(e) |
+| Public endpoints (`skipBilling`) | Per-IP rate limit | `lib/agent/billing-middleware.ts` |
+
+Tests: `tests/data-gateway-rate-limit.test.ts`.
+
+**Contractual:** B(g) also calls for *contractual* safeguards (end users bound
+against scraping / redistribution). The API Terms of Service / acceptable-use
+clause is the contractual half — see follow-up below.
+
+## Open follow-ups
+
+- **Contractual AUP clause** (B(g) contractual half): ensure the published API
+  Terms include explicit no-scraping / no-bulk-extraction / no-redistribution-of-
+  raw-data language. Lives on the public site (RM_ORG), not this repo.
+- The €350→€700/mo step-up is intro-rate expiry (~May 2027), not a redistribution
+  charge — renegotiate or re-confirm scope before then if desired.

--- a/lib/ratelimit/data-gateway-rate-limit.ts
+++ b/lib/ratelimit/data-gateway-rate-limit.ts
@@ -1,0 +1,83 @@
+import { Ratelimit } from "@upstash/ratelimit";
+import { Redis } from "@upstash/redis";
+import { isUpstashRedisConfigured } from "@/lib/upstash-redis-config";
+
+/**
+ * EODHD Exhibit B(g) safeguard — anti-scraping throttle for the data gateway.
+ *
+ * The `/api/data/*` gateway uses soft auth (`verifyGatewayAuth`) and does NOT go
+ * through `withBilling`, so it has no per-key rate limiter. Without a throttle a
+ * client could systematically harvest the derived surface (and probe raw fields)
+ * symbol-by-symbol. This adds a per-IP sliding window at the middleware
+ * chokepoint, mirroring the existing playground limiter.
+ *
+ * - First-party server-to-server callers (the gateway service key) are exempt —
+ *   SSR, sync jobs, and internal fan-out must not be throttled.
+ * - Fails OPEN if Upstash is unconfigured or unavailable (same posture as the
+ *   billing limiter): availability over enforcement.
+ */
+
+const DATA_GATEWAY_RPM = Number(process.env.DATA_GATEWAY_RPM ?? 120);
+
+let _limiter: Ratelimit | null | undefined;
+
+function getLimiter(): Ratelimit | null {
+  if (_limiter !== undefined) return _limiter;
+  _limiter = null;
+  if (!isUpstashRedisConfigured()) return _limiter;
+  const redis = new Redis({
+    url: process.env.UPSTASH_REDIS_REST_URL!,
+    token: process.env.UPSTASH_REDIS_REST_TOKEN!,
+  });
+  _limiter = new Ratelimit({
+    redis,
+    limiter: Ratelimit.slidingWindow(DATA_GATEWAY_RPM, "60 s"),
+    prefix: "rl:data-gateway",
+  });
+  return _limiter;
+}
+
+/** True when the request carries the gateway service key (first-party, exempt). */
+function isServiceKey(authHeader: string | null): boolean {
+  const key = process.env.RISKMODELS_API_SERVICE_KEY;
+  if (!key || !authHeader) return false;
+  return authHeader.replace(/^Bearer\s+/i, "").trim() === key;
+}
+
+/** Best-effort client IP from proxy headers (Vercel sets x-forwarded-for). */
+export function clientIp(headers: Headers): string {
+  const xff = headers.get("x-forwarded-for");
+  if (xff) {
+    const first = xff.split(",")[0]?.trim();
+    if (first) return first;
+  }
+  return headers.get("x-real-ip")?.trim() || "unknown";
+}
+
+export interface DataGatewayRateLimitResult {
+  ok: boolean;
+  retryAfterSec?: number;
+  limit?: number;
+}
+
+/**
+ * Check the data-gateway rate limit for a request. Returns `{ ok: true }` for
+ * exempt (service key), unconfigured (dev), or under-limit requests; otherwise
+ * `{ ok: false, retryAfterSec, limit }`.
+ */
+export async function checkDataGatewayRateLimit(
+  headers: Headers,
+): Promise<DataGatewayRateLimitResult> {
+  if (isServiceKey(headers.get("authorization"))) return { ok: true };
+  const lim = getLimiter();
+  if (!lim) return { ok: true };
+  try {
+    const r = await lim.limit(`ip:${clientIp(headers)}`);
+    if (r.success) return { ok: true };
+    const retryAfterSec = Math.max(1, Math.ceil((r.reset - Date.now()) / 1000));
+    return { ok: false, retryAfterSec, limit: DATA_GATEWAY_RPM };
+  } catch (err) {
+    console.error("[data-gateway-rl] fail open", err);
+    return { ok: true };
+  }
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,5 +1,6 @@
 import { createServerClient } from '@supabase/ssr';
 import { NextResponse, type NextRequest } from 'next/server';
+import { checkDataGatewayRateLimit } from '@/lib/ratelimit/data-gateway-rate-limit';
 
 export async function middleware(request: NextRequest) {
   // Internal render route used by Playwright — skip Supabase session refresh.
@@ -8,6 +9,26 @@ export async function middleware(request: NextRequest) {
     const requestHeaders = new Headers(request.headers);
     requestHeaders.set('x-pathname', request.nextUrl.pathname);
     return NextResponse.next({ request: { headers: requestHeaders } });
+  }
+
+  // EODHD Exhibit B(g) safeguard: the soft-auth /api/data/* gateway has no
+  // per-key limiter (it does not use withBilling), so throttle it per-IP to
+  // prevent systematic scraping / dataset reconstruction. Service-key
+  // (first-party) callers are exempt; fails open if Upstash is unavailable.
+  if (request.nextUrl.pathname.startsWith('/api/data/')) {
+    const rl = await checkDataGatewayRateLimit(request.headers);
+    if (!rl.ok) {
+      return NextResponse.json(
+        { error: 'Rate limit exceeded' },
+        {
+          status: 429,
+          headers: {
+            'Retry-After': String(rl.retryAfterSec ?? 60),
+            'X-RateLimit-Limit': String(rl.limit ?? ''),
+          },
+        },
+      );
+    }
   }
 
   // Supabase magic link falls back to site root when /auth/callback isn't in the allowlist.

--- a/tests/data-gateway-rate-limit.test.ts
+++ b/tests/data-gateway-rate-limit.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  checkDataGatewayRateLimit,
+  clientIp,
+} from "@/lib/ratelimit/data-gateway-rate-limit";
+
+/**
+ * EODHD Exhibit B(g) anti-scraping throttle on the /api/data/* gateway.
+ * These tests cover the pure logic (IP extraction, service-key exemption,
+ * fail-open). The Upstash-backed counting path is exercised in integration.
+ */
+
+function headers(map: Record<string, string>): Headers {
+  return new Headers(map);
+}
+
+describe("clientIp", () => {
+  it("takes the first entry of x-forwarded-for", () => {
+    expect(clientIp(headers({ "x-forwarded-for": "1.2.3.4, 5.6.7.8" }))).toBe("1.2.3.4");
+  });
+  it("falls back to x-real-ip", () => {
+    expect(clientIp(headers({ "x-real-ip": "9.9.9.9" }))).toBe("9.9.9.9");
+  });
+  it("returns 'unknown' when no IP headers are present", () => {
+    expect(clientIp(headers({}))).toBe("unknown");
+  });
+});
+
+describe("checkDataGatewayRateLimit", () => {
+  const ORIG_KEY = process.env.RISKMODELS_API_SERVICE_KEY;
+  const ORIG_URL = process.env.UPSTASH_REDIS_REST_URL;
+  beforeEach(() => {
+    process.env.RISKMODELS_API_SERVICE_KEY = "svc-secret";
+    // Ensure Upstash is treated as unconfigured so we never hit the network.
+    delete process.env.UPSTASH_REDIS_REST_URL;
+  });
+  afterEach(() => {
+    if (ORIG_KEY === undefined) delete process.env.RISKMODELS_API_SERVICE_KEY;
+    else process.env.RISKMODELS_API_SERVICE_KEY = ORIG_KEY;
+    if (ORIG_URL === undefined) delete process.env.UPSTASH_REDIS_REST_URL;
+    else process.env.UPSTASH_REDIS_REST_URL = ORIG_URL;
+  });
+
+  it("exempts first-party service-key callers", async () => {
+    const r = await checkDataGatewayRateLimit(headers({ authorization: "Bearer svc-secret" }));
+    expect(r.ok).toBe(true);
+  });
+
+  it("fails open when Upstash is not configured", async () => {
+    const r = await checkDataGatewayRateLimit(headers({ "x-forwarded-for": "1.2.3.4" }));
+    expect(r.ok).toBe(true);
+  });
+});


### PR DESCRIPTION
## Why

Closes the last open item from the EODHD license audit (BWMACRO **H.69**). Exhibit B(g) of the signed Data Services Agreement requires *"reasonable technical and contractual safeguards … to prevent bulk download, systematic scraping, or reconstruction of the Services Data."*

The app already had **mature per-key rate limiting + metered cost** in `withBilling` — but the `/api/data/*` gateway uses soft auth (`verifyGatewayAuth`) and **does not go through `withBilling`**, so it had **no throttle at all**. A client could systematically harvest the derived surface symbol-by-symbol.

## What

- **`lib/ratelimit/data-gateway-rate-limit.ts`** — per-IP Upstash sliding-window limiter (`DATA_GATEWAY_RPM`, default 120/min), reusing the existing Upstash infra (same pattern as the playground limiter). First-party **service-key callers are exempt** (SSR, sync jobs, internal fan-out); **fails open** if Upstash is unavailable — availability over enforcement, matching the billing limiter.
- **`middleware.ts`** — enforce on `/api/data/*` at the chokepoint (covers every gateway route at once); returns `429` + `Retry-After`.
- **`docs/legal/eodhd-data-license-safeguards.md`** — maps each control to Exhibit B(e)/(g) for the EODHD audit trail.

Raw fields (`price_close`, `market_cap`) are already **per-symbol-only** after PR #138, so no single-call dataset reconstruction exists. This adds the missing throttle on the iteration vector.

## Not in scope (follow-up)

Exhibit B(g) also calls for a **contractual** safeguard — a no-scraping / no-bulk-extraction clause in the published API Terms. That lives on the public site (RM_ORG), a separate repo. Tracked in H.69.

## Tests

- 5 new in `tests/data-gateway-rate-limit.test.ts` (IP extraction, service-key exemption, fail-open) — green.
- Full relevant suite green; typecheck clean (only pre-existing `.next/types` docs errors); lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)