### PR TITLE
v0.6.0 feat(seo): sitemap + landing Compare callout + canonical .app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to the RiskModels API surface and public assets.
 
 
+## [0.6.0] — 2026-06-09
+
+### Added
+
+- **`/sitemap.xml`** — Generated sitemap covering the public marketing + docs surface (10 static routes + every `content/docs` MDX page, enumerated automatically). Auth/account/oauth, the print render-snapshot routes, and per-ticker dynamic pages are excluded. `robots.txt` now advertises it via a `Sitemap:` directive.
+- **Landing "Compare" callout** — A buyer-facing band below the research-proof block linking to `/compare/barra-axioma` ("Evaluating against Barra or Axioma?"), giving the comparison page a higher-visibility entry point than the footer/audience-card links alone.
+
+### Fixed
+
+- **Canonical URLs resolve to the public `.app` domain** — Added `metadataBase` (and a shared `CANONICAL_SITE_URL` constant) so relative canonical/OG URLs resolve to `https://riskmodels.app` instead of the request host. The app also answers on `.net` (legacy/terms), and a per-host canonical split SEO signal. The sitemap and `robots.txt` `Sitemap:` directive use the same canonical, not `NEXT_PUBLIC_APP_URL` (which is `.net` in some envs).
+
+
 ## [0.5.0] — 2026-06-09
 
 ### Added

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -8,6 +8,7 @@ import Footer from '@/components/Footer';
 import { ChatBubble } from '@/components/chat/ChatBubble';
 import { GoogleAdsTag } from '@/components/GoogleAdsTag';
 import { UTMTracker } from '@/components/UTMTracker';
+import { CANONICAL_SITE_URL } from '@/lib/constants';
 
 const inter = Inter({ subsets: ['latin'] });
 
