### PR TITLE
feat(mcp-oauth): Phase B/C — authorization server (authz_code + PKCE + DCR)

### DIFF
--- a/app/api/oauth/authorize/decision/route.ts
+++ b/app/api/oauth/authorize/decision/route.ts
@@ -1,0 +1,97 @@
+/**
+ * POST /api/oauth/authorize/decision — handles the consent screen submission.
+ *
+ * Re-validates the client + redirect_uri server-side (never trusts the hidden
+ * form fields for security decisions) and re-derives the user from the session
+ * cookie. On "approve" it mints a single-use, PKCE-bound authorization code and
+ * 303-redirects back to the client's redirect_uri with `code` + `state`.
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { ensureStarterCredits } from "@/lib/agent/billing";
+import {
+  getClient,
+  redirectUriRegistered,
+  sha256,
+  randomToken,
+  AUTH_CODE_TTL_MS,
+  OAUTH_SCOPE,
+} from "@/lib/oauth/server";
+
+export const dynamic = "force-dynamic";
+
+function redirectTo(redirectUri: string, params: Record<string, string>): NextResponse {
+  const u = new URL(redirectUri);
+  for (const [k, v] of Object.entries(params)) if (v) u.searchParams.set(k, v);
+  return NextResponse.redirect(u.toString(), { status: 303 });
+}
+
+export async function POST(req: NextRequest) {
+  const form = await req.formData();
+  const clientId = String(form.get("client_id") ?? "");
+  const redirectUri = String(form.get("redirect_uri") ?? "");
+  const codeChallenge = String(form.get("code_challenge") ?? "");
+  const codeChallengeMethod = String(form.get("code_challenge_method") ?? "S256");
+  const scope = String(form.get("scope") ?? OAUTH_SCOPE);
+  const state = String(form.get("state") ?? "");
+  const decision = String(form.get("decision") ?? "");
+
+  // Re-validate client + redirect_uri against the DB — the form is attacker-controllable.
+  const client = await getClient(clientId);
+  if (!client || !redirectUriRegistered(client, redirectUri)) {
+    return new NextResponse("Invalid client or redirect_uri", { status: 400 });
+  }
+
+  if (decision !== "approve") {
+    return redirectTo(redirectUri, { error: "access_denied", state });
+  }
+  if (!codeChallenge || codeChallengeMethod !== "S256") {
+    return redirectTo(redirectUri, { error: "invalid_request", error_description: "PKCE S256 required", state });
+  }
+
+  // User identity comes from the session cookie, never the form.
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    // Session lost mid-flow — re-enter authorize, which routes to sign-in.
+    const qs = new URLSearchParams({
+      response_type: "code",
+      client_id: clientId,
+      redirect_uri: redirectUri,
+      code_challenge: codeChallenge,
+      code_challenge_method: codeChallengeMethod,
+      scope,
+      state,
+    });
+    return NextResponse.redirect(new URL(`/oauth/authorize?${qs.toString()}`, req.url), { status: 303 });
+  }
+
+  // Ensure a billing account exists so the token minted from this code can charge.
+  try {
+    await ensureStarterCredits(user.id);
+  } catch (e) {
+    console.error("[oauth/decision] ensureStarterCredits failed:", e);
+  }
+
+  const code = randomToken(32);
+  const admin = createAdminClient();
+  const { error } = await admin.from("oauth_auth_codes").insert({
+    code_hash: sha256(code),
+    user_id: user.id,
+    client_id: clientId,
+    redirect_uri: redirectUri,
+    code_challenge: codeChallenge,
+    code_challenge_method: codeChallengeMethod,
+    scope,
+    expires_at: new Date(Date.now() + AUTH_CODE_TTL_MS).toISOString(),
+  });
+  if (error) {
+    console.error("[oauth/decision] auth code insert failed:", error.message);
+    return new NextResponse("server_error", { status: 500 });
+  }
+
+  return redirectTo(redirectUri, { code, state });
+}

--- a/app/api/oauth/register/route.ts
+++ b/app/api/oauth/register/route.ts
@@ -1,0 +1,80 @@
+/**
+ * POST /api/oauth/register — Dynamic Client Registration (RFC 7591).
+ *
+ * MCP clients (Claude Desktop / Cursor) self-register here after discovering the
+ * authorization server. Public clients only: no client_secret is issued; the
+ * token endpoint relies on PKCE (token_endpoint_auth_method "none").
+ */
+import { NextRequest, NextResponse } from "next/server";
+import crypto from "crypto";
+import { createAdminClient } from "@/lib/supabase/admin";
+
+export const dynamic = "force-dynamic";
+
+const CORS: Record<string, string> = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type, Authorization",
+};
+
+export async function OPTIONS() {
+  return new NextResponse(null, { status: 204, headers: CORS });
+}
+
+// Absolute URI (https, or any scheme:// e.g. custom-app or http://localhost loopback).
+function isAbsoluteUri(u: unknown): u is string {
+  return typeof u === "string" && /^[a-z][a-z0-9+.-]*:\/\/.+/i.test(u);
+}
+
+export async function POST(req: NextRequest) {
+  let body: Record<string, unknown>;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json(
+      { error: "invalid_client_metadata", error_description: "Body must be JSON" },
+      { status: 400, headers: CORS },
+    );
+  }
+
+  const redirectUris = body?.redirect_uris;
+  if (!Array.isArray(redirectUris) || redirectUris.length === 0 || !redirectUris.every(isAbsoluteUri)) {
+    return NextResponse.json(
+      { error: "invalid_redirect_uri", error_description: "redirect_uris must be a non-empty array of absolute URIs" },
+      { status: 400, headers: CORS },
+    );
+  }
+
+  const clientId = crypto.randomUUID();
+  const clientName = typeof body?.client_name === "string" ? (body.client_name as string).slice(0, 200) : null;
+
+  const admin = createAdminClient();
+  const { error } = await admin.from("oauth_clients").insert({
+    client_id: clientId,
+    redirect_uris: redirectUris,
+    client_name: clientName,
+    grant_types: ["authorization_code", "refresh_token"],
+    response_types: ["code"],
+    token_endpoint_auth_method: "none",
+    metadata: body,
+  });
+
+  if (error) {
+    console.error("[oauth/register] insert error:", error.message);
+    return NextResponse.json({ error: "server_error" }, { status: 500, headers: CORS });
+  }
+
+  // RFC 7591 client information response.
+  return NextResponse.json(
+    {
+      client_id: clientId,
+      client_id_issued_at: Math.floor(Date.now() / 1000),
+      redirect_uris: redirectUris,
+      grant_types: ["authorization_code", "refresh_token"],
+      response_types: ["code"],
+      token_endpoint_auth_method: "none",
+      ...(clientName ? { client_name: clientName } : {}),
+    },
+    { status: 201, headers: { ...CORS, "Cache-Control": "no-store" } },
+  );
+}

