### PR TITLE
feat(mcp): expose stock returns as MCP tools (broaden beyond risk decomposition)

### DIFF
--- a/lib/mcp/tools/riskmodels-tools.ts
+++ b/lib/mcp/tools/riskmodels-tools.ts
@@ -116,6 +116,8 @@ export function registerRiskModelsTools(
     | "hedgePortfolio"
     | "portfolioDecompose"
     | "whitepaperExample"
+    | "getReturns"
+    | "getReturnAttribution"
   >,
   server: McpLikeServer,
 ): void {
@@ -133,6 +135,75 @@ export function registerRiskModelsTools(
     async ({ ticker }) => {
       try {
         return textResult(await sdk.decompose(ticker));
+      } catch (error) {
+        return errorResult(error);
+      }
+    },
+  );
+
+  server.registerTool(
+    "riskmodels_get_returns",
+    {
+      title: "RiskModels Stock Total Returns",
+      annotations: { readOnlyHint: true },
+      description:
+        "Daily dividend-adjusted total (gross) return series for any US stock or ETF (GET /ticker-returns), with per-day L3 market/sector/subsector hedge ratios and explained-risk fractions (sum to ~1.0). Up to 15 years of point-in-time, time-safe history. Use for performance tracking, backtests, or as the clean returns input to any risk or attribution work.",
+      inputSchema: {
+        ticker: z.string().min(1).describe("Ticker symbol, e.g. NVDA or AAPL"),
+        years: z
+          .number()
+          .int()
+          .min(1)
+          .max(15)
+          .optional()
+          .describe("Years of daily history (default 1, max 15)"),
+      },
+    },
+    async ({ ticker, years }) => {
+      try {
+        return textResult(await sdk.getReturns(ticker, { years }));
+      } catch (error) {
+        return errorResult(error);
+      }
+    },
+  );
+
+  server.registerTool(
+    "riskmodels_get_return_attribution",
+    {
+      title: "RiskModels Return Attribution (factor vs residual)",
+      annotations: { readOnlyHint: true },
+      description:
+        "Daily return attribution (GET /returns-decomposition): decomposes each day's gross return into additive L1/L2/L3 factor (market/sector/subsector) and residual (stock-specific) return components from ds_erm3_returns. Isolates the residual return series — the stock-picking / alpha component — for manager-skill evaluation and stat-arb. Set include_lstar for the Lstar-dispatched residual series.",
+      inputSchema: {
+        ticker: z.string().min(1).describe("Ticker symbol, e.g. NVDA or AAPL"),
+        years: z
+          .number()
+          .int()
+          .min(1)
+          .optional()
+          .describe("Calendar years of daily history (default 1)"),
+        market_factor_etf: z.string().optional().describe("Market factor ETF (default SPY)"),
+        include_lstar: z
+          .boolean()
+          .optional()
+          .describe("Include lstar + lstar_residual_return arrays (default false)"),
+        threshold: z
+          .number()
+          .optional()
+          .describe("Marginal ER threshold for Lstar derivation (default 0.01)"),
+      },
+    },
+    async ({ ticker, years, market_factor_etf, include_lstar, threshold }) => {
+      try {
+        return textResult(
+          await sdk.getReturnAttribution(ticker, {
+            years,
+            marketFactorEtf: market_factor_etf,
+            includeLstar: include_lstar,
+            threshold,
+          }),
+        );
       } catch (error) {
         return errorResult(error);
       }

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.BlueWaterCorp/riskmodels",
   "title": "RiskModels",
-  "description": "US equity risk: decompose any stock into market/sector/subsector/residual bets + ETF hedge ratios.",
+  "description": "Clean dividend-adjusted US equity total returns, plus institutional risk decomposition, factor-vs-residual return attribution, and executable ETF hedge ratios. Read-only, point-in-time, structured outputs.",
   "websiteUrl": "https://riskmodels.app",
   "repository": {
     "url": "https://github.com/BlueWaterCorp/RiskModels_API",

--- a/packages/riskmodels-sdk/src/client.ts
+++ b/packages/riskmodels-sdk/src/client.ts
@@ -65,6 +65,15 @@ function redactedCurl(apiCall: Omit<ApiCallMetadata, "curl">): string {
   return parts.join(" ");
 }
 
+/** Wrap a raw GET payload with the request metadata, without a bespoke normalizer. */
+function attachApiCall(raw: unknown, apiCall: ApiCallMetadata): Record<string, unknown> {
+  const payload =
+    raw && typeof raw === "object" && !Array.isArray(raw)
+      ? (raw as Record<string, unknown>)
+      : { data: raw };
+  return { ...payload, api_call: apiCall };
+}
+
 function positionWeight(position: PositionInput): number {
   const value = position.weight ?? position.dollars;
   if (value === undefined || !Number.isFinite(value) || value <= 0) {
@@ -213,6 +222,49 @@ export class RiskModelsClient {
 
   async whitepaperExample(exampleId: Parameters<typeof runWhitepaperExample>[1]) {
     return runWhitepaperExample(this, exampleId);
+  }
+
+  /**
+   * GET /ticker-returns — daily dividend-adjusted total (gross) return series for a
+   * single name, with per-day L3 market/sector/subsector hedge ratios and
+   * explained-risk fractions. Up to 15 years of point-in-time history.
+   */
+  async getReturns(
+    ticker: string,
+    options: { years?: number; array?: string } = {},
+  ): Promise<Record<string, unknown>> {
+    const query: Record<string, string | number | boolean> = {
+      ticker: ticker.trim().toUpperCase(),
+    };
+    if (options.years !== undefined) query.years = options.years;
+    if (options.array !== undefined) query.array = options.array;
+    const { raw, apiCall } = await this.request("GET", "/ticker-returns", { query });
+    return attachApiCall(raw, apiCall);
+  }
+
+  /**
+   * GET /returns-decomposition — daily gross return decomposed into additive
+   * L1/L2/L3 factor (market/sector/subsector) and residual return components,
+   * isolating residual (stock-specific) return. Optional Lstar dispatch.
+   */
+  async getReturnAttribution(
+    ticker: string,
+    options: {
+      years?: number;
+      marketFactorEtf?: string;
+      includeLstar?: boolean;
+      threshold?: number;
+    } = {},
+  ): Promise<Record<string, unknown>> {
+    const query: Record<string, string | number | boolean> = {
+      ticker: ticker.trim().toUpperCase(),
+    };
+    if (options.years !== undefined) query.years = options.years;
+    if (options.marketFactorEtf !== undefined) query.market_factor_etf = options.marketFactorEtf;
+    if (options.includeLstar !== undefined) query.include_lstar = options.includeLstar;
+    if (options.threshold !== undefined) query.threshold = options.threshold;
+    const { raw, apiCall } = await this.request("GET", "/returns-decomposition", { query });
+    return attachApiCall(raw, apiCall);
   }
 
   private async request(

--- a/tests/onboarding-upgrade.test.ts
+++ b/tests/onboarding-upgrade.test.ts
@@ -125,6 +125,7 @@ describe("RiskModels CLI installer planning", () => {
     const plans = buildInstallPlans(detections, {
       apiKey: "rm_agent_live_abcdefghijklmnopqrstuvwxyz",
       embedKey: true,
+      transport: "local",
     });
 
     expect(plans[0].mcpServer).toEqual({
@@ -223,6 +224,8 @@ describe("RiskModels MCP live-paper tools", () => {
 
     expect([...tools.keys()]).toEqual([
       "riskmodels_decompose",
+      "riskmodels_get_returns",
+      "riskmodels_get_return_attribution",
       "riskmodels_get_hedge_levels",
       "riskmodels_compare",
       "riskmodels_hedge_position",


### PR DESCRIPTION
## Why
Refining the MCP positioning to reach a broader audience ("clean stock returns," not just hedging quants) surfaced a gap: **the API has the returns data, but MCP never exposed it as a tool.** All 12 existing MCP tools are decomposition / hedge / portfolio-risk. So "stock returns via MCP" was a promise the tools couldn't keep. This closes that gap so the broadened copy is *true*.

## New tools (both read-only, wrap existing REST endpoints)
| Tool | Endpoint | Returns |
|---|---|---|
| `riskmodels_get_returns` | `GET /ticker-returns` ($0.005) | Daily dividend-adjusted **total (gross) return** series + per-day L3 hedge ratios & ER fractions; up to 15y point-in-time |
| `riskmodels_get_return_attribution` | `GET /returns-decomposition` ($0.02) | Daily gross decomposed into **L1/L2/L3 factor + residual** return; isolates the residual (stock-picking/alpha) series; optional Lstar |

## Changes
- **SDK** (`packages/riskmodels-sdk`): `getReturns` / `getReturnAttribution` on `RiskModelsClient` + `attachApiCall` helper.
- **Tools** (`lib/mcp/tools/riskmodels-tools.ts`): register both, extend the `Pick` type. Shared by **both** servers (hosted `lib/mcp` + stdio `mcp/`), so they appear in each.
- **`server.json`**: description reworked to lead with returns.
- **Test fix**: a latent typecheck break from #156 (`buildInstallPlans` called without the now-required `transport`) — `next build` doesn't typecheck tests so it slipped through; fixed + tool-list assertion updated.

## Verification
- `tsc --noEmit` clean; **10/10** onboarding tests pass.
- Live contract check (demo key): `ticker-returns` → 250 daily rows incl. `returns_gross`; `returns-decomposition` → HTTP 200.
- Hosted server deploys on merge → the claude.ai connector gains both tools live.

## Copy follow-ups (not code — your call)
- **Smithery listing description** (set in Smithery UI): suggest leading with returns, same as `server.json`.
- `mcp/package.json` description + the precision claims ("19+ yrs out-of-sample, ±0.1%") — left for the republish track; recommend dropping unverified precision per methodology-rigor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)