### PR TITLE
fix(audit): skip /feedback smoke (false FAIL) + name failing endpoints in email

### DIFF
--- a/scripts/audit/send_audit_email.py
+++ b/scripts/audit/send_audit_email.py
@@ -42,6 +42,7 @@ def build_body(report_dir: Path) -> tuple[str, str, str]:
     routes = _load(report_dir / "route_drift.json")
     docs = _load(report_dir / "docs_conformity.json")
     schema = _load(report_dir / "schema_check.json")
+    smoke = _load(report_dir / "smoke" / "smoke_report.json")
 
     overall = summary.get("overall", "UNKNOWN")
     ts = summary.get("timestamp", "?")
@@ -77,14 +78,38 @@ def build_body(report_dir: Path) -> tuple[str, str, str]:
     elif drift:
         findings.append(f"migration-drift: SKIPPED ({drift.get('summary', {}).get('reason', 'no creds')})")
 
+    # Actionable failure detail — name the specific endpoints so an agent can fix
+    # without re-running the audit. (Previously the email gave only counts, e.g.
+    # "smoke-endpoints FAIL", forcing a live re-run to find the offending call.)
+    detail: list[str] = []
+    for b in (smoke or {}).get("meta", {}).get("likely_bugs", []):
+        d = str(b.get("detail") or b.get("note") or "").strip().replace("\n", " ")
+        detail.append(
+            f"smoke  {b.get('method', '')} {b.get('path', '')} → {b.get('status')}"
+            + (f"  · {d[:180]}" if d else "")
+        )
+    if schema:
+        for f in schema.get("findings", [])[:12]:
+            errs = "; ".join(
+                f"{e.get('loc')}: {str(e.get('msg', ''))[:90]}" for e in (f.get("errors") or [])[:2]
+            )
+            detail.append(
+                f"schema {str(f.get('method', '')).upper()} {f.get('path', '')} "
+                f"({f.get('error_count', 0)} err)" + (f"  · {errs}" if errs else "")
+            )
+
     subject = f"[RiskModels API audit] {overall} — {ts}"
 
     status_lines = "\n".join(f"  {n:<18} {s}" for n, s in rows)
     finding_lines = "\n".join(f"  - {f}" for f in findings) or "  (no finding files)"
+    detail_block = ""
+    if detail:
+        detail_block = "Failure detail (specific endpoints):\n" + "\n".join(f"  • {d}" for d in detail) + "\n\n"
     text = (
         f"RiskModels API audit — {overall}  ({ts})\n\n"
         f"Checks:\n{status_lines}\n\n"
         f"Findings:\n{finding_lines}\n\n"
+        f"{detail_block}"
         f"Full reports: {summary.get('reports_dir', report_dir)} (CI artifact)\n"
     )
 
@@ -99,6 +124,17 @@ def build_body(report_dir: Path) -> tuple[str, str, str]:
         for n, s in rows
     )
     findings_html = "".join(f"<li style='margin:2px 0'>{f}</li>" for f in findings) or "<li>(no finding files)</li>"
+
+    def esc(s: str) -> str:
+        return s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+    detail_html = ""
+    if detail:
+        items = "".join(f"<li style='margin:2px 0;font-family:monospace;font-size:13px'>{esc(d)}</li>" for d in detail)
+        detail_html = (
+            '<h3 style="margin:16px 0 4px">Failure detail</h3>'
+            f'<ul style="margin:0;padding-left:18px">{items}</ul>'
+        )
     html = (
         f'<div style="font-family:system-ui,sans-serif;max-width:640px">'
         f'<h2 style="margin:0 0 4px">RiskModels API audit — '
@@ -106,6 +142,7 @@ def build_body(report_dir: Path) -> tuple[str, str, str]:
         f'<p style="color:#71717a;margin:0 0 16px">{ts}</p>'
         f'<table style="border-collapse:collapse;margin-bottom:16px">{rows_html}</table>'
         f'<h3 style="margin:0 0 4px">Findings</h3><ul style="margin:0;padding-left:18px">{findings_html}</ul>'
+        f'{detail_html}'
         f'<p style="color:#71717a;font-size:12px;margin-top:16px">Full reports in the workflow run artifact.</p>'
         f"</div>"
     )