--- a/app/api/oauth/token/route.ts
+++ b/app/api/oauth/token/route.ts
@@ -1,0 +1,189 @@
+/**
+ * POST /api/oauth/token — OAuth token endpoint.
+ *
+ * Grants:
+ *  - authorization_code: validates a single-use PKCE-bound code, consumes it,
+ *    and issues an access token. The access token IS a scoped `rm_user_*` key
+ *    minted into user_generated_api_keys, so it authenticates at /api/mcp/sse
+ *    via the existing validateApiKey path with no resource-server changes.
+ *  - refresh_token: rotates the refresh token and issues a fresh access token.
+ *
+ * Public clients (token_endpoint_auth_method "none") — no client_secret; the
+ * authorization_code grant is bound to the client via PKCE.
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { generateUserApiKey } from "@/lib/user-api-keys";
+import { ensureStarterCredits } from "@/lib/agent/billing";
+import {
+  sha256,
+  randomToken,
+  verifyPkceS256,
+  getClient,
+  ACCESS_TOKEN_TTL_S,
+  REFRESH_TOKEN_TTL_MS,
+  KEY_SCOPES,
+} from "@/lib/oauth/server";
+
+export const dynamic = "force-dynamic";
+
+const CORS: Record<string, string> = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type, Authorization",
+};
+
+export async function OPTIONS() {
+  return new NextResponse(null, { status: 204, headers: CORS });
+}
+
+function tokenError(error: string, desc?: string, status = 400): NextResponse {
+  return NextResponse.json(
+    { error, ...(desc ? { error_description: desc } : {}) },
+    { status, headers: { ...CORS, "Cache-Control": "no-store" } },
+  );
+}
+
+async function parseBody(req: NextRequest): Promise<Record<string, string>> {
+  const ct = req.headers.get("content-type") || "";
+  if (ct.includes("application/json")) {
+    try {
+      return (await req.json()) as Record<string, string>;
+    } catch {
+      return {};
+    }
+  }
+  const form = await req.formData();
+  const out: Record<string, string> = {};
+  form.forEach((v, k) => {
+    out[k] = String(v);
+  });
+  return out;
+}
+
+/** Mint a scoped rm_user_* access token + a rotating refresh token. */
+async function issueTokens(userId: string, clientId: string, clientName: string | null, scope: string) {
+  const admin = createAdminClient();
+  try {
+    await ensureStarterCredits(userId);
+  } catch (e) {
+    console.error("[oauth/token] ensureStarterCredits failed:", e);
+  }
+
+  const { plainKey, hashedKey, prefix } = generateUserApiKey("live");
+  const { error: keyErr } = await admin.from("user_generated_api_keys").insert({
+    user_id: userId,
+    key_hash: hashedKey,
+    key_prefix: prefix,
+    name: `MCP OAuth${clientName ? `: ${clientName}` : ""}`,
+    scopes: KEY_SCOPES,
+    expires_at: new Date(Date.now() + ACCESS_TOKEN_TTL_S * 1000).toISOString(),
+  });
+  if (keyErr) throw new Error(`access key insert: ${keyErr.message}`);
+
+  const refresh = randomToken(32);
+  const { error: refErr } = await admin.from("oauth_refresh_tokens").insert({
+    token_hash: sha256(refresh),
+    user_id: userId,
+    client_id: clientId,
+    scope,
+    expires_at: new Date(Date.now() + REFRESH_TOKEN_TTL_MS).toISOString(),
+  });
+  if (refErr) throw new Error(`refresh token insert: ${refErr.message}`);
+
+  return NextResponse.json(
+    {
+      access_token: plainKey,
+      token_type: "Bearer",
+      expires_in: ACCESS_TOKEN_TTL_S,
+      refresh_token: refresh,
+      scope,
+    },
+    { status: 200, headers: { ...CORS, "Cache-Control": "no-store" } },
+  );
+}
+
+export async function POST(req: NextRequest) {
+  const body = await parseBody(req);
+  const grantType = body.grant_type;
+  const admin = createAdminClient();
+
+  // ----- authorization_code + PKCE -----
+  if (grantType === "authorization_code") {
+    const code = body.code;
+    const redirectUri = body.redirect_uri;
+    const clientId = body.client_id;
+    const codeVerifier = body.code_verifier;
+    if (!code || !redirectUri || !clientId || !codeVerifier) {
+      return tokenError("invalid_request", "Missing code, redirect_uri, client_id, or code_verifier");
+    }
+
+    const { data: codeRow } = await admin
+      .from("oauth_auth_codes")
+      .select("id, user_id, client_id, redirect_uri, code_challenge, scope, expires_at, consumed_at")
+      .eq("code_hash", sha256(code))
+      .maybeSingle();
+
+    if (!codeRow) return tokenError("invalid_grant", "Authorization code not found");
+    if (codeRow.consumed_at) return tokenError("invalid_grant", "Authorization code already used");
+    if (new Date(codeRow.expires_at) < new Date()) return tokenError("invalid_grant", "Authorization code expired");
+    if (codeRow.client_id !== clientId) return tokenError("invalid_grant", "client_id mismatch");
+    if (codeRow.redirect_uri !== redirectUri) return tokenError("invalid_grant", "redirect_uri mismatch");
+    if (!verifyPkceS256(codeVerifier, codeRow.code_challenge)) {
+      return tokenError("invalid_grant", "PKCE verification failed");
+    }
+
+    // Single-use: consume atomically (guard on consumed_at IS NULL to block replay/race).
+    const { data: consumed } = await admin
+      .from("oauth_auth_codes")
+      .update({ consumed_at: new Date().toISOString() })
+      .eq("id", codeRow.id)
+      .is("consumed_at", null)
+      .select("id");
+    if (!consumed || consumed.length === 0) return tokenError("invalid_grant", "Authorization code already used");
+
+    const client = await getClient(clientId);
+    try {
+      return await issueTokens(codeRow.user_id, clientId, client?.client_name ?? null, codeRow.scope);
+    } catch (e) {
+      console.error("[oauth/token] issue (code) failed:", e);
+      return tokenError("server_error", undefined, 500);
+    }
+  }
+
+  // ----- refresh_token (rotating) -----
+  if (grantType === "refresh_token") {
+    const refreshToken = body.refresh_token;
+    const clientId = body.client_id;
+    if (!refreshToken || !clientId) return tokenError("invalid_request", "Missing refresh_token or client_id");
+
+    const { data: row } = await admin
+      .from("oauth_refresh_tokens")
+      .select("id, user_id, client_id, scope, expires_at, revoked_at")
+      .eq("token_hash", sha256(refreshToken))
+      .maybeSingle();
+
+    if (!row || row.revoked_at) return tokenError("invalid_grant", "Refresh token invalid");
+    if (new Date(row.expires_at) < new Date()) return tokenError("invalid_grant", "Refresh token expired");
+    if (row.client_id !== clientId) return tokenError("invalid_grant", "client_id mismatch");
+
+    // Rotate: revoke the presented refresh token before issuing a new pair.
+    const { data: revoked } = await admin
+      .from("oauth_refresh_tokens")
+      .update({ revoked_at: new Date().toISOString() })
+      .eq("id", row.id)
+      .is("revoked_at", null)
+      .select("id");
+    if (!revoked || revoked.length === 0) return tokenError("invalid_grant", "Refresh token already used");
+
+    const client = await getClient(clientId);
+    try {
+      return await issueTokens(row.user_id, clientId, client?.client_name ?? null, row.scope);
+    } catch (e) {
+      console.error("[oauth/token] issue (refresh) failed:", e);
+      return tokenError("server_error", undefined, 500);
+    }
+  }
+
+  return tokenError("unsupported_grant_type", `Unsupported grant_type: ${grantType ?? "(none)"}`);
+}

