### PR TITLE
fix(mcp): gate OAuth 401 advertisement behind a flag (key-first default)

### DIFF
--- a/app/api/mcp/sse/route.ts
+++ b/app/api/mcp/sse/route.ts
@@ -53,6 +53,17 @@ function errorResponse(
 // failing at client registration. Tier-1 Bearer API keys still authenticate
 // and never reach this branch.
 //
+// GATED OFF BY DEFAULT (`MCP_ADVERTISE_OAUTH`). RiskModels is API-key-first:
+// the key is how Lisa's team already connects, how the Anthropic directory
+// connector authenticates, and the lowest-friction path for a cold user. The
+// authorization server this header points to (`lib/oauth/server.ts` +
+// `/.well-known/oauth-protected-resource`) is incomplete, so advertising it
+// made keyless discovery probes (Smithery's wizard, Claude's connector wizard)
+// follow the challenge into an OAuth flow that hangs. With the flag off, a
+// keyless request gets a plain 401 whose message tells the client to supply a
+// key — clients fall back to API-key config instead of the hang. Set
+// `MCP_ADVERTISE_OAUTH=true` to restore the challenge once OAuth is finished.
+//
 // Origin is derived from the REQUEST host (the .app origin the client used),
 // not NEXT_PUBLIC_APP_URL — that env points at the .net portal here, which has
 // no OAuth routes; advertising it sends clients to register against .net.
@@ -70,10 +81,14 @@ function wwwAuthenticateHeader(req: NextRequest): Record<string, string> {
 async function handle(req: NextRequest): Promise<Response> {
   const auth = await authenticateMcpRequest(req);
   if (!auth.ok) {
+    // Only advertise the OAuth challenge when explicitly enabled — see
+    // wwwAuthenticateHeader above. Default (flag unset) = key-first, no
+    // advertisement, so keyless wizards get a clean 401 instead of hanging.
+    const advertiseOAuth = process.env.MCP_ADVERTISE_OAUTH === "true";
     return errorResponse(
       auth.status,
       auth.error,
-      auth.status === 401 ? wwwAuthenticateHeader(req) : undefined,
+      auth.status === 401 && advertiseOAuth ? wwwAuthenticateHeader(req) : undefined,
     );
   }
 

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@riskmodels/mcp",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "mcpName": "io.github.BlueWaterCorp/riskmodels",
   "description": "MCP server for RiskModels: decompose US equities into four-bet variance shares with ETF hedge ratios",
   "type": "module",

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/BlueWaterCorp/RiskModels_API",
     "source": "github"
   },
-  "version": "1.0.4",
+  "version": "1.0.5",
   "packages": [
     {
       "identifier": "@riskmodels/mcp",
       "registryType": "npm",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "transport": {
         "type": "stdio",
         "command": "npx",

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -12,7 +12,12 @@
   "packages": [
     {
       "identifier": "@riskmodels/mcp",
-      "registryType": "npm"
+      "registryType": "npm",
+      "transport": {
+        "type": "stdio",
+        "command": "npx",
+        "args": ["-y", "@riskmodels/mcp"]
+      }
     }
   ],
   "remotes": [

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -9,6 +9,12 @@
     "source": "github"
   },
   "version": "1.0.4",
+  "packages": [
+    {
+      "name": "@riskmodels/mcp",
+      "registry": "npm"
+    }
+  ],
   "remotes": [
     {
       "type": "streamable-http",

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -11,8 +11,8 @@
   "version": "1.0.4",
   "packages": [
     {
-      "name": "@riskmodels/mcp",
-      "registry": "npm"
+      "identifier": "@riskmodels/mcp",
+      "registryType": "npm"
     }
   ],
   "remotes": [

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -13,6 +13,7 @@
     {
       "identifier": "@riskmodels/mcp",
       "registryType": "npm",
+      "version": "1.0.4",
       "transport": {
         "type": "stdio",
         "command": "npx",


### PR DESCRIPTION
## Problem
The hosted MCP endpoint (`/api/mcp/sse`) returns the RFC 9728 `WWW-Authenticate: Bearer resource_metadata=…` challenge on a keyless 401. That challenge points at an **incomplete** OAuth authorization server (`lib/oauth/server.ts` + `/.well-known/oauth-protected-resource`). MCP connector wizards (Smithery, Claude's custom-connector setup) probe the endpoint **keyless first**, follow the challenge, and hang in an OAuth flow that never completes.

Verified live:
```
$ curl -i -X POST https://riskmodels.app/api/mcp/sse
HTTP/2 401
www-authenticate: Bearer resource_metadata="https://riskmodels.app/.well-known/oauth-protected-resource"
```

## Fix
Gate the advertisement behind `MCP_ADVERTISE_OAUTH` (**default off**). RiskModels is API-key-first — the key is how existing corporate users connect, how the Anthropic directory connector authenticates, and the lowest-friction path for a cold user. With the flag off, a keyless request returns a plain 401 whose message tells the client to supply `Authorization: Bearer <key>` or `?api_key=<key>`, so wizards fall back to API-key config instead of hanging.

- **Key-bearing requests are unaffected** — they authenticate and never reach the 401 branch.
- **Reversible** — set `MCP_ADVERTISE_OAUTH=true` to restore the challenge once the OAuth server is finished.
- No change to `lib/oauth/server.ts` or the `.well-known` routes (left in place, just no longer advertised).

## Self-test after deploy
1. `curl -i -X POST https://riskmodels.app/api/mcp/sse` → 401 with **no** `www-authenticate` header.
2. Add as a Claude custom connector with `…/api/mcp/sse?api_key=<KEY>` → connects, no OAuth.
3. Add bare URL → prompts cleanly for a key, does not hang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)