### PR TITLE
fix(onboarding): correct connector-by-URL claim (needs OAuth we don't have yet)

### DIFF
--- a/app/api-reference/page.tsx
+++ b/app/api-reference/page.tsx
@@ -396,7 +396,7 @@ export default function ApiReferencePage() {
                     <p className="text-xs text-zinc-500 mt-2">
                       Want it permanently in Claude or Cursor? Run{' '}
                       <code className="text-zinc-400">npx -y riskmodels@latest install</code> once (needs Node) — see the{' '}
-                      <a href="/docs/agent-integration" className="text-terminal hover:underline">agent integration guide</a>.
+                      <Link href="/docs/agent-integration" className="text-terminal hover:underline">agent integration guide</Link>.
                     </p>
                   </div>
 

--- a/app/api-reference/page.tsx
+++ b/app/api-reference/page.tsx
@@ -394,9 +394,9 @@ export default function ApiReferencePage() {
 {`Visit riskmodels.app and set it up to use in this chat, then tell me what you can analyze.`}
                     </div>
                     <p className="text-xs text-zinc-500 mt-2">
-                      Want it permanently? In Claude Desktop or Cursor, open Settings → Connectors → Add custom connector and paste{' '}
-                      <code className="text-zinc-400">https://riskmodels.app/api/mcp/sse</code> (authorize with your{' '}
-                      <a href="/get-key" className="text-terminal hover:underline">key</a>).
+                      Want it permanently in Claude or Cursor? Run{' '}
+                      <code className="text-zinc-400">npx -y riskmodels@latest install</code> once (needs Node) — see the{' '}
+                      <a href="/docs/agent-integration" className="text-terminal hover:underline">agent integration guide</a>.
                     </p>
                   </div>
 

--- a/content/docs/agent-integration.mdx
+++ b/content/docs/agent-integration.mdx
@@ -23,11 +23,12 @@ Use the RiskModels API with your AI assistant of choice to perform quant researc
     </div>
     <div className="px-5 pb-4 pt-2">
       <span className="text-sm font-semibold text-zinc-100">Keep it (Claude Desktop / Cursor, persistent)</span>
-      <p className="text-xs text-zinc-400 mt-1">Settings → Connectors → Add custom connector, then paste the hosted MCP URL. Authorize with a <code className="text-zinc-300">Bearer</code> key from <a href="/get-key" className="text-primary hover:underline">riskmodels.app/get-key</a>.</p>
+      <p className="text-xs text-zinc-400 mt-1">One command wires it into every supported client. Needs Node installed.</p>
       <div className="flex items-center justify-between bg-zinc-950 border border-zinc-700 rounded-lg px-4 py-2.5 font-mono text-sm text-zinc-200 mt-2">
-        <span>https://riskmodels.app/api/mcp/sse</span>
-        <button onclick="navigator.clipboard.writeText('https://riskmodels.app/api/mcp/sse');this.textContent='✓';setTimeout(()=>this.textContent='Copy',1500)" className="ml-4 text-xs text-zinc-500 hover:text-zinc-200 transition-colors flex-shrink-0">Copy</button>
+        <span>npx -y riskmodels@latest install</span>
+        <button onclick="navigator.clipboard.writeText('npx -y riskmodels@latest install');this.textContent='✓';setTimeout(()=>this.textContent='Copy',1500)" className="ml-4 text-xs text-zinc-500 hover:text-zinc-200 transition-colors flex-shrink-0">Copy</button>
       </div>
+      <p className="text-xs text-zinc-600 mt-2">Native "Add custom connector by URL" needs OAuth, which the hosted server doesn't implement yet — until then use the command above (or the <code className="text-zinc-500">mcp-remote</code> proxy in MCP setup below).</p>
     </div>
   </div>
 
@@ -111,15 +112,25 @@ the API or SDK and generate a Python plot.
 
 <h2 id="mcp-setup">MCP Server Setup</h2>
 
-### No terminal — hosted connector (recommended)
+### Hosted — via the mcp-remote proxy (no local build)
 
-In **Claude Desktop** or **Cursor**, open **Settings → Connectors → Add custom connector** and paste the hosted MCP URL:
+The hosted endpoint at `https://riskmodels.app/api/mcp/sse` authenticates with a **Bearer API key**. Add it to your client's MCP config through the `mcp-remote` proxy:
 
+```json
+{
+  "mcpServers": {
+    "riskmodels": {
+      "command": "npx",
+      "args": ["-y", "mcp-remote", "https://riskmodels.app/api/mcp/sse"],
+      "env": { "AUTHORIZATION": "Bearer <your key>" }
+    }
+  }
+}
 ```
-https://riskmodels.app/api/mcp/sse
-```
 
-Authorize with `Authorization: Bearer <your key>` (get one at [/get-key](/get-key)), and ensure the client sends `Accept: application/json, text/event-stream`. Nothing to build, clone, or install — discovery tools are free; data tools bill per underlying REST route.
+Get a key at [/get-key](/get-key). Discovery tools are free; data tools bill per underlying REST route.
+
+> **Native connector-by-URL is not supported yet.** The "Add custom connector" flow in Claude Desktop / Cursor expects OAuth (Dynamic Client Registration), which this server does not implement — it uses Bearer API keys, so pasting the URL into that UI fails to register. Until MCP OAuth ships, use the `mcp-remote` config above or `riskmodels install`. For zero-setup access today, use the try-now prompt at the top of this page.
 
 ### Local — build from source (developer)
 

--- a/lib/llms-txt.ts
+++ b/lib/llms-txt.ts
@@ -27,9 +27,10 @@ You are an AI assistant reading this because someone pointed you at riskmodels.a
 - For live data on the Magnificent 7, use the **Public sample API key** below (if present) as \`Authorization: Bearer …\`. If you can make HTTP POSTs, you may self-provision a free key: \`POST /api/auth/provision-free\`. For the full ~3,000-name universe, tell the human to grab a free key at https://riskmodels.app/get-key (browser, no terminal).
 - Make one real call to confirm the connection, then tell the human what you can analyze and ask what they want to look at. **Do not tell a human to open a terminal for this case.**
 
-**2. "Help me set it up" / "add this to my Claude/Cursor"** — they want RiskModels available permanently. You cannot edit their app's config yourself, so relay these steps:
-- **No terminal (recommended):** in Claude Desktop or Cursor, open **Settings → Connectors → Add custom connector** and paste this URL: \`https://riskmodels.app/api/mcp/sse\`. For auth, use \`Authorization: Bearer <their key>\` (key from https://riskmodels.app/get-key). Send header \`Accept: application/json, text/event-stream\`.
-- **Developer (terminal):** \`npm install -g riskmodels@latest\` then \`riskmodels install\` — auto-wires Claude Desktop, Cursor, Codex, and VS Code and stores the key in ~/.config/riskmodels/config.json.
+**2. "Help me set it up" / "add this to my Claude/Cursor"** — they want RiskModels available permanently. You cannot edit their app's config yourself, so relay these steps. Persistent setup currently needs a one-time terminal step (the native connector-by-URL UI is not supported yet — see note):
+- **Simplest (one command):** \`npm install -g riskmodels@latest\` then \`riskmodels install\` — prompts for the key, auto-wires Claude Desktop, Cursor, Codex, and VS Code, and stores the key in ~/.config/riskmodels/config.json.
+- **Hosted, no local build:** add the \`mcp-remote\` proxy to the client's MCP config — \`npx -y mcp-remote https://riskmodels.app/api/mcp/sse\` with env \`AUTHORIZATION=Bearer <their key>\` (key from https://riskmodels.app/get-key).
+- **Note:** the native "Add custom connector by URL" flow in Claude Desktop / Cursor expects OAuth, which this server does not implement yet (it authenticates with Bearer API keys). Pasting the URL into that UI will fail to register. For a zero-setup experience today, use case 1 above instead.
 
 ## Magnificent 7 (MAG7)
 


### PR DESCRIPTION
Follow-up to #141, which merged before this correction commit landed — so `main` currently ships a connector-by-URL instruction that **fails** in the real client UIs.

## What & why

Verifying #141 against live Claude Desktop / Cursor: the native **"Add custom connector by URL"** flow returns *"Couldn't register with RiskModels's sign-in service."* Root cause — that flow follows the MCP Authorization spec (OAuth + Dynamic Client Registration), but `/api/mcp/sse` authenticates with **Bearer API keys** and exposes no OAuth metadata:
- `POST /api/mcp/sse` unauth → `401` with no `WWW-Authenticate` header
- `/.well-known/oauth-protected-resource` + `/.well-known/oauth-authorization-server` (± path-suffixed) → all `404`

So the client falls back to DCR, finds no auth server, and fails.

## Changes (docs only — same 3 files as #141)

- **`lib/llms-txt.ts`** — case 2 ("help me set it up") now relays `riskmodels install` (simplest) or the `mcp-remote` proxy as the persistent paths, with an explicit note that connector-by-URL needs OAuth we don't implement yet. Zero-setup = the case-1 paste prompt.
- **`app/api-reference/page.tsx`** — persistent hint points to `npx -y riskmodels@latest install`.
- **`content/docs/agent-integration.mdx`** — "Keep it" card uses the install command; MCP setup documents the `mcp-remote` proxy + a blockquote on the OAuth gap.

The genuinely no-terminal **try-now paste prompt is unaffected and works in prod today.**

The real fix that unlocks connector-by-URL is **MCP OAuth** — tracked separately (BWMACRO backlog E.20), scoped to also offer the user a choice of OAuth / paste-API-key / MAG7-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)