### PR TITLE
feat(mcp-oauth): Phase A — OAuth discovery surface for connector-by-URL

### DIFF
--- a/app/.well-known/oauth-authorization-server/route.ts
+++ b/app/.well-known/oauth-authorization-server/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from "next/server";
+import { getAppUrl } from "@/lib/app-url";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /.well-known/oauth-authorization-server — RFC 8414 authorization-server metadata.
+ *
+ * Advertised by the protected-resource metadata so an MCP client can run the
+ * OAuth authorization-code + PKCE + Dynamic Client Registration flow against
+ * this origin (`.app`). Sign-in reuses `.app`'s own Supabase Google/GitHub/
+ * magic-link flow — `.net` (the no-code workspace) is never involved.
+ *
+ * Phase A FORWARD-DECLARES the endpoints below; they return 404 until:
+ *   - Phase B: `/oauth/authorize` + `/api/oauth/token` (authorization_code + PKCE)
+ *   - Phase C: `/api/oauth/register` (Dynamic Client Registration, RFC 7591)
+ * This is intentional — Phase A only proves the discovery handshake is well-formed.
+ */
+export function GET() {
+  const base = getAppUrl().replace(/\/$/, "");
+  return NextResponse.json(
+    {
+      issuer: base,
+      authorization_endpoint: `${base}/oauth/authorize`,
+      token_endpoint: `${base}/api/oauth/token`,
+      registration_endpoint: `${base}/api/oauth/register`,
+      response_types_supported: ["code"],
+      grant_types_supported: ["authorization_code", "refresh_token"],
+      code_challenge_methods_supported: ["S256"],
+      token_endpoint_auth_methods_supported: ["none"],
+      scopes_supported: ["mcp:read"],
+    },
+    { headers: { "Cache-Control": "public, max-age=300" } },
+  );
+}

--- a/app/.well-known/oauth-protected-resource/api/mcp/sse/route.ts
+++ b/app/.well-known/oauth-protected-resource/api/mcp/sse/route.ts
@@ -1,0 +1,10 @@
+/**
+ * GET /.well-known/oauth-protected-resource/api/mcp/sse
+ *
+ * Path-suffixed variant of the RFC 9728 protected-resource metadata. Per the
+ * MCP Authorization spec some clients build the well-known URL by inserting the
+ * protected resource's path (`/api/mcp/sse`) after `/.well-known/...`. Serve the
+ * identical document from both locations. Single source of truth: the parent
+ * `oauth-protected-resource/route.ts`.
+ */
+export { GET, dynamic } from "../../../route";

--- a/app/.well-known/oauth-protected-resource/route.ts
+++ b/app/.well-known/oauth-protected-resource/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from "next/server";
+import { getAppUrl } from "@/lib/app-url";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /.well-known/oauth-protected-resource — RFC 9728 protected-resource metadata.
+ *
+ * Points MCP clients (Claude Desktop, Cursor) at the authorization server so the
+ * native "Add custom connector by URL" flow can discover how to authenticate,
+ * instead of failing at client registration against a presumed sign-in service.
+ *
+ * Phase A (MCP OAuth) — discovery surface only. The `/oauth/*` endpoints listed
+ * in the authorization-server metadata land in Phases B (authorization_code +
+ * PKCE + token) and C (Dynamic Client Registration). Tier-1 Bearer API keys
+ * continue to work unchanged.
+ */
+export function GET() {
+  const base = getAppUrl().replace(/\/$/, "");
+  return NextResponse.json(
+    {
+      resource: `${base}/api/mcp/sse`,
+      authorization_servers: [base],
+      bearer_methods_supported: ["header"],
+      resource_documentation: `${base}/docs/agent-integration`,
+    },
+    { headers: { "Cache-Control": "public, max-age=300" } },
+  );
+}

--- a/app/api/mcp/sse/route.ts
+++ b/app/api/mcp/sse/route.ts
@@ -20,6 +20,7 @@ import {
 } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
 import { createMcpServer } from "@/lib/mcp/server";
 import { authenticateMcpRequest } from "@/lib/mcp/auth";
