### PR TITLE
feat(landing): hero connector callout — Add to Claude/Cursor, no terminal

### DIFF
--- a/components/landing/ConnectorHeroCallout.tsx
+++ b/components/landing/ConnectorHeroCallout.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { Copy, Check } from 'lucide-react';
+import { copyTextToClipboard } from '@/lib/copy-to-clipboard';
+
+const MCP_URL = 'https://riskmodels.app/api/mcp/sse';
+
+/**
+ * Hero callout for the no-terminal MCP OAuth connector. Paste the URL into
+ * Claude / Cursor's "Add custom connector", sign in once, done — no API key.
+ */
+export default function ConnectorHeroCallout() {
+  const [copied, setCopied] = useState(false);
+  const copy = () => {
+    void copyTextToClipboard(MCP_URL).then((ok) => {
+      if (ok) {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      }
+    });
+  };
+
+  return (
+    <div className="mx-auto mt-8 max-w-xl rounded-lg border border-zinc-800 bg-zinc-900/40 p-4 text-left">
+      <p className="font-mono text-[11px] uppercase tracking-[0.18em] text-zinc-500">
+        Add to Claude or Cursor · no terminal, no API key
+      </p>
+      <div className="mt-2 flex items-center gap-2 rounded-md border border-zinc-700 bg-zinc-950 px-3 py-2">
+        <code className="flex-1 truncate font-mono text-[13px] text-zinc-200">{MCP_URL}</code>
+        <button
+          onClick={copy}
+          className="inline-flex flex-shrink-0 items-center gap-1.5 rounded border border-zinc-700 px-2 py-1 font-mono text-[11px] text-zinc-400 transition hover:border-zinc-600 hover:text-zinc-100"
+          aria-label="Copy connector URL"
+        >
+          {copied ? <Check className="size-3.5 text-emerald-400" aria-hidden /> : <Copy className="size-3.5" aria-hidden />}
+          {copied ? 'Copied' : 'Copy'}
+        </button>
+      </div>
+      <p className="mt-2 text-[12px] leading-snug text-zinc-500">
+        Settings → Connectors → Add custom connector → paste → Connect. Sign in once and approve; the
+        tools load automatically.{' '}
+        <Link href="/docs/agent-integration" className="text-emerald-400 hover:underline">
+          Setup guide →
+        </Link>
+      </p>
+    </div>
+  );
+}

--- a/components/landing/HeroLanding.tsx
+++ b/components/landing/HeroLanding.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import { ArrowRight, ShieldCheck } from 'lucide-react';
+import ConnectorHeroCallout from '@/components/landing/ConnectorHeroCallout';
 
 export default function HeroLanding() {
   return (
@@ -38,6 +39,7 @@ export default function HeroLanding() {
             See the Worked Example
           </Link>
         </div>
+        <ConnectorHeroCallout />
         <div className="mt-6 flex flex-wrap items-center justify-center gap-2 text-[11px] text-zinc-500">
           <span className="inline-flex items-center gap-1.5 rounded-full border border-emerald-500/40 bg-emerald-500/10 px-2.5 py-1 font-mono uppercase tracking-[0.18em] text-emerald-300">
             <ShieldCheck className="size-3" aria-hidden />


### PR DESCRIPTION
Final step of the MCP OAuth arc (E.20): promote the now-working no-terminal connector in the landing hero. Compact plate under the CTAs — MCP URL + Copy, the Add-custom-connector flow, and a setup-guide link. On-brand with the existing hero + DESIGN.md (institutional plate, no glass/glow/gradient). Build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)