### PR TITLE
feat(onboarding): no-terminal "set it up in this chat" + connector-by-URL

### DIFF
--- a/app/api-reference/page.tsx
+++ b/app/api-reference/page.tsx
@@ -383,29 +383,26 @@ export default function ApiReferencePage() {
                 <div>
                   <h2 className="text-2xl font-semibold tracking-tight mb-3">Fastest way to get started with agents</h2>
                   <p className="text-zinc-400 max-w-2xl">
-                    The RiskModels MCP server lets your agent directly call the decomposition engine. No manual endpoint hunting required.
+                    Paste one line into any AI chat (Claude, ChatGPT, Cursor). The agent reads riskmodels.app, wires itself up for the conversation, and tells you what it can do — no install, no terminal.
                   </p>
                 </div>
 
                 <div className="space-y-4">
                   <div>
-                    <div className="text-xs uppercase tracking-widest text-zinc-500 mb-2">Recommended first prompt (copy &amp; paste)</div>
+                    <div className="text-xs uppercase tracking-widest text-zinc-500 mb-2">Paste this into a fresh chat (copy &amp; paste)</div>
                     <div className="relative rounded-xl border border-zinc-800 bg-zinc-950 p-5 font-mono text-sm text-zinc-200 whitespace-pre-wrap">
-{`Load the RiskModels MCP server from riskmodels.app.
-
-Then analyze my situation and tell me the highest-leverage ways to use the RiskModels tools and API:
-
-[Describe your workflow or problem here — e.g. "I manage a 30-name long/short equity book with heavy tech and healthcare exposure. I want to measure residual vs factor risk on each name and generate ETF hedge suggestions."]`}
+{`Visit riskmodels.app and set it up to use in this chat, then tell me what you can analyze.`}
                     </div>
+                    <p className="text-xs text-zinc-500 mt-2">
+                      Want it permanently? In Claude Desktop or Cursor, open Settings → Connectors → Add custom connector and paste{' '}
+                      <code className="text-zinc-400">https://riskmodels.app/api/mcp/sse</code> (authorize with your{' '}
+                      <a href="/get-key" className="text-terminal hover:underline">key</a>).
+                    </p>
                   </div>
 
                   <div className="flex flex-wrap gap-3">
                     <button
-                      onClick={() => navigator.clipboard.writeText(`Load the RiskModels MCP server from riskmodels.app.
-
-Then analyze my situation and tell me the highest-leverage ways to use the RiskModels tools and API:
-
-[Describe your workflow or problem here — e.g. "I manage a 30-name long/short equity book with heavy tech and healthcare exposure. I want to measure residual vs factor risk on each name and generate ETF hedge suggestions."]`)}
+                      onClick={() => navigator.clipboard.writeText(`Visit riskmodels.app and set it up to use in this chat, then tell me what you can analyze.`)}
                       className="px-4 py-2 text-sm rounded-lg border border-zinc-700 hover:bg-zinc-900 transition-colors"
                     >
                       Copy agent prompt
