### PR TITLE
feat(cli): remote-first MCP install (key-first, no npm-publish dependency)

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "riskmodels",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "description": "RiskModels CLI — REST API, SQL query, schema, billing, and agent manifests",
   "type": "module",
   "bin": {

--- a/cli/src/commands/install.ts
+++ b/cli/src/commands/install.ts
@@ -8,7 +8,12 @@ import {
   sharedRiskmodelsConfigExists,
 } from "../lib/config.js";
 import { detectClients, selectedClients } from "../lib/mcp-config-paths.js";
-import { buildInstallPlans, firstPrompt } from "../lib/mcp-install-plan.js";
+import {
+  buildInstallPlans,
+  firstPrompt,
+  looksLikeRiskmodelsKey,
+  type McpTransport,
+} from "../lib/mcp-install-plan.js";
 import { printResults } from "../lib/display.js";
 import {
   API_KEY_EMAIL_HINT,
@@ -17,7 +22,11 @@ import {
   printInstallSuccessHuman,
 } from "../lib/mcp-cli-human-output.js";
 import { redactSecret } from "../lib/redact.js";
-import { installMcpConfig, writeSharedApiKey } from "../lib/mcp-config-writer.js";
+import {
+  installClaudeCodeRemote,
+  installMcpConfig,
+  writeSharedApiKey,
+} from "../lib/mcp-config-writer.js";
 import { apiRootFromUserBase } from "../lib/api-url.js";
 import { apiFetchOptionalAuth } from "../lib/api-client.js";
 import { warnIfGlobalJsonBeforeSubcommand } from "../lib/global-json-hint.js";
@@ -29,6 +38,8 @@ type InstallOptions = {
   dryRun?: boolean;
   yes?: boolean;
   embedKey?: boolean;
+  remote?: boolean;
+  local?: boolean;
   json?: boolean;
 };
 
@@ -86,7 +97,9 @@ export function installCommand(): Command {
     .option("--api-key <key>", "RiskModels API key for one-shot setup")
     .option("--dry-run", "Show planned config changes without writing")
     .option("--yes", "Non-interactive mode")
-    .option("--embed-key", "Explicitly embed the API key in MCP config env (not recommended)")
+    .option("--remote", "Use the hosted endpoint via mcp-remote (default)")
+    .option("--local", "Use the local stdio server (npx @riskmodels/mcp) instead of the hosted endpoint")
+    .option("--embed-key", "Local stdio only: embed the API key in MCP config env (not recommended)")
     .option("--json", "Structured JSON instead of formatted text (matches historical output shape)")
     .action(async (opts: InstallOptions, cmd: Command) => {
       const json = opts.json || (cmd.optsWithGlobals() as { json?: boolean }).json || false;
@@ -100,20 +113,39 @@ export function installCommand(): Command {
       }
 
       const dryRun = opts.dryRun ?? false;
+      const transport: McpTransport = opts.local ? "local" : "remote";
       const { apiKey, source } = await resolveApiKey(opts);
+
+      if (apiKey && !looksLikeRiskmodelsKey(apiKey)) {
+        const msg =
+          'That does not look like a RiskModels API key (expected an "rm_…" value). ' +
+          "Get one at https://riskmodels.app/get-key";
+        if (json) {
+          warnIfGlobalJsonBeforeSubcommand("install");
+          printResults({ error: msg, apiKey: { source } }, json);
+        } else {
+          console.error(chalk.red(msg));
+        }
+        process.exitCode = 1;
+        return;
+      }
+
       const detections = await detectClients(clients);
-      const plans = buildInstallPlans(detections, { apiKey, embedKey: opts.embedKey });
+      const plans = buildInstallPlans(detections, { apiKey, embedKey: opts.embedKey, transport });
       const existingConfig = await loadConfig();
 
       const output = {
         dryRun,
+        transport,
         apiKey: {
           found: !!apiKey,
           source,
           value: redactSecret(apiKey),
           storage: configPath(),
           willStoreInSharedConfig: !!apiKey && source !== configPath() && !dryRun,
-          embeddedInMcpConfig: !!opts.embedKey,
+          // Remote always carries the key in the Authorization header; local only
+          // embeds it when --embed-key is passed.
+          embeddedInMcpConfig: transport === "remote" ? !!apiKey : !!opts.embedKey,
         },
         clients: plans,
         firstPrompt: firstPrompt(),
@@ -157,13 +189,19 @@ export function installCommand(): Command {
       const sharedBefore = await sharedRiskmodelsConfigExists();
       const sharedConfigWrite = await writeSharedApiKey(apiKey, existingConfig?.apiBaseUrl ?? DEFAULT_API_BASE);
       const writes = await Promise.all(
-        detections.map((detection) =>
-          installMcpConfig(detection, {
+        detections.map((detection) => {
+          // Claude Code reads its own config, not claude_desktop_config.json —
+          // register via its CLI over HTTP transport instead of writing Desktop JSON.
+          if (transport === "remote" && detection.client === "claude" && detection.commandAvailable) {
+            return Promise.resolve(installClaudeCodeRemote(detection, { apiKey }));
+          }
+          return installMcpConfig(detection, {
             apiKey,
             embedKey: opts.embedKey,
             apiBaseUrl: existingConfig?.apiBaseUrl,
-          }),
-        ),
+            transport,
+          });
+        }),
       );
       const test = await connectionTest(existingConfig?.apiBaseUrl);
       const result = {
@@ -184,7 +222,8 @@ export function installCommand(): Command {
           connectionTest: test,
           firstPrompt: firstPrompt(),
           hadErrors: writes.some((w) => w.action === "error") || !test.ok,
-          showClaudeCodeMcpTip: detections.some((d) => d.client === "claude" && d.commandAvailable),
+          showClaudeCodeMcpTip:
+            transport === "local" && detections.some((d) => d.client === "claude" && d.commandAvailable),
         });
       }
       if (writes.some((write) => write.action === "error") || !test.ok) {

--- a/cli/src/lib/mcp-config-writer.ts
+++ b/cli/src/lib/mcp-config-writer.ts
@@ -1,8 +1,13 @@
 import { mkdir, readFile, writeFile, copyFile } from "node:fs/promises";
+import { spawnSync } from "node:child_process";
 import path from "node:path";
 import { configPath, DEFAULT_API_BASE, loadConfig, type RiskmodelsConfig } from "./config.js";
 import type { ClientDetection } from "./mcp-config-paths.js";
-import { defaultMcpServerConfig } from "./mcp-install-plan.js";
+import {
+  claudeCodeRemoteAddArgs,
+  mcpServerConfigFor,
+  type McpTransport,
+} from "./mcp-install-plan.js";
 
 export interface ConfigWriteResult {
   client: string;
@@ -17,6 +22,7 @@ export interface SafeWriteOptions {
   apiKey?: string;
   embedKey?: boolean;
   apiBaseUrl?: string;
+  transport?: McpTransport;
   now?: Date;
 }
 
@@ -214,7 +220,7 @@ export async function installMcpConfig(
 
   try {
     const { exists, text } = await readIfExists(detection.configPath);
-    const mcpServer = defaultMcpServerConfig(opts.apiKey, !!opts.embedKey);
+    const mcpServer = mcpServerConfigFor(opts.transport ?? "remote", opts.apiKey, !!opts.embedKey);
     const nextText =
       detection.client === "codex"
         ? mergeCodexTomlConfig(text, mcpServer)
@@ -237,6 +243,47 @@ export async function installMcpConfig(
       message: error instanceof Error ? error.message : String(error),
     };
   }
+}
+
+/**
+ * Register the hosted endpoint with Claude Code via its own CLI
+ * (`claude mcp add --transport http …`) instead of writing Desktop JSON —
+ * Claude Code reads its own config, not claude_desktop_config.json. Idempotent:
+ * removes any existing `riskmodels` entry first so re-running doesn't error on
+ * "already exists". Used for the remote transport when the `claude` CLI is present.
+ */
+export function installClaudeCodeRemote(
+  detection: ClientDetection,
+  opts: { apiKey?: string } = {},
+): ConfigWriteResult {
+  const base = {
+    client: detection.client,
+    label: detection.label,
+    configPath: detection.configPath,
+  };
+  // Best-effort removal of a prior entry — ignore failure (none registered yet).
+  spawnSync("claude", ["mcp", "remove", "--scope", "user", "riskmodels"], { stdio: "ignore" });
+
+  const res = spawnSync("claude", claudeCodeRemoteAddArgs(opts.apiKey), {
+    stdio: "pipe",
+    encoding: "utf8",
+  });
+  if (res.error) {
+    return { ...base, action: "error", message: `Failed to run \`claude\`: ${res.error.message}` };
+  }
+  if (res.status === 0) {
+    return {
+      ...base,
+      action: "written",
+      message: "Registered with Claude Code via `claude mcp add --transport http` (user scope).",
+    };
+  }
+  const detail = (res.stderr || res.stdout || "").trim();
+  return {
+    ...base,
+    action: "error",
+    message: detail || `\`claude mcp add\` exited with status ${res.status ?? "unknown"}.`,
+  };
 }
 
 export function removeJsonMcpConfig(existingText: string): { text: string; removed: boolean } {

--- a/cli/src/lib/mcp-install-plan.ts
+++ b/cli/src/lib/mcp-install-plan.ts
@@ -1,5 +1,5 @@
 import type { ClientDetection } from "./mcp-config-paths.js";
-import { redactJson } from "./redact.js";
+import { redactJson, redactSecret } from "./redact.js";
 
 export interface InstallPlan {
   client: string;
@@ -11,6 +11,15 @@ export interface InstallPlan {
   mcpServer: unknown;
 }
 
+/** Hosted MCP endpoint (Streamable HTTP). Key-first auth, no npm publish needed. */
+export const REMOTE_MCP_URL = "https://riskmodels.app/api/mcp/sse";
+
+export type McpTransport = "remote" | "local";
+
+/**
+ * Local stdio path: runs the published `@riskmodels/mcp` server via npx. The key
+ * is read from the shared config by default; `--embed-key` writes it into env.
+ */
 export function defaultMcpServerConfig(apiKey?: string, embedKey = false): unknown {
   return {
     command: "npx",
@@ -25,19 +34,89 @@ export function defaultMcpServerConfig(apiKey?: string, embedKey = false): unkno
   };
 }
 
+/**
+ * Remote path (default): bridges a stdio client to the hosted endpoint via
+ * `mcp-remote`. The key rides in an `Authorization: Bearer` header — kept out of
+ * the URL so it never lands in server access logs or referrers. Works today with
+ * no npm publish dependency.
+ */
+export function remoteMcpServerConfig(apiKey?: string): unknown {
+  const args = ["-y", "mcp-remote", REMOTE_MCP_URL];
+  if (apiKey) {
+    args.push("--header", `Authorization: Bearer ${apiKey}`);
+  }
+  return { command: "npx", args };
+}
+
+/**
+ * Native `claude mcp add` args for Claude Code — registers the hosted endpoint
+ * over HTTP transport at user scope (no mcp-remote shim needed; Claude Code
+ * speaks Streamable HTTP directly).
+ */
+export function claudeCodeRemoteAddArgs(apiKey?: string): string[] {
+  const args = ["mcp", "add", "--scope", "user", "--transport", "http", "riskmodels", REMOTE_MCP_URL];
+  if (apiKey) {
+    args.push("--header", `Authorization: Bearer ${apiKey}`);
+  }
+  return args;
+}
+
+export function mcpServerConfigFor(
+  transport: McpTransport,
+  apiKey?: string,
+  embedKey = false,
+): unknown {
+  return transport === "remote"
+    ? remoteMcpServerConfig(apiKey)
+    : defaultMcpServerConfig(apiKey, embedKey);
+}
+
+/** RiskModels keys are `rm_agent_live_…` / `rm_…`. Cheap client-side sanity check. */
+export function looksLikeRiskmodelsKey(key: string): boolean {
+  return /^rm_[A-Za-z0-9_]+$/.test(key.trim());
+}
+
+/**
+ * Mask `Authorization: Bearer <token>` strings anywhere in a config tree.
+ * `redactJson` only masks values whose *key name* matches (e.g. `env.RISKMODELS_API_KEY`);
+ * the remote header lives inside an `args` string, so it needs this pass too.
+ */
+export function redactBearerStrings(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(redactBearerStrings);
+  if (typeof value === "string") {
+    const m = value.match(/^(Authorization:\s*Bearer\s+)(.+)$/i);
+    return m ? `${m[1]}${redactSecret(m[2])}` : value;
+  }
+  if (value && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value)) out[k] = redactBearerStrings(v);
+    return out;
+  }
+  return value;
+}
+
 export function buildInstallPlans(
   detections: ClientDetection[],
-  opts: { apiKey?: string; embedKey?: boolean },
+  opts: { apiKey?: string; embedKey?: boolean; transport: McpTransport },
 ): InstallPlan[] {
-  return detections.map((detection) => ({
-    client: detection.client,
-    label: detection.label,
-    status: detection.status,
-    mode: detection.mode,
-    configPath: detection.configPath,
-    notes: detection.notes,
-    mcpServer: redactJson(defaultMcpServerConfig(opts.apiKey, opts.embedKey)),
-  }));
+  return detections.map((detection) => {
+    const claudeCodeNative =
+      opts.transport === "remote" && detection.client === "claude" && detection.commandAvailable;
+    const mcpServer = redactBearerStrings(
+      redactJson(mcpServerConfigFor(opts.transport, opts.apiKey, opts.embedKey)),
+    );
+    return {
+      client: detection.client,
+      label: detection.label,
+      status: detection.status,
+      mode: claudeCodeNative ? "command" : detection.mode,
+      configPath: detection.configPath,
+      notes: claudeCodeNative
+        ? [...detection.notes, "Remote: will register via `claude mcp add --transport http` (user scope)."]
+        : detection.notes,
+      mcpServer,
+    };
+  });
 }
 
 export function firstPrompt(): string {


### PR DESCRIPTION
## Why
RiskModels is API-key-first, and the **remote hosted endpoint** is the lowest-friction "install from anywhere" path — it works today, needs no npm publish, and matches the Anthropic directory listing. But `riskmodels install` defaulted to the **local stdio** path (`npx @riskmodels/mcp`), which is currently blocked on republish. This flips the default to remote.

Pairs with #155 (which removes the keyless OAuth-advertisement hang on the same endpoint).

## What changed
- **Remote is the default.** `riskmodels install` writes the hosted-endpoint config; `--local` opts into the stdio path.
- **Key-first via header.** The key rides in `Authorization: Bearer` (mcp-remote `--header`), kept out of the URL so it can't leak into access logs/referrers. New `redactBearerStrings` masks the token in dry-run/JSON output (`redactJson` only masks by key *name*; the header is an `args` string).
- **Claude Code native registration.** When the `claude` CLI is present, registers via `claude mcp add --scope user --transport http riskmodels <url> --header …` (idempotent remove-then-add) — Claude Code reads its own config, not `claude_desktop_config.json`. Desktop / Cursor / Codex get the `mcp-remote` shim through the existing safe-write/backup machinery.
- **Early key validation** (`rm_` prefix) fails before any file write.
- CLI **2.0.2 → 2.1.0**.

## Verification (local)
- `tsc` clean.
- `install --all --dry-run --json` (remote default) → every client gets `npx -y mcp-remote …/api/mcp/sse --header "Authorization: Bearer rm_age...0XYZ"` (**redacted**), `transport: remote`.
- `install --local …` → `npx -y @riskmodels/mcp`.
- `install --api-key not-a-real-key` → rejected, exit 1.

## Follow-ups (not in this PR)
- Surface the two zero-install copy-paste one-liners (the `claude mcp add …` line + the raw `?api_key=` connector URL for claude.ai chat) in `mcp-config` / a `connect` helper.
- Local-stdio republish track (`@riskmodels/mcp` to npm) remains separate — see `mcp/NPM_REPUBLISH_CHECKLIST.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)