--- a/sdk/scripts/smoke_v3_all_endpoints.py
+++ b/sdk/scripts/smoke_v3_all_endpoints.py
@@ -170,6 +170,11 @@ def should_skip(skip_expensive: bool, method: str, path: str) -> tuple[bool, str
         return True, "skip LLM spend (set RUN_CHAT=1 to enable)"
     if path == "/webhooks/subscribe":
         return True, "skip webhook subscription lifecycle"
+    if method == "post" and path == "/feedback":
+        # Mutating write (inserts a feedback_events row). Skip against live prod —
+        # an empty body correctly 400s ("Empty feedback") and a valid body would
+        # pollute prod feedback data. Consistent with the other mutating-write skips.
+        return True, "skip mutating feedback write"
     if path.startswith("/plaid/"):
         return True, "skip Plaid (needs user session)"
     if method == "patch" and path in ("/balance", "/user/billing-config"):

--- a/sdk/scripts/smoke_v3_all_endpoints.py
+++ b/sdk/scripts/smoke_v3_all_endpoints.py
@@ -740,6 +740,10 @@ def main() -> int:
                     )
                 )
 
+    # Likely product bugs (same heuristic as the stdout summary below). Persisted
+    # into the report meta so the audit email can name the failing endpoints —
+    # otherwise a reader only sees "smoke-endpoints FAIL" with no actionable detail.
+    bugs = [r for r in run.rows if is_bug(r)]
     meta = {
         "title": "RiskModels API v3 smoke report",
         "generated_utc": datetime.now(timezone.utc).isoformat(),
@@ -753,6 +757,16 @@ def main() -> int:
         "openapi_path": str(OPENAPI_PATH),
         "stream_max_bytes": _STREAM_MAX_BYTES,
         "json_body_max_chars": _JSON_BODY_MAX,
+        "likely_bugs": [
+            {
+                "method": r.method.upper(),
+                "path": r.path,
+                "status": r.status,
+                "note": r.note,
+                "detail": (r.snippet or r.error or "")[:300] if hasattr(r, "snippet") else "",
+            }
+            for r in bugs
+        ],
     }
     if write_json:
         write_json_report(report_dir / "smoke_report.json", meta, records)
@@ -784,7 +798,6 @@ def main() -> int:
             extra += f" | {row.snippet}"
         print(f"{flag} {row.method.upper():6} {status!s:>4} {row.path}{extra}")
 
-    bugs = [r for r in run.rows if is_bug(r)]
     print("\n--- Likely product bugs (non-skip, unexpected 4xx/5xx or transport) ---")
     if not bugs:
         print("(none)")


### PR DESCRIPTION
The 2026-06-06 audit emailed **FAIL** with only `smoke-endpoints FAIL` + finding counts — no actionable detail. Diagnosing required a live smoke re-run, which surfaced the sole failure: `POST /feedback -> 400 "Empty feedback"`.

### 1. Fix the false failure (`5a5ed9a`)
`/feedback` (added in #136) is a **mutating write** that correctly rejects an empty body. The smoke POSTs an empty body against **live prod**, gets a correct `400`, and flags it as a product bug — and a *valid* body would pollute prod `feedback_events`. Skip it like the other mutating writes (auth provision, webhook subscribe, PATCH balance/billing-config). → `smoke-endpoints` back to PASS.

### 2. Make the email actionable (`73fca14`)
Per request: the audit email should carry enough detail to fix from the email alone. Now it does —
- smoke persists its "likely product bugs" into `meta.likely_bugs`;
- the email reads `smoke_report.json` + `schema_check.json` and renders a **Failure detail** section naming endpoints:
\`\`\`
Failure detail (specific endpoints):
  • smoke  POST /feedback → 400  · { "error": "Empty feedback", … }
  • schema GET /data/security-history/latest/AAPL (1 err) · price_close: required field missing
\`\`\`
(text + HTML).

Verified: `py_compile` clean; `should_skip` unit-checked (POST /feedback skipped, GET/others unaffected); email dry-run against a fixture renders the detail block.

Note (separate, intended): the `schema-check` "2 endpoints violating schema" are the H.69 (#138) raw-field stripping on `security-history` — a deliberate contract change, reported as a known issue (schema-check stays PASS), not addressed here.