### PR TITLE
chore(audit): retire weekly-audit cron — moved to the mini ops box

### DIFF
--- a/.github/workflows/weekly-audit.yml
+++ b/.github/workflows/weekly-audit.yml
@@ -21,9 +21,14 @@
 name: Weekly API Audit
 
 on:
-  schedule:
-    - cron: '0 13 * * 6'   # Saturday 13:00 UTC (~9am ET, drifts with DST)
-  workflow_dispatch:        # manual run for testing
+  # The scheduled Saturday run was RETIRED 2026-06-08 — it now runs on the Mac
+  # mini ops box as a launchd job (BWMACRO scripts/ops/saturday_audit.sh), which
+  # additionally triages with claude -p and records results in gbrain +
+  # ops_services. This workflow is kept for manual runs only (CI fallback / when
+  # the mini is down). Re-add the `schedule:` block below to restore the cron.
+  #   schedule:
+  #     - cron: '0 13 * * 6'   # Saturday 13:00 UTC
+  workflow_dispatch:        # manual run for testing / CI fallback
 
 concurrency:
   group: weekly-audit


### PR DESCRIPTION
The Saturday drift-audit (added in #134) now runs on the Mac mini as a launchd job (`BWMACRO/scripts/ops/saturday_audit.sh`), which additionally triages with `claude -p` and records results in gbrain + the `ops_services` heartbeat. This retires the redundant GitHub Actions cron so there aren't two Saturday emails.

## Change
- `.github/workflows/weekly-audit.yml`: `schedule:` block **commented out** (not deleted — the cron is one edit away if the mini is down). `workflow_dispatch` kept for manual runs / CI fallback.

## Paired change
BWMACRO PR #49 adds the mini job + `ops_services` table + admin Operations board.

🤖 Generated with [Claude Code](https://claude.com/claude-code)