### PR TITLE
fix(attribution): capture UTM on get-key landing

### DIFF
--- a/app/get-key/page.tsx
+++ b/app/get-key/page.tsx
@@ -7,7 +7,7 @@ import { createClient } from '@/lib/supabase/client';
 import type { User } from '@supabase/supabase-js';
 import { Copy, Check, Trash2, KeyRound, Mail, LogOut, CreditCard, AlertCircle, Zap, Plus, Pencil } from 'lucide-react';
 import { copyTextToClipboard } from '@/lib/copy-to-clipboard';
-import { clearUTMData, getUTMData } from '@/lib/utm';
+import { captureUTMFromURL, clearUTMData, getUTMData } from '@/lib/utm';
 import { captureGclid, getStoredGclid, reportSignupConversion } from '@/lib/google-ads-conversion';
 
 interface ApiKey {
@@ -158,6 +158,11 @@ function GetKeyPage() {
 
     /** Persist the Google click id (gclid/wbraid/gbraid) for phase-2 offline activation import. */
     captureGclid(window.location.search);
+
+    /** Persist UTM (utm_source/medium/campaign + referrer) so social/content signups
+     *  are attributable. getUTMData() reads this back at signup; the capture call was
+     *  previously missing, so utm-tagged inbound links recorded nothing. */
+    captureUTMFromURL(window.location.search);
 
     const code = searchParams.get('code');
     const stripe = searchParams.get('stripe');


### PR DESCRIPTION
get-key's mount effect called `captureGclid()` but never `captureUTMFromURL()`, so `utm_source/medium/campaign` on inbound links were never stored — `getUTMData()` at signup read empty and `signup_attribution` recorded no source. The rest of the chain (`lib/utm`, `parseValidatedSignupUtm`, `persistSignupAttributionIfVacant`) was already wired; this one missing call is why social/content signups are unattributable. One-line fix (mirrors the gclid capture). Paired with BWMACRO posts gaining tracked `?utm_*` signup CTAs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)