+import { getAppUrl } from "@/lib/app-url";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -30,7 +31,11 @@ export const dynamic = "force-dynamic";
 // Raise this only after confirming the deployment tier supports longer.
 export const maxDuration = 60;
 
-function errorResponse(status: number, message: string): Response {
+function errorResponse(
+  status: number,
+  message: string,
+  extraHeaders?: Record<string, string>,
+): Response {
   return new Response(
     JSON.stringify({
       jsonrpc: "2.0",
@@ -39,14 +44,31 @@ function errorResponse(status: number, message: string): Response {
     }),
     {
       status,
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", ...(extraHeaders ?? {}) },
     },
   );
 }
 
+// RFC 9728 challenge so MCP clients (Claude Desktop / Cursor) discover the
+// authorization server on a 401 and can run the OAuth connect flow instead of
+// failing at client registration. Tier-1 Bearer API keys still authenticate
+// and never reach this branch.
+function wwwAuthenticateHeader(): Record<string, string> {
+  const base = getAppUrl().replace(/\/$/, "");
+  return {
+    "WWW-Authenticate": `Bearer resource_metadata="${base}/.well-known/oauth-protected-resource"`,
+  };
+}
+
 async function handle(req: NextRequest): Promise<Response> {
   const auth = await authenticateMcpRequest(req);
-  if (!auth.ok) return errorResponse(auth.status, auth.error);
+  if (!auth.ok) {
+    return errorResponse(
+      auth.status,
+      auth.error,
+      auth.status === 401 ? wwwAuthenticateHeader() : undefined,
+    );
+  }
 
   // Tools call back into our own REST endpoints. Prefer the explicit API URL
   // envs — `NEXT_PUBLIC_APP_URL` points to the portal (.net), not the API (.app).


### PR DESCRIPTION
First phase of **MCP OAuth** (backlog E.20, plan `mcp_oauth_three_tier_auth.md` §8) — the discovery layer that lets Claude Desktop / Cursor's native **"Add custom connector by URL"** flow get past the failure you hit (*"Couldn't register with RiskModels's sign-in service"*).

## What this does

Makes `.app` *discoverable* as an MCP authorization server. **No auth behavior changes** — Tier-1 Bearer API keys and the demo path are untouched; this only adds metadata + a challenge header.

- **`WWW-Authenticate` on the MCP 401** — `app/api/mcp/sse/route.ts` now returns `Bearer resource_metadata="…/.well-known/oauth-protected-resource"` on unauthenticated requests.
- **`/.well-known/oauth-protected-resource`** (RFC 9728) + a path-suffixed `/api/mcp/sse` variant some clients probe.
- **`/.well-known/oauth-authorization-server`** (RFC 8414) — forward-declares the `/oauth/*` endpoints.

`issuer`/`resource` resolve via `getAppUrl()` → `riskmodels.app` in prod, the preview origin on preview deploys.

## Honest boundary

Phase A **does not** make connector-by-URL fully work — it forward-declares `/oauth/authorize`, `/api/oauth/token`, `/api/oauth/register`, which **404 until Phases B/C**. It changes the connector's failure point from "discovery fails" to "registration 404" — that transition is the signal we're verifying, and it's no worse for any user (docs don't yet advertise the connector path).

## Test plan
- [ ] CI green (lint/typecheck/build)
- [ ] On the **preview** deploy: `GET /.well-known/oauth-protected-resource` + `/oauth-authorization-server` → 200 valid JSON; `POST /api/mcp/sse` unauth → 401 with `WWW-Authenticate`; with a key → 200 (no regression)
- [ ] In Claude Desktop, "Add custom connector" pointed at the **preview** `/api/mcp/sse` now advances to the registration step instead of failing at discovery

**Do not merge to main / update onboarding docs** until Phases B/C make the connector actually usable — this is a foundation PR, verified on preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)