@@ -431,9 +428,7 @@ Then analyze my situation and tell me the highest-leverage ways to use the RiskM
                     ].map((example, i) => (
                       <button
                         key={i}
-                        onClick={() => navigator.clipboard.writeText(`Load the RiskModels MCP server from riskmodels.app.
-
-Then analyze my situation and tell me the highest-leverage ways to use the RiskModels tools and API:
+                        onClick={() => navigator.clipboard.writeText(`Visit riskmodels.app and set it up to use in this chat. Then help me with this:
 
 ${example}`)}
                         className="text-left px-4 py-3 rounded-lg border border-zinc-800 hover:border-zinc-700 hover:bg-zinc-900/50 text-zinc-400 hover:text-zinc-200 transition-all"

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -85,6 +85,11 @@ export default async function RootLayout({
   return (
     <html lang="en" className="dark" suppressHydrationWarning>
       <head>
+        {/* Agent discovery: a bare fetch of riskmodels.app self-routes an AI agent to the
+            machine-readable entry points, so a human only ever has to say "riskmodels.app"
+            (never a path). Humans get the same pointer as a visible link in the Footer. */}
+        <link rel="alternate" type="text/plain" href="/llms.txt" title="RiskModels for AI agents (llms.txt)" />
+        <link rel="alternate" type="application/json" href="/.well-known/agent-manifest.json" title="RiskModels agent manifest" />
         {/* Google tag: last in <head>, just before </head> (see GoogleAdsTag) */}
         <GoogleAdsTag />
       </head>

--- a/content/docs/agent-integration.mdx
+++ b/content/docs/agent-integration.mdx
@@ -9,27 +9,49 @@ Use the RiskModels API with your AI assistant of choice to perform quant researc
 
 <div className="not-prose my-6 space-y-3">
 
-  <div className="rounded-xl border border-primary/40 bg-zinc-900/80 overflow-hidden">
+  <div className="rounded-xl border border-primary/50 bg-zinc-900/80 overflow-hidden">
     <div className="px-5 py-2 bg-primary/10 border-b border-primary/20">
-      <span className="text-xs font-semibold text-primary uppercase tracking-widest">Fastest — Start in 60 seconds</span>
+      <span className="text-xs font-semibold text-primary uppercase tracking-widest">Fastest — no terminal, use it in your AI chat</span>
+    </div>
+    <div className="px-5 pt-4 pb-2">
+      <span className="text-sm font-semibold text-zinc-100">Try it now (any chat: Claude, ChatGPT, Cursor)</span>
+      <p className="text-xs text-zinc-400 mt-1">Paste this into a fresh chat. The agent reads riskmodels.app, sets itself up for the conversation, and tells you what it can analyze. Nothing to install.</p>
+      <div className="flex items-center justify-between bg-zinc-950 border border-zinc-700 rounded-lg px-4 py-2.5 font-mono text-sm text-zinc-200 mt-2">
+        <span>Visit riskmodels.app and set it up to use in this chat, then tell me what you can analyze.</span>
+        <button onclick="navigator.clipboard.writeText('Visit riskmodels.app and set it up to use in this chat, then tell me what you can analyze.');this.textContent='✓';setTimeout(()=>this.textContent='Copy',1500)" className="ml-4 text-xs text-zinc-500 hover:text-zinc-200 transition-colors flex-shrink-0">Copy</button>
+      </div>
+    </div>
+    <div className="px-5 pb-4 pt-2">
+      <span className="text-sm font-semibold text-zinc-100">Keep it (Claude Desktop / Cursor, persistent)</span>
+      <p className="text-xs text-zinc-400 mt-1">Settings → Connectors → Add custom connector, then paste the hosted MCP URL. Authorize with a <code className="text-zinc-300">Bearer</code> key from <a href="/get-key" className="text-primary hover:underline">riskmodels.app/get-key</a>.</p>
+      <div className="flex items-center justify-between bg-zinc-950 border border-zinc-700 rounded-lg px-4 py-2.5 font-mono text-sm text-zinc-200 mt-2">
+        <span>https://riskmodels.app/api/mcp/sse</span>
+        <button onclick="navigator.clipboard.writeText('https://riskmodels.app/api/mcp/sse');this.textContent='✓';setTimeout(()=>this.textContent='Copy',1500)" className="ml-4 text-xs text-zinc-500 hover:text-zinc-200 transition-colors flex-shrink-0">Copy</button>
+      </div>
+    </div>
+  </div>
+
+  <div className="rounded-xl border border-zinc-800 bg-zinc-900/60 overflow-hidden">
+    <div className="px-5 py-2 bg-zinc-800/50 border-b border-zinc-800">
+      <span className="text-xs font-semibold text-zinc-400 uppercase tracking-widest">Developer — terminal install</span>
     </div>
     <div className="flex items-start gap-4 px-5 pt-4 pb-2">
       <svg className="w-7 h-7 text-zinc-300 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" /></svg>
       <div className="flex-1">
         <span className="text-sm font-semibold text-zinc-100">Any Terminal</span>
-        <p className="text-xs text-zinc-400 mt-1">Install the npm package globally. No AI configuration needed — your agent can also call these commands from its terminal panel.</p>
+        <p className="text-xs text-zinc-400 mt-1">Install the CLI globally, then let it auto-wire Claude Desktop, Cursor, Codex, and VS Code in one command.</p>
       </div>
     </div>
     <div className="px-5 pb-4 space-y-2">
       <div className="flex items-center justify-between bg-zinc-950 border border-zinc-700 rounded-lg px-4 py-2.5 font-mono text-sm text-zinc-200">
-        <span>npm install -g riskmodels-cli</span>
-        <button onclick="navigator.clipboard.writeText('npm install -g riskmodels-cli');this.textContent='✓';setTimeout(()=>this.textContent='Copy',1500)" className="ml-4 text-xs text-zinc-500 hover:text-zinc-200 transition-colors flex-shrink-0">Copy</button>
+        <span>npm install -g riskmodels@latest</span>
+        <button onclick="navigator.clipboard.writeText('npm install -g riskmodels@latest');this.textContent='✓';setTimeout(()=>this.textContent='Copy',1500)" className="ml-4 text-xs text-zinc-500 hover:text-zinc-200 transition-colors flex-shrink-0">Copy</button>
       </div>
       <div className="flex items-center justify-between bg-zinc-950 border border-zinc-700 rounded-lg px-4 py-2.5 font-mono text-sm text-zinc-200">
-        <span>riskmodels config set apiKey YOUR_API_KEY</span>
-        <button onclick="navigator.clipboard.writeText('riskmodels config set apiKey YOUR_API_KEY');this.textContent='✓';setTimeout(()=>this.textContent='Copy',1500)" className="ml-4 text-xs text-zinc-500 hover:text-zinc-200 transition-colors flex-shrink-0">Copy</button>
+        <span>riskmodels install</span>
+        <button onclick="navigator.clipboard.writeText('riskmodels install');this.textContent='✓';setTimeout(()=>this.textContent='Copy',1500)" className="ml-4 text-xs text-zinc-500 hover:text-zinc-200 transition-colors flex-shrink-0">Copy</button>
       </div>
-      <p className="text-xs text-zinc-600 pt-1">Get your API key at <a href="/get-key" className="text-primary hover:underline">riskmodels.app/get-key</a></p>
+      <p className="text-xs text-zinc-600 pt-1"><code className="text-zinc-400">riskmodels install</code> prompts for your key (get one at <a href="/get-key" className="text-primary hover:underline">riskmodels.app/get-key</a>) and stores it in <code className="text-zinc-400">~/.config/riskmodels/config.json</code>.</p>
     </div>
   </div>
 
@@ -89,7 +111,19 @@ the API or SDK and generate a Python plot.
 
 <h2 id="mcp-setup">MCP Server Setup</h2>
 
-Add to `.cursor/mcp.json` (or your Claude Desktop / Zed config):
+### No terminal — hosted connector (recommended)
+
+In **Claude Desktop** or **Cursor**, open **Settings → Connectors → Add custom connector** and paste the hosted MCP URL:
+
+```
+https://riskmodels.app/api/mcp/sse
+```
+
+Authorize with `Authorization: Bearer <your key>` (get one at [/get-key](/get-key)), and ensure the client sends `Accept: application/json, text/event-stream`. Nothing to build, clone, or install — discovery tools are free; data tools bill per underlying REST route.
+
+### Local — build from source (developer)
+
+If you're hacking on the server itself, add to `.cursor/mcp.json` (or your Claude Desktop / Zed config):
 
 ```bash
 # Build the MCP server first (required before first use)

--- a/lib/llms-txt.ts
+++ b/lib/llms-txt.ts
@@ -18,6 +18,19 @@ ETF hedge ratios, metrics, portfolio snapshots, and a hosted MCP surface.
 
 **No sign-in yet?** If this host publishes a shared demo key, you will find it under **Public sample API key** below — use it as \`RISKMODELS_API_KEY\` / \`Authorization: Bearer …\` for MAG7 examples. That path is meant for browser agents that cannot run \`POST /api/auth/provision-free\`.
 
+## If a human asks you to set up RiskModels
+
+You are an AI assistant reading this because someone pointed you at riskmodels.app. There are two distinct requests — handle the one they made:
+
+**1. "Set it up for this chat" / "help me analyze …"** — set yourself up now, in this conversation, with no install:
+- Discovery is free and needs no key — read the endpoints and capabilities in this file.
+- For live data on the Magnificent 7, use the **Public sample API key** below (if present) as \`Authorization: Bearer …\`. If you can make HTTP POSTs, you may self-provision a free key: \`POST /api/auth/provision-free\`. For the full ~3,000-name universe, tell the human to grab a free key at https://riskmodels.app/get-key (browser, no terminal).
+- Make one real call to confirm the connection, then tell the human what you can analyze and ask what they want to look at. **Do not tell a human to open a terminal for this case.**
+
+**2. "Help me set it up" / "add this to my Claude/Cursor"** — they want RiskModels available permanently. You cannot edit their app's config yourself, so relay these steps:
+- **No terminal (recommended):** in Claude Desktop or Cursor, open **Settings → Connectors → Add custom connector** and paste this URL: \`https://riskmodels.app/api/mcp/sse\`. For auth, use \`Authorization: Bearer <their key>\` (key from https://riskmodels.app/get-key). Send header \`Accept: application/json, text/event-stream\`.
+- **Developer (terminal):** \`npm install -g riskmodels@latest\` then \`riskmodels install\` — auto-wires Claude Desktop, Cursor, Codex, and VS Code and stores the key in ~/.config/riskmodels/config.json.
+
 ## Magnificent 7 (MAG7)
 
 These seven US equities are the usual demo / smoke-test set (landing charts, optional public sample key, \`mag7=true\` on tickers):
@@ -26,7 +39,9 @@ ${mag7BulletList()}
 
 One-line form: **${mag7Csv}**. For Alphabet use **GOOG** in examples; **GOOGL** aliases to the same name in the API. The public JSON from \`GET /api/tickers?mag7=true\` may list **GOOGL**; both work with \`GET /api/metrics/{ticker}\` and related routes.
 
-## First-time setup (human runs once in a terminal)
+## Developer setup — CLI (human runs once in a terminal)
+
+This is the developer path for case 2 above; non-technical humans should prefer the no-terminal connector.
 
 - Install Node.js LTS (https://nodejs.org).
 - Get an API key: https://riskmodels.app/get-key


### PR DESCRIPTION
## Why

We have two distinct MCP audiences but only the **agent** path was well-defined. For **humans**, every documented setup assumed a terminal (`npm` / clone + build), and the shipped landing "first prompt" (*"Load the RiskModels MCP server…"*) assumed setup was already done — a dead end for a non-technical user who just opened Claude or ChatGPT.

This PR makes the **human** path frictionless and splits it into two rungs:

- **Try it now** (any web chat): paste one line → the agent reads `riskmodels.app`, wires itself up *for the conversation*, and reports what it can do. No install.
- **Keep it** (Claude Desktop / Cursor): add the hosted MCP server by **URL** through the connector UI — no terminal.
- **Developer**: the existing `riskmodels install` CLI flow.

## Changes

- **`app/layout.tsx`** — `<link rel="alternate">` to `/llms.txt` + `/.well-known/agent-manifest.json` in the root `<head>` so a bare fetch of `riskmodels.app` self-routes an agent. Humans never type a path (the Footer already carries the visible `llms.txt` link).
- **`lib/llms-txt.ts`** — new **"If a human asks you to set up RiskModels"** section that routes the agent between *set-it-up-for-this-chat* (no install; demo key / `provision-free`; one confirm call) and *help-me-set-it-up-permanently* (connector URL + `riskmodels install`). Terminal section retitled as the developer path.
- **`app/api-reference/page.tsx`** — replaced the first-prompt block with **"Visit riskmodels.app and set it up to use in this chat, then tell me what you can analyze."** + a connector hint; example starters reframed to setup-then-ask.
- **`content/docs/agent-integration.mdx`** — no-terminal card (try-now prompt + connector URL) is now the **first** option; terminal card relabeled "Developer"; **fixed stale `riskmodels-cli` / `config set apiKey` → `riskmodels@latest` / `riskmodels install`**; added hosted connector-by-URL as the recommended MCP setup.

## Verification

- `tsc --noEmit` clean on all four changed files (only pre-existing `.next/types` stale-cache errors for an untouched docs route).
- **Demo key already live in prod** — `LLMS_TXT_PUBLIC_AGENT_KEY` is set in Doppler `erm3/prd`, synced to Vercel; live `riskmodels.app/llms.txt` serves the key block and it returns **HTTP 200** on `GET /api/metrics/{NVDA,AAPL}`. The try-now path works today.

## Before merge

- [ ] Verify connector-by-URL against the live Claude Desktop / Cursor connector UIs (the Accept-header 406 caveat is `EventSource`-only; native connectors send the right header).

Backlog: BWMACRO `MASTER_BACKLOG.md` **G.20**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)