### PR TITLE
docs(readme): add Smithery server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ RiskModels provides factor decompositions and ETF-executable hedge ratios for US
 [![Live Docs](https://img.shields.io/badge/Live%20Docs-riskmodels.net%2Fdocs%2Fapi-6366f1)](https://riskmodels.net/docs/api/erm3)
 [![OpenAPI](https://img.shields.io/badge/OpenAPI-3.0.3-85ea2d)](OPENAPI_SPEC.yaml)
 [![PyPI](https://img.shields.io/pypi/v/riskmodels-py.svg)](https://pypi.org/project/riskmodels-py/)
+[![smithery badge](https://smithery.ai/badge/service-c09f/riskmodels)](https://smithery.ai/servers/service-c09f/riskmodels)
 
 ![RiskModels — MAG7 macro correlations & cross-sectional rank snapshot](./assets/readme_inspiration.png)
 


### PR DESCRIPTION
Adds the Smithery badge/link-back to the README badge row.

## Why
Smithery's server verification checklist includes a "link to Smithery" criterion. This adds the official badge for the **service-c09f/riskmodels** server, which doubles as the link-back.

- Badge image: `https://smithery.ai/badge/service-c09f/riskmodels` (verified returns a valid SVG, HTTP 200)
- Links to the live server page: https://smithery.ai/servers/service-c09f/riskmodels

Pairs with the apex `riskmodels.app` `smithery-verification` TXT record (domain verification) added separately in DNS.

## Change
One line added to the existing README badge row (alongside CI / Live Docs / OpenAPI / PyPI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)