### PR TITLE
docs(mcp-oauth): Phase D — connector-by-URL works; flip onboarding copy

### DIFF
--- a/app/api-reference/page.tsx
+++ b/app/api-reference/page.tsx
@@ -394,8 +394,8 @@ export default function ApiReferencePage() {
 {`Visit riskmodels.app and set it up to use in this chat, then tell me what you can analyze.`}
                     </div>
                     <p className="text-xs text-zinc-500 mt-2">
-                      Want it permanently in Claude or Cursor? Run{' '}
-                      <code className="text-zinc-400">npx -y riskmodels@latest install</code> once (needs Node) — see the{' '}
+                      Want it permanently in Claude or Cursor? Settings → Connectors → Add custom connector → paste{' '}
+                      <code className="text-zinc-400">https://riskmodels.app/api/mcp/sse</code> and Connect — sign in, no key needed. Details in the{' '}
                       <Link href="/docs/agent-integration" className="text-terminal hover:underline">agent integration guide</Link>.
                     </p>
                   </div>

--- a/content/docs/agent-integration.mdx
+++ b/content/docs/agent-integration.mdx
@@ -22,13 +22,13 @@ Use the RiskModels API with your AI assistant of choice to perform quant researc
       </div>
     </div>
     <div className="px-5 pb-4 pt-2">
-      <span className="text-sm font-semibold text-zinc-100">Keep it (Claude Desktop / Cursor, persistent)</span>
-      <p className="text-xs text-zinc-400 mt-1">One command wires it into every supported client. Needs Node installed.</p>
+      <span className="text-sm font-semibold text-zinc-100">Keep it (Claude Desktop / Cursor, persistent — no terminal)</span>
+      <p className="text-xs text-zinc-400 mt-1">Settings → Connectors → Add custom connector, paste the URL (leave OAuth fields blank), then Connect. You sign in at riskmodels.app and approve once — no API key to handle, billing on your account.</p>
       <div className="flex items-center justify-between bg-zinc-950 border border-zinc-700 rounded-lg px-4 py-2.5 font-mono text-sm text-zinc-200 mt-2">
-        <span>npx -y riskmodels@latest install</span>
-        <button onclick="navigator.clipboard.writeText('npx -y riskmodels@latest install');this.textContent='✓';setTimeout(()=>this.textContent='Copy',1500)" className="ml-4 text-xs text-zinc-500 hover:text-zinc-200 transition-colors flex-shrink-0">Copy</button>
+        <span>https://riskmodels.app/api/mcp/sse</span>
+        <button onclick="navigator.clipboard.writeText('https://riskmodels.app/api/mcp/sse');this.textContent='✓';setTimeout(()=>this.textContent='Copy',1500)" className="ml-4 text-xs text-zinc-500 hover:text-zinc-200 transition-colors flex-shrink-0">Copy</button>
       </div>
-      <p className="text-xs text-zinc-600 mt-2">Native "Add custom connector by URL" needs OAuth, which the hosted server doesn't implement yet — until then use the command above (or the <code className="text-zinc-500">mcp-remote</code> proxy in MCP setup below).</p>
+      <p className="text-xs text-zinc-600 mt-2">Prefer a terminal, or need Codex / VS Code? <code className="text-zinc-500">npx -y riskmodels@latest install</code> wires every client in one command.</p>
     </div>
   </div>
 
@@ -112,9 +112,19 @@ the API or SDK and generate a Python plot.
 
 <h2 id="mcp-setup">MCP Server Setup</h2>
 
-### Hosted — via the mcp-remote proxy (no local build)
+### Connect by URL (no terminal, recommended)
 
-The hosted endpoint at `https://riskmodels.app/api/mcp/sse` authenticates with a **Bearer API key**. Add it to your client's MCP config through the `mcp-remote` proxy:
+In **Claude Desktop** or **Cursor**, open **Settings → Connectors → Add custom connector** and paste:
+
+```
+https://riskmodels.app/api/mcp/sse
+```
+
+Leave the OAuth Client ID / Secret fields blank, click **Add**, then **Connect**. You'll sign in at riskmodels.app and approve access once (OAuth 2.0 + PKCE — the client registers itself); the tools then load and metered calls bill your account. Nothing to install, and no API key to copy or store.
+
+### Hosted via the mcp-remote proxy (Bearer key)
+
+Prefer a static API key instead of signing in? Add the endpoint through the `mcp-remote` proxy:
 
 ```json
 {
@@ -129,8 +139,6 @@ The hosted endpoint at `https://riskmodels.app/api/mcp/sse` authenticates with a
 ```
 
 Get a key at [/get-key](/get-key). Discovery tools are free; data tools bill per underlying REST route.
-
-> **Native connector-by-URL is not supported yet.** The "Add custom connector" flow in Claude Desktop / Cursor expects OAuth (Dynamic Client Registration), which this server does not implement — it uses Bearer API keys, so pasting the URL into that UI fails to register. Until MCP OAuth ships, use the `mcp-remote` config above or `riskmodels install`. For zero-setup access today, use the try-now prompt at the top of this page.
 
 ### Local — build from source (developer)
 

--- a/lib/llms-txt.ts
+++ b/lib/llms-txt.ts
@@ -27,10 +27,9 @@ You are an AI assistant reading this because someone pointed you at riskmodels.a
 - For live data on the Magnificent 7, use the **Public sample API key** below (if present) as \`Authorization: Bearer …\`. If you can make HTTP POSTs, you may self-provision a free key: \`POST /api/auth/provision-free\`. For the full ~3,000-name universe, tell the human to grab a free key at https://riskmodels.app/get-key (browser, no terminal).
 - Make one real call to confirm the connection, then tell the human what you can analyze and ask what they want to look at. **Do not tell a human to open a terminal for this case.**
 
-**2. "Help me set it up" / "add this to my Claude/Cursor"** — they want RiskModels available permanently. You cannot edit their app's config yourself, so relay these steps. Persistent setup currently needs a one-time terminal step (the native connector-by-URL UI is not supported yet — see note):
-- **Simplest (one command):** \`npm install -g riskmodels@latest\` then \`riskmodels install\` — prompts for the key, auto-wires Claude Desktop, Cursor, Codex, and VS Code, and stores the key in ~/.config/riskmodels/config.json.
-- **Hosted, no local build:** add the \`mcp-remote\` proxy to the client's MCP config — \`npx -y mcp-remote https://riskmodels.app/api/mcp/sse\` with env \`AUTHORIZATION=Bearer <their key>\` (key from https://riskmodels.app/get-key).
-- **Note:** the native "Add custom connector by URL" flow in Claude Desktop / Cursor expects OAuth, which this server does not implement yet (it authenticates with Bearer API keys). Pasting the URL into that UI will fail to register. For a zero-setup experience today, use case 1 above instead.
+**2. "Help me set it up" / "add this to my Claude/Cursor"** — they want RiskModels available permanently. You cannot edit their app's config yourself, so relay these steps (no terminal needed):
+- **Recommended — connect by URL (no terminal, no API key):** in Claude Desktop or Cursor, open **Settings → Connectors → Add custom connector**, paste \`https://riskmodels.app/api/mcp/sse\`, leave the OAuth Client ID / Secret fields blank, then click **Add → Connect**. They sign in at riskmodels.app (Google / GitHub / email) and approve access once (OAuth 2.0 + PKCE; the client registers itself); the tools load and metered calls bill their RiskModels account. No key to copy or store.
+- **Developer alternatives (terminal):** \`npm install -g riskmodels@latest\` then \`riskmodels install\` (auto-wires Claude Desktop, Cursor, Codex, VS Code), or the \`mcp-remote\` proxy — \`npx -y mcp-remote https://riskmodels.app/api/mcp/sse\` with env \`AUTHORIZATION=Bearer <their key>\` (key from https://riskmodels.app/get-key).
 
 ## Magnificent 7 (MAG7)
 


### PR DESCRIPTION
The OAuth connector is live + verified end-to-end (Phases A/B/C + the .net→.app origin fix), so the post-#142 "connector not supported yet" copy is now false. Phase D flips the three onboarding surfaces to feature the no-terminal connector and present the three choices: **try-now paste** / **connect by URL (OAuth)** / **developer CLI**. Landing-page hero deferred to after Phase E hardening, per CEO. Build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)