--- a/app/get-key/page.tsx
+++ b/app/get-key/page.tsx
@@ -223,6 +223,11 @@ function GetKeyPage() {
   /** Append `?ref=CODE` onto the post-auth `next=` so the param survives the round-trip even if
    *  sessionStorage is unavailable (e.g. cross-domain OAuth in some browsers). Belt + suspenders. */
   const buildNextPath = () => {
+    // OAuth / connector flow: an upstream page (e.g. /oauth/authorize) sends the
+    // user here with ?next=<internal path> to return to after sign-in. Only honor
+    // internal, same-origin paths (must start with "/") to avoid open redirects.
+    const nextParam = searchParams.get('next');
+    if (nextParam && nextParam.startsWith('/')) return nextParam;
     const ref = readPersistedReferralCode(searchParams);
     return ref ? `/get-key?ref=${encodeURIComponent(ref)}` : '/get-key';
   };

--- a/app/oauth/authorize/page.tsx
+++ b/app/oauth/authorize/page.tsx
@@ -1,0 +1,149 @@
+/**
+ * GET /oauth/authorize — OAuth authorization endpoint (authorization_code + PKCE).
+ *
+ * Flow:
+ *  1. Validate the client_id + redirect_uri against the registered client
+ *     BEFORE redirecting anywhere (never bounce errors to an unvalidated URI).
+ *  2. If the user has no `.app` Supabase session, send them to `.app`'s own
+ *     sign-in (`/get-key`) with this authorize URL as `?next=` so they return
+ *     here after login. `.net` is never involved.
+ *  3. Render a minimal consent screen; "Allow" POSTs to
+ *     /api/oauth/authorize/decision, which mints the single-use auth code and
+ *     redirects back to the client's redirect_uri.
+ */
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { getClient, redirectUriRegistered, OAUTH_SCOPE } from "@/lib/oauth/server";
+
+export const dynamic = "force-dynamic";
+
+const AUTHORIZE_PARAMS = [
+  "response_type",
+  "client_id",
+  "redirect_uri",
+  "code_challenge",
+  "code_challenge_method",
+  "scope",
+  "state",
+] as const;
+
+function str(v: string | string[] | undefined): string | undefined {
+  return Array.isArray(v) ? v[0] : v;
+}
+
+function redirectClientError(redirectUri: string, state: string, error: string, desc?: string): never {
+  const u = new URL(redirectUri);
+  u.searchParams.set("error", error);
+  if (desc) u.searchParams.set("error_description", desc);
+  if (state) u.searchParams.set("state", state);
+  redirect(u.toString());
+}
+
+function ErrorCard({ title, detail }: { title: string; detail: string }) {
+  return (
+    <main className="min-h-[70vh] flex items-center justify-center px-4">
+      <div className="max-w-md w-full rounded-xl border border-red-900/50 bg-zinc-950 p-6">
+        <h1 className="text-lg font-semibold text-red-300">{title}</h1>
+        <p className="mt-2 text-sm text-zinc-400">{detail}</p>
+      </div>
+    </main>
+  );
+}
+
+export default async function AuthorizePage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const sp = await searchParams;
+  const responseType = str(sp.response_type);
+  const clientId = str(sp.client_id);
+  const redirectUri = str(sp.redirect_uri);
+  const codeChallenge = str(sp.code_challenge);
+  const codeChallengeMethod = str(sp.code_challenge_method) ?? "S256";
+  const scope = str(sp.scope) ?? OAUTH_SCOPE;
+  const state = str(sp.state) ?? "";
+
+  // 1. Validate client + redirect_uri before trusting them as a redirect target.
+  if (!clientId || !redirectUri) {
+    return <ErrorCard title="Invalid request" detail="Missing client_id or redirect_uri." />;
+  }
+  const client = await getClient(clientId);
+  if (!client) {
+    return <ErrorCard title="Unknown client" detail="This client_id is not registered. Remove and re-add the connector so it can register again." />;
+  }
+  if (!redirectUriRegistered(client, redirectUri)) {
+    return <ErrorCard title="Redirect URI mismatch" detail="The redirect_uri does not match a URI registered for this client." />;
+  }
+
+  // From here errors are safe to return to the (validated) client redirect_uri.
+  if (responseType !== "code") redirectClientError(redirectUri, state, "unsupported_response_type");
+  if (!codeChallenge || codeChallengeMethod !== "S256") {
+    redirectClientError(redirectUri, state, "invalid_request", "PKCE S256 code_challenge is required");
+  }
+
+  // 2. Require a signed-in .app user; otherwise bounce to .app's own sign-in.
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    const qs = new URLSearchParams();
+    for (const k of AUTHORIZE_PARAMS) {
+      const v = str(sp[k]);
+      if (v) qs.set(k, v);
+    }
+    redirect(`/get-key?next=${encodeURIComponent(`/oauth/authorize?${qs.toString()}`)}`);
+  }
+
+  // 3. Consent screen — plain server-rendered form, no client JS needed.
+  return (
+    <main className="min-h-[70vh] flex items-center justify-center px-4 py-10">
+      <div className="max-w-md w-full rounded-xl border border-zinc-800 bg-zinc-950 p-6">
+        <div className="text-xs uppercase tracking-widest text-zinc-500">RiskModels — authorize access</div>
+        <h1 className="mt-2 text-xl font-semibold text-zinc-100">
+          {client.client_name ? `"${client.client_name}"` : "An application"} wants to connect
+        </h1>
+        <p className="mt-3 text-sm text-zinc-400">
+          It will be able to <strong className="text-zinc-200">read your risk data</strong> through RiskModels and
+          <strong className="text-zinc-200"> bill your account</strong> for metered calls, on your behalf.
+        </p>
+        <ul className="mt-4 text-sm text-zinc-400 space-y-1">
+          <li>• Scope: <code className="text-zinc-300">{scope}</code></li>
+          <li>• Signed in as <span className="text-zinc-300">{user.email ?? user.id}</span></li>
+        </ul>
+
+        <form method="POST" action="/api/oauth/authorize/decision" className="mt-6 flex gap-3">
+          <input type="hidden" name="client_id" value={clientId} />
+          <input type="hidden" name="redirect_uri" value={redirectUri} />
+          <input type="hidden" name="code_challenge" value={codeChallenge} />
+          <input type="hidden" name="code_challenge_method" value={codeChallengeMethod} />
+          <input type="hidden" name="scope" value={scope} />
+          <input type="hidden" name="state" value={state} />
+          <button
+            type="submit"
+            name="decision"
+            value="deny"
+            className="flex-1 rounded-lg border border-zinc-700 px-4 py-2.5 text-sm text-zinc-300 hover:bg-zinc-900 transition-colors"
+          >
+            Deny
+          </button>
+          <button
+            type="submit"
+            name="decision"
+            value="approve"
+            className="flex-1 rounded-lg bg-emerald-600 px-4 py-2.5 text-sm font-medium text-white hover:bg-emerald-500 transition-colors"
+          >
+            Allow
+          </button>
+        </form>
+
+        <p className="mt-4 text-xs text-zinc-600">
+          You can revoke this access any time from your API keys at{" "}
+          <Link href="/get-key" className="text-zinc-400 hover:underline">riskmodels.app/get-key</Link>.
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/lib/oauth/server.ts
+++ b/lib/oauth/server.ts
@@ -1,0 +1,57 @@
+/**
+ * MCP OAuth authorization-server helpers (Phase B/C, backlog E.20).
+ *
+ * The access token issued by /api/oauth/token is a scoped `rm_user_*` key
+ * (decision: mint under the hood — validateApiKey already accepts it at
+ * /api/mcp/sse). These helpers cover the OAuth protocol state only:
+ * client lookup, PKCE, and hashed single-use codes / refresh tokens.
+ */
+import crypto from "crypto";
+import { createAdminClient } from "@/lib/supabase/admin";
+
+/** OAuth scope advertised in the AS metadata (`scopes_supported`). */
+export const OAUTH_SCOPE = "mcp:read";
+/** Underlying scope stamped on the minted rm_user_* key — what the REST API expects. */
+export const KEY_SCOPES = ["read"];
+export const AUTH_CODE_TTL_MS = 5 * 60_000; // 5 min
+export const ACCESS_TOKEN_TTL_S = 3600; // 1 h
+export const REFRESH_TOKEN_TTL_MS = 30 * 24 * 60 * 60_000; // 30 d
+
+export function sha256(input: string): string {
+  return crypto.createHash("sha256").update(input).digest("hex");
+}
+
+export function randomToken(bytes = 32): string {
+  return crypto.randomBytes(bytes).toString("base64url");
+}
+
+/** PKCE S256 check: base64url(sha256(verifier)) === challenge, constant-time. */
+export function verifyPkceS256(verifier: string, challenge: string): boolean {
+  if (!verifier || !challenge) return false;
+  const computed = crypto.createHash("sha256").update(verifier).digest("base64url");
+  const a = Buffer.from(computed);
+  const b = Buffer.from(challenge);
+  return a.length === b.length && crypto.timingSafeEqual(a, b);
+}
+
+export interface OAuthClient {
+  client_id: string;
+  redirect_uris: string[];
+  client_name: string | null;
+}
+
+export async function getClient(clientId: string): Promise<OAuthClient | null> {
+  if (!clientId) return null;
+  const admin = createAdminClient();
+  const { data } = await admin
+    .from("oauth_clients")
+    .select("client_id, redirect_uris, client_name")
+    .eq("client_id", clientId)
+    .maybeSingle();
+  return (data as OAuthClient) ?? null;
+}
+
+/** Exact-match the redirect_uri against the client's registered set (no prefix/substring matching). */
+export function redirectUriRegistered(client: OAuthClient, redirectUri: string): boolean {
+  return Array.isArray(client.redirect_uris) && client.redirect_uris.includes(redirectUri);
+}


### PR DESCRIPTION
Implements the OAuth endpoints that Phase A (#143) forward-declared, so Claude Desktop / Cursor's **"Add custom connector by URL"** completes a connection with **no terminal and no API-key handling** — the OAuth tier of the three-choice model (backlog E.20, plan §4).

## Endpoints (all on `.app`; sign-in reuses `.app`'s own Supabase flow — `.net` never involved)
- `POST /api/oauth/register` — Dynamic Client Registration (RFC 7591); public clients, PKCE-bound, no secret.
- `GET /oauth/authorize` — validates client + redirect_uri, requires an `.app` session (else bounces to `/get-key?next=`), renders a minimal consent screen.
- `POST /api/oauth/authorize/decision` — mints a single-use PKCE-bound auth code, 303 to the client redirect_uri.
- `POST /api/oauth/token` — `authorization_code` (PKCE verify + single-use consume) and `refresh_token` (rotating) grants.

## Token model
Access token = a scoped `rm_user_*` key minted into `user_generated_api_keys`. It authenticates at `/api/mcp/sse` through the **existing `validateApiKey` path with zero resource-server changes**, and bills normally (`ensureStarterCredits` on issue). 1 h access / 30 d refresh.

## Security
- client_id + redirect_uri re-validated server-side at every step (consent form never trusted)
- user identity always from the session cookie
- auth codes single-use via atomic `consumed_at` guard (5-min TTL); refresh tokens hashed + rotated
- PKCE S256 required, constant-time compare; all secrets stored SHA-256-hashed

## ⚠️ Requires migration before it functions
`oauth_clients` / `oauth_auth_codes` / `oauth_refresh_tokens` — `BWMACRO/supabase/migrations/20260607120000_mcp_oauth_tables.sql` must be applied to the shared Supabase, else all three endpoints 500.

## Test plan
- [ ] CI green
- [ ] migration applied to prod Supabase
- [ ] on prod: `POST /api/oauth/register` → 201 with client_id; `POST /api/oauth/token` bad grant → structured `invalid_grant`; metadata still 200
- [ ] **end-to-end in Claude Desktop**: add connector → sign in → consent → tools load and a data call bills

Preview is SSO-walled, so verification runs on prod after merge (like Phase A).

🤖 Generated with [Claude Code](https://claude.com/claude-code)