@@ -18,6 +19,10 @@ const jetbrainsMono = JetBrains_Mono({
 });
 
 export const metadata: Metadata = {
+  // Resolve relative metadata URLs (canonical, og) against the canonical .app domain,
+  // not the request host — the app also answers on .net, and a per-host canonical would
+  // split SEO signal. See CANONICAL_SITE_URL in lib/constants.
+  metadataBase: new URL(CANONICAL_SITE_URL),
   title: {
     default: 'RiskModels API — Precision Equity Risk Intelligence',
     template: '%s | RiskModels API',

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,6 +3,7 @@ import WorkedExampleHero from '@/components/landing/WorkedExampleHero';
 import AudienceCards from '@/components/landing/AudienceCards';
 import TerminalShowcase from '@/components/TerminalShowcase';
 import ResearchProof from '@/components/landing/ResearchProof';
+import CompareCallout from '@/components/landing/CompareCallout';
 import FailureContrast from '@/components/landing/FailureContrast';
 import RiskWalkthroughWithToggle from '@/components/landing/RiskWalkthroughWithToggle';
 import BridgeSection from '@/components/landing/BridgeSection';
@@ -27,6 +28,7 @@ export default function HomePage() {
       <AudienceCards />
       <TerminalShowcase />
       <ResearchProof />
+      <CompareCallout />
       {SHOW_LEGACY_SECTIONS && (
         <>
           <FailureContrast />

--- a/app/robots.txt/route.ts
+++ b/app/robots.txt/route.ts
@@ -1,4 +1,5 @@
 import { getAppUrl } from '@/lib/app-url';
+import { CANONICAL_SITE_URL } from '@/lib/constants';
 
 /**
  * Plain robots.txt with a comment pointing agents at /llms.txt (llmstxt.org-style bootstrap).
@@ -8,6 +9,8 @@ export async function GET() {
   const body = `# https://www.robotstxt.org/robotstxt.html
 User-agent: *
 Allow: /
+
+Sitemap: ${CANONICAL_SITE_URL}/sitemap.xml
 
 # Machine-readable agent bootstrap (MCP install, curl, optional public MAG7 demo Bearer when enabled):
 # ${base}/llms.txt

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,44 @@
+import type { MetadataRoute } from 'next';
+import { CANONICAL_SITE_URL } from '@/lib/constants';
+import { getAllDocSlugs } from '@/lib/mdx';
+
+/**
+ * Public sitemap. Covers the marketing + docs surface only — auth/account/oauth,
+ * the print render-snapshot routes, and the per-ticker dynamic pages are
+ * intentionally excluded (private, non-indexable, or unbounded). Docs pages are
+ * enumerated from content/docs so new MDX files appear automatically.
+ */
+export default function sitemap(): MetadataRoute.Sitemap {
+  const base = CANONICAL_SITE_URL;
+  const now = new Date();
+
+  // [path, priority] — changeFrequency/lastModified shared below.
+  const staticRoutes: Array<[string, number]> = [
+    ['/', 1.0],
+    ['/compare/barra-axioma', 0.8],
+    ['/pricing', 0.8],
+    ['/docs', 0.8],
+    ['/installation', 0.7],
+    ['/api-reference', 0.7],
+    ['/for-agents', 0.7],
+    ['/cli', 0.6],
+    ['/snapshots', 0.6],
+    ['/legal', 0.3],
+  ];
+
+  const staticEntries: MetadataRoute.Sitemap = staticRoutes.map(([path, priority]) => ({
+    url: `${base}${path}`,
+    lastModified: now,
+    changeFrequency: 'weekly',
+    priority,
+  }));
+
+  const docEntries: MetadataRoute.Sitemap = getAllDocSlugs().map((slug) => ({
+    url: `${base}/docs/${slug}`,
+    lastModified: now,
+    changeFrequency: 'monthly',
+    priority: 0.6,
+  }));
+
+  return [...staticEntries, ...docEntries];
+}

--- a/components/landing/CompareCallout.tsx
+++ b/components/landing/CompareCallout.tsx
@@ -1,0 +1,37 @@
+import Link from 'next/link';
+import { ArrowRight } from 'lucide-react';
+
+/**
+ * Buyer-facing entry point to the /compare/barra-axioma positioning page.
+ * Sits below the research-proof block — the buyer evaluating enterprise risk
+ * platforms is the same reader who just saw the methodology credibility.
+ */
+export default function CompareCallout() {
+  return (
+    <section className="border-b border-zinc-800 bg-black px-4 py-14 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-4xl">
+        <div className="flex flex-col items-start gap-6 rounded-2xl border border-zinc-800 bg-zinc-950/80 p-8 sm:flex-row sm:items-center sm:justify-between">
+          <div className="max-w-xl">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-emerald-400">
+              Evaluating alternatives?
+            </p>
+            <h2 className="mt-3 text-2xl font-bold tracking-tight text-white sm:text-3xl">
+              Evaluating against Barra or Axioma?
+            </h2>
+            <p className="mt-3 text-sm leading-relaxed text-zinc-300">
+              See where RiskModels fits — API-native decomposition with tradable ETF
+              hedge ratios, for teams that need holdings-level risk without an enterprise
+              platform.
+            </p>
+          </div>
+          <Link
+            href="/compare/barra-axioma"
+            className="inline-flex shrink-0 items-center gap-2 rounded-lg bg-emerald-500 px-6 py-3 text-sm font-semibold text-zinc-950 shadow-[0_0_0_1px_rgba(16,185,129,0.4),0_10px_28px_-8px_rgba(16,185,129,0.6)] transition hover:bg-emerald-400"
+          >
+            Compare <ArrowRight className="h-4 w-4" />
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,4 +1,11 @@
 export const RISK_MODEL_VERSION = "3.0";
 
+/**
+ * Canonical public marketing domain. Fixed to .app on purpose — NEXT_PUBLIC_APP_URL
+ * (what getAppUrl() reads) is .net in some envs, which is the legacy/terms host, not
+ * the indexable site. Use this for SEO surfaces (sitemap, robots Sitemap directive).
+ */
+export const CANONICAL_SITE_URL = "https://riskmodels.app";
+
 /** Canonical methodology / provenance URL surfaced to agents (response _agent.provenance, _metadata.wiki_uri). */
-export const METHODOLOGY_URL = "https://riskmodels.app/docs/methodology";
+export const METHODOLOGY_URL = `${CANONICAL_SITE_URL}/docs/methodology`;


### PR DESCRIPTION
## Summary

Follow-up to #152 — the two discoverability items: more prominent linking to the comparison page, and a sitemap. Plus a canonical-domain fix surfaced while wiring the sitemap.

- **`app/sitemap.ts`** — Generated `/sitemap.xml` covering the public marketing + docs surface: 10 static routes + every `content/docs` MDX page (enumerated via `getAllDocSlugs`, so new docs appear automatically). 24 URLs total. Excludes auth/account/oauth, print render-snapshot routes, and per-ticker dynamic pages. `robots.txt` now advertises it via a `Sitemap:` directive.
- **`components/landing/CompareCallout.tsx`** — Buyer-facing landing band ("Evaluating against Barra or Axioma?") below the research-proof block, linking to `/compare/barra-axioma`. Chosen over a Navbar entry to avoid crowding the dev-dense top nav. Reuses the hero's emerald-CTA styling.
- **Canonical fix** — Added `CANONICAL_SITE_URL` (`lib/constants.ts`) and `metadataBase` (`app/layout.tsx`) so relative canonical/OG URLs resolve to `https://riskmodels.app`, not the request host. The sitemap and robots `Sitemap:` directive use this canonical, **not** `getAppUrl()`/`NEXT_PUBLIC_APP_URL` — which is `.net` in some envs (cf. #145) and would have emitted cross-domain `.net` URLs that search engines reject.

## Why the canonical fix

`.net` returns 200 for `/` and `/pricing` (a separate, older property), so a relative `<link rel=canonical>` self-canonicalizes per host and splits SEO signal across `.net`/`.app`. `metadataBase` makes this app's declared canonicals absolute `.app`. Verified: the compare page canonical now renders `https://riskmodels.app/compare/barra-axioma` (was relative).

## Verification (local dev)
- [x] `/sitemap.xml` → 200, 24 URLs, all `https://riskmodels.app`, includes `/compare/barra-axioma` + all docs
- [x] `robots.txt` → `Sitemap: https://riskmodels.app/sitemap.xml`
- [x] Compare page canonical + og:url → absolute `.app`
- [x] Landing band renders between ResearchProof and Pricing (a11y tree confirms placement, heading level, CTA)
- [x] `tsc --noEmit` clean · `next lint` clean

## Not in scope / flagged
- **`.net` duplicate content** for `/` and `/pricing` is a pre-existing issue rooted in the separate `.net` property — not fixable from this repo. `metadataBase` consolidates this app's signal to `.app`; fully resolving `.net` dupes needs canonicals/redirects on that property.
- **Visual:** band is structurally verified; eyeball it on the preview deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)