### PR TITLE
feat(mcp-oauth): Phase E — hardening + security-review fixes

### DIFF
--- a/app/.well-known/oauth-authorization-server/route.ts
+++ b/app/.well-known/oauth-authorization-server/route.ts
@@ -24,6 +24,7 @@ export async function GET() {
       authorization_endpoint: `${base}/oauth/authorize`,
       token_endpoint: `${base}/api/oauth/token`,
       registration_endpoint: `${base}/api/oauth/register`,
+      revocation_endpoint: `${base}/api/oauth/revoke`,
       response_types_supported: ["code"],
       grant_types_supported: ["authorization_code", "refresh_token"],
       code_challenge_methods_supported: ["S256"],

--- a/app/api/keys/route.ts
+++ b/app/api/keys/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
+import { createAdminClient } from '@/lib/supabase/admin';
 import { ensureStarterCredits } from '@/lib/agent/billing';
 import { generateUserApiKey } from '@/lib/user-api-keys';
 
@@ -108,6 +109,15 @@ export async function DELETE(request: NextRequest) {
   const { id } = await request.json().catch(() => ({}));
   if (!id) return NextResponse.json({ error: 'Missing key id' }, { status: 400 });
 
+  // Look up the key's name first so we can cascade refresh-token revocation for
+  // OAuth-minted keys (named "MCP OAuth…").
+  const { data: keyRow } = await supabase
+    .from('user_generated_api_keys')
+    .select('name')
+    .eq('id', id)
+    .eq('user_id', user.id)
+    .maybeSingle();
+
   const { error } = await supabase
     .from('user_generated_api_keys')
     .update({ revoked_at: new Date().toISOString() })
@@ -116,6 +126,22 @@ export async function DELETE(request: NextRequest) {
 
   if (error) {
     return NextResponse.json({ error: 'Failed to revoke key' }, { status: 500 });
+  }
+
+  // Disconnecting an MCP OAuth grant must also kill the refresh tokens, else the
+  // connector could silently mint a fresh access key. Conservative at this scale:
+  // revoke all of the user's OAuth refresh tokens (they re-consent to reconnect).
+  if (keyRow?.name?.startsWith('MCP OAuth')) {
+    try {
+      const admin = createAdminClient();
+      await admin
+        .from('oauth_refresh_tokens')
+        .update({ revoked_at: new Date().toISOString() })
+        .eq('user_id', user.id)
+        .is('revoked_at', null);
+    } catch (e) {
+      console.error('[keys] OAuth refresh-token revoke cascade failed:', e);
+    }
   }
 
   return NextResponse.json({ success: true });

--- a/app/api/oauth/authorize/decision/route.ts
+++ b/app/api/oauth/authorize/decision/route.ts
@@ -28,6 +28,22 @@ function redirectTo(redirectUri: string, params: Record<string, string>): NextRe
 }
 
 export async function POST(req: NextRequest) {
+  // CSRF defense-in-depth: the consent form is same-origin. Reject cross-site
+  // POSTs (Supabase cookies are SameSite=Lax, but don't rely on that alone — a
+  // forged approve would mint a code for an attacker's client on the victim's
+  // session).
+  const origin = req.headers.get("origin");
+  const host = req.headers.get("x-forwarded-host") ?? req.headers.get("host");
+  if (origin && host) {
+    try {
+      if (new URL(origin).host !== host) {
+        return new NextResponse("Cross-site request rejected", { status: 403 });
+      }
+    } catch {
+      return new NextResponse("Invalid origin", { status: 403 });
+    }
+  }
+
   const form = await req.formData();
   const clientId = String(form.get("client_id") ?? "");
   const redirectUri = String(form.get("redirect_uri") ?? "");

--- a/app/api/oauth/register/route.ts
+++ b/app/api/oauth/register/route.ts
@@ -8,6 +8,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import crypto from "crypto";
 import { createAdminClient } from "@/lib/supabase/admin";
+import { clientIp, rateLimit } from "@/lib/oauth/rate-limit";
 
 export const dynamic = "force-dynamic";
 
@@ -21,12 +22,31 @@ export async function OPTIONS() {
   return new NextResponse(null, { status: 204, headers: CORS });
 }
 
-// Absolute URI (https, or any scheme:// e.g. custom-app or http://localhost loopback).
+// Absolute redirect URI. Allow https and custom app schemes; for http require a
+// loopback host (RFC 8252) so an authorization code is never delivered over
+// cleartext to an arbitrary remote host.
+const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "[::1]", "::1"]);
 function isAbsoluteUri(u: unknown): u is string {
-  return typeof u === "string" && /^[a-z][a-z0-9+.-]*:\/\/.+/i.test(u);
+  if (typeof u !== "string" || !/^[a-z][a-z0-9+.-]*:\/\/.+/i.test(u)) return false;
+  try {
+    const url = new URL(u);
+    if (url.protocol === "http:") return LOOPBACK_HOSTS.has(url.hostname);
+    return true; // https or a custom (native-app) scheme
+  } catch {
+    return false;
+  }
 }
 
 export async function POST(req: NextRequest) {
+  // Anti-abuse: cap dynamic client registrations per IP (DCR is infrequent).
+  const rl = await rateLimit("register", clientIp(req), 30, 3600);
+  if (!rl.ok) {
+    return NextResponse.json(
+      { error: "too_many_requests", error_description: "Registration rate limit exceeded. Try again later." },
+      { status: 429, headers: { ...CORS, "Retry-After": String(rl.retryAfter) } },
+    );
+  }
+
   let body: Record<string, unknown>;
   try {
     body = await req.json();

--- a/app/api/oauth/revoke/route.ts
+++ b/app/api/oauth/revoke/route.ts
@@ -1,0 +1,85 @@
+/**
+ * POST /api/oauth/revoke — OAuth 2.0 token revocation (RFC 7009).
+ *
+ * Accepts an access token (a scoped rm_user_* key) or a refresh token and
+ * revokes it. Per RFC 7009 the endpoint returns 200 whether or not the token
+ * existed (only a missing `token` param is a 400 invalid_request).
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { hashApiKey } from "@/lib/user-api-keys";
+import { sha256 } from "@/lib/oauth/server";
+import { clientIp, rateLimit } from "@/lib/oauth/rate-limit";
+
+export const dynamic = "force-dynamic";
+
+const CORS: Record<string, string> = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type, Authorization",
+};
+
+export async function OPTIONS() {
+  return new NextResponse(null, { status: 204, headers: CORS });
+}
+
+async function parseBody(req: NextRequest): Promise<Record<string, string>> {
+  const ct = req.headers.get("content-type") || "";
+  if (ct.includes("application/json")) {
+    try {
+      return (await req.json()) as Record<string, string>;
+    } catch {
+      return {};
+    }
+  }
+  const form = await req.formData();
+  const out: Record<string, string> = {};
+  form.forEach((v, k) => {
+    out[k] = String(v);
+  });
+  return out;
+}
+
+export async function POST(req: NextRequest) {
+  const rl = await rateLimit("revoke", clientIp(req), 60, 60);
+  if (!rl.ok) {
+    return NextResponse.json(
+      { error: "too_many_requests" },
+      { status: 429, headers: { ...CORS, "Cache-Control": "no-store", "Retry-After": String(rl.retryAfter) } },
+    );
+  }
+
+  const body = await parseBody(req);
+  const token = body.token;
+  if (!token) {
+    return NextResponse.json(
+      { error: "invalid_request", error_description: "Missing token parameter" },
+      { status: 400, headers: { ...CORS, "Cache-Control": "no-store" } },
+    );
+  }
+
+  const admin = createAdminClient();
+  const now = new Date().toISOString();
+  try {
+    if (token.startsWith("rm_user_")) {
+      // Access token — a scoped user key.
+      await admin
+        .from("user_generated_api_keys")
+        .update({ revoked_at: now })
+        .eq("key_hash", hashApiKey(token))
+        .is("revoked_at", null);
+    } else {
+      // Opaque refresh token.
+      await admin
+        .from("oauth_refresh_tokens")
+        .update({ revoked_at: now })
+        .eq("token_hash", sha256(token))
+        .is("revoked_at", null);
+    }
+  } catch (e) {
+    console.error("[oauth/revoke] revoke failed:", e);
+    // RFC 7009: still return 200 to avoid leaking token validity.
+  }
+
+  return NextResponse.json({}, { status: 200, headers: { ...CORS, "Cache-Control": "no-store" } });
+}

--- a/app/api/oauth/token/route.ts
+++ b/app/api/oauth/token/route.ts
@@ -24,6 +24,7 @@ import {
   REFRESH_TOKEN_TTL_MS,
   KEY_SCOPES,
 } from "@/lib/oauth/server";
+import { clientIp, rateLimit } from "@/lib/oauth/rate-limit";
 
 export const dynamic = "force-dynamic";
 
@@ -104,6 +105,15 @@ async function issueTokens(userId: string, clientId: string, clientName: string 
 }
 
 export async function POST(req: NextRequest) {
+  // Anti-abuse: cap token exchanges per IP (also blunts auth-code / refresh brute force).
+  const rl = await rateLimit("token", clientIp(req), 60, 60);
+  if (!rl.ok) {
+    return NextResponse.json(
+      { error: "too_many_requests", error_description: "Token rate limit exceeded." },
+      { status: 429, headers: { ...CORS, "Cache-Control": "no-store", "Retry-After": String(rl.retryAfter) } },
+    );
+  }
+
   const body = await parseBody(req);
   const grantType = body.grant_type;
   const admin = createAdminClient();
@@ -163,7 +173,23 @@ export async function POST(req: NextRequest) {
       .eq("token_hash", sha256(refreshToken))
       .maybeSingle();
 
-    if (!row || row.revoked_at) return tokenError("invalid_grant", "Refresh token invalid");
+    if (row?.revoked_at) {
+      // Replay of an already-rotated refresh token is a theft signal (RFC 6819
+      // §5.2.2.3): revoke the whole family for this user+client so neither party
+      // can keep refreshing.
+      try {
+        await admin
+          .from("oauth_refresh_tokens")
+          .update({ revoked_at: new Date().toISOString() })
+          .eq("user_id", row.user_id)
+          .eq("client_id", row.client_id)
+          .is("revoked_at", null);
+      } catch (e) {
+        console.error("[oauth/token] family revoke on replay failed:", e);
+      }
+      return tokenError("invalid_grant", "Refresh token invalid");
+    }
+    if (!row) return tokenError("invalid_grant", "Refresh token invalid");
     if (new Date(row.expires_at) < new Date()) return tokenError("invalid_grant", "Refresh token expired");
     if (row.client_id !== clientId) return tokenError("invalid_grant", "client_id mismatch");
 

--- a/app/oauth/authorize/page.tsx
+++ b/app/oauth/authorize/page.tsx
@@ -114,6 +114,13 @@ export default async function AuthorizePage({
           <li>• Signed in as <span className="text-zinc-300">{user.email ?? user.id}</span></li>
         </ul>
 
+        <div className="mt-4 rounded-lg border border-amber-900/40 bg-amber-950/20 px-3 py-2">
+          <p className="text-xs text-amber-200/90">
+            Access will be sent to <code className="text-amber-100">{(() => { try { return new URL(redirectUri).host; } catch { return redirectUri; } })()}</code>.
+            Only approve if you recognize this destination.
+          </p>
+        </div>
+
         <form method="POST" action="/api/oauth/authorize/decision" className="mt-6 flex gap-3">
           <input type="hidden" name="client_id" value={clientId} />
           <input type="hidden" name="redirect_uri" value={redirectUri} />

--- a/lib/oauth/rate-limit.ts
+++ b/lib/oauth/rate-limit.ts
@@ -1,0 +1,64 @@
+/**
+ * IP rate limiter for the unauthenticated OAuth AS endpoints (register, token,
+ * revoke). Fixed-window counter on Upstash Redis with an in-memory fallback
+ * when Redis isn't configured (dev). Best-effort: never blocks a request on a
+ * limiter error — fails open.
+ */
+import { redis } from "@/lib/cache/redis";
+
+const memoryHits = new Map<string, { count: number; resetAt: number }>();
+
+export function clientIp(req: Request): string {
+  const xff = req.headers.get("x-forwarded-for");
+  if (xff) return xff.split(",")[0]!.trim();
+  return req.headers.get("x-real-ip") || "unknown";
+}
+
+export interface RateLimitResult {
+  ok: boolean;
+  remaining: number;
+  retryAfter: number; // seconds
+}
+
+/**
+ * @param bucket   logical name, e.g. "register" | "token"
+ * @param id       per-caller id (usually the client IP)
+ * @param limit    max requests per window
+ * @param windowSec window length in seconds
+ */
+export async function rateLimit(
+  bucket: string,
+  id: string,
+  limit: number,
+  windowSec: number,
+): Promise<RateLimitResult> {
+  const key = `riskmodels:oauth:rl:${bucket}:${id}`;
+
+  if (redis) {
+    try {
+      const count = await redis.incr(key);
+      if (count === 1) await redis.expire(key, windowSec);
+      return { ok: count <= limit, remaining: Math.max(0, limit - count), retryAfter: windowSec };
+    } catch (e) {
+      console.error("[oauth/rate-limit] redis error (failing open):", e);
+      return { ok: true, remaining: limit, retryAfter: 0 };
+    }
+  }
+
+  // In-memory fallback (single instance only — fine for dev / Redis-less).
+  const now = Date.now();
+  const cur = memoryHits.get(key);
+  if (!cur || cur.resetAt <= now) {
+    memoryHits.set(key, { count: 1, resetAt: now + windowSec * 1000 });
+    if (memoryHits.size > 5000) {
+      for (const [k, v] of memoryHits) if (v.resetAt <= now) memoryHits.delete(k);
+    }
+    return { ok: true, remaining: limit - 1, retryAfter: windowSec };
+  }
+  cur.count += 1;
+  return {
+    ok: cur.count <= limit,
+    remaining: Math.max(0, limit - cur.count),
+    retryAfter: Math.ceil((cur.resetAt - now) / 1000),
+  };
+}


### PR DESCRIPTION
Final phase of MCP OAuth (E.20). Rate limiting, RFC 7009 revocation, refresh-revoke cascade on disconnect, and fixes from a security-review pass.

**Hardening:** IP rate limits on register/token/revoke; `/api/oauth/revoke` (RFC 7009) + advertised in AS metadata; disconnecting an OAuth key in /get-key cascades to revoke refresh tokens.

**Security-review fixes:** consent screen now surfaces the redirect destination host (anti-phishing, HIGH); registration blocks cleartext http to non-loopback; refresh replay revokes the token family (RFC 6819).

**Confirmed sound by review:** PKCE S256 constant-time, single-use codes, CSRF Origin check, hashed secrets, session-only user binding, parameterized queries, read-only scope.

Cleanup migration (`BWMACRO/supabase`) prunes the inert `phase-b-verify` test client. Build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)