### PR TITLE
fix(mcp-oauth): advertise .app request origin, not NEXT_PUBLIC_APP_URL (.net)

### DIFF
--- a/app/.well-known/oauth-authorization-server/route.ts
+++ b/app/.well-known/oauth-authorization-server/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { getAppUrl } from "@/lib/app-url";
+import { appOrigin } from "@/lib/oauth/server";
 
 export const dynamic = "force-dynamic";
 
@@ -16,8 +16,8 @@ export const dynamic = "force-dynamic";
  *   - Phase C: `/api/oauth/register` (Dynamic Client Registration, RFC 7591)
  * This is intentional — Phase A only proves the discovery handshake is well-formed.
  */
-export function GET() {
-  const base = getAppUrl().replace(/\/$/, "");
+export async function GET() {
+  const base = await appOrigin();
   return NextResponse.json(
     {
       issuer: base,

--- a/app/.well-known/oauth-protected-resource/route.ts
+++ b/app/.well-known/oauth-protected-resource/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { getAppUrl } from "@/lib/app-url";
+import { appOrigin } from "@/lib/oauth/server";
 
 export const dynamic = "force-dynamic";
 
@@ -15,8 +15,8 @@ export const dynamic = "force-dynamic";
  * PKCE + token) and C (Dynamic Client Registration). Tier-1 Bearer API keys
  * continue to work unchanged.
  */
-export function GET() {
-  const base = getAppUrl().replace(/\/$/, "");
+export async function GET() {
+  const base = await appOrigin();
   return NextResponse.json(
     {
       resource: `${base}/api/mcp/sse`,

--- a/app/api/mcp/sse/route.ts
+++ b/app/api/mcp/sse/route.ts
@@ -20,7 +20,6 @@ import {
 } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
 import { createMcpServer } from "@/lib/mcp/server";
 import { authenticateMcpRequest } from "@/lib/mcp/auth";
-import { getAppUrl } from "@/lib/app-url";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -53,8 +52,16 @@ function errorResponse(
 // authorization server on a 401 and can run the OAuth connect flow instead of
 // failing at client registration. Tier-1 Bearer API keys still authenticate
 // and never reach this branch.
-function wwwAuthenticateHeader(): Record<string, string> {
-  const base = getAppUrl().replace(/\/$/, "");
+//
+// Origin is derived from the REQUEST host (the .app origin the client used),
+// not NEXT_PUBLIC_APP_URL — that env points at the .net portal here, which has
+// no OAuth routes; advertising it sends clients to register against .net.
+function wwwAuthenticateHeader(req: NextRequest): Record<string, string> {
+  const host = req.headers.get("x-forwarded-host") ?? req.headers.get("host");
+  const proto = req.headers.get("x-forwarded-proto") ?? "https";
+  const base = host
+    ? `${proto}://${host}`
+    : (process.env.RISKMODELS_API_URL || "https://riskmodels.app").replace(/\/$/, "");
   return {
     "WWW-Authenticate": `Bearer resource_metadata="${base}/.well-known/oauth-protected-resource"`,
   };
@@ -66,7 +73,7 @@ async function handle(req: NextRequest): Promise<Response> {
     return errorResponse(
       auth.status,
       auth.error,
-      auth.status === 401 ? wwwAuthenticateHeader() : undefined,
+      auth.status === 401 ? wwwAuthenticateHeader(req) : undefined,
     );
   }
 

--- a/lib/oauth/server.ts
+++ b/lib/oauth/server.ts
@@ -7,7 +7,34 @@
  * client lookup, PKCE, and hashed single-use codes / refresh tokens.
  */
 import crypto from "crypto";
+import { headers } from "next/headers";
 import { createAdminClient } from "@/lib/supabase/admin";
+
+/**
+ * Origin to advertise in OAuth metadata + the WWW-Authenticate challenge.
+ *
+ * MUST be the origin the client actually fetched from (RFC 8414 issuer rule) —
+ * i.e. the `.app` host where the OAuth + MCP routes live. Derive it from the
+ * request host, NOT from `getAppUrl()`/`NEXT_PUBLIC_APP_URL`: in this deployment
+ * that env points at the `.net` portal, which has no OAuth routes — advertising
+ * it sends clients to register against `.net` and they fail with
+ * "couldn't register with the sign-in service".
+ */
+export async function appOrigin(): Promise<string> {
+  try {
+    const h = await headers();
+    const host = h.get("x-forwarded-host") ?? h.get("host");
+    const proto = h.get("x-forwarded-proto") ?? "https";
+    if (host) return `${proto}://${host}`;
+  } catch {
+    // No request context (shouldn't happen in these routes) — fall through.
+  }
+  return (
+    process.env.RISKMODELS_API_URL ||
+    process.env.NEXT_PUBLIC_RISKMODELS_API_URL ||
+    "https://riskmodels.app"
+  ).replace(/\/$/, "");
+}
 
 /** OAuth scope advertised in the AS metadata (`scopes_supported`). */
 export const OAUTH_SCOPE = "mcp:read";


### PR DESCRIPTION
Fixes the live connector failure. Discovery metadata was advertising `riskmodels.net` (from `getAppUrl()`/`NEXT_PUBLIC_APP_URL`), where no OAuth routes exist, so Claude registered against `.net` and failed. Now derives the advertised origin from the request host (RFC 8414 issuer rule) across the AS metadata, protected-resource metadata, and the MCP 401 challenge. Build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)