### PR TITLE
feat(mcp): Tier-A capability tools + generic passthrough (full API reachable via MCP)

### DIFF
--- a/lib/mcp/server.ts
+++ b/lib/mcp/server.ts
@@ -300,7 +300,9 @@ export function createMcpServer(opts: McpServerOptions): McpServer {
 
   // --- Tools ---
 
-  registerRiskModelsTools(sdk, server);
+  registerRiskModelsTools(sdk, server, {
+    capabilities: loadJson<Array<{ method?: string; endpoint?: string }>>("capabilities.json") ?? [],
+  });
   // Hosted-only: the render tool needs GCP Cloud Run auth, so it lives outside
   // lib/mcp/tools/ and is not compiled into the public stdio package.
   registerRiskModelsRenderTool(server);

--- a/lib/mcp/tools/riskmodels-tools.ts
+++ b/lib/mcp/tools/riskmodels-tools.ts
@@ -105,6 +105,57 @@ export function createRiskModelsSdk(opts: { apiKey?: string | null; apiBase?: st
   });
 }
 
+/** Capabilities/paths the generic passthrough must never reach (SQL, Plaid, chat). */
+const PASSTHROUGH_BLOCKED = [/^\/cli(\/|$)/i, /^\/plaid(\/|$)/i, /^\/chat(\/|$)/i];
+
+/**
+ * Normalize a passthrough path BEFORE any allow/deny decision: decode, drop a
+ * query string, strip a leading `/api`, and resolve `.`/`..` segments. Resolving
+ * traversal here is what stops `/x/../cli/query` from reaching a blocked endpoint
+ * after URL normalization downstream.
+ */
+export function normalizeApiPath(raw: string): string {
+  let p = (raw ?? "").trim();
+  try {
+    p = decodeURIComponent(p);
+  } catch {
+    /* keep undecoded */
+  }
+  const qi = p.indexOf("?");
+  if (qi >= 0) p = p.slice(0, qi);
+  if (!p.startsWith("/")) p = `/${p}`;
+  p = p.replace(/^\/api(?=\/|$)/, "");
+  const out: string[] = [];
+  for (const seg of p.split("/")) {
+    if (seg === "" || seg === ".") continue;
+    if (seg === "..") {
+      out.pop();
+      continue;
+    }
+    out.push(seg);
+  }
+  return `/${out.join("/")}`;
+}
+
+function endpointToMatcher(method: string, endpoint: string): { method: string; re: RegExp } {
+  const path = endpoint.replace(/^\/api(?=\/|$)/, "");
+  const parts = path
+    .split("/")
+    .map((seg) => (/^\{.+\}$/.test(seg) ? "[^/]+" : seg.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+  return { method: method.toUpperCase(), re: new RegExp(`^${parts.join("/")}$`) };
+}
+
+/** Allowlist of {method, path-pattern} the passthrough may dispatch — registered, non-blocked capabilities only. */
+export function buildPassthroughAllowlist(
+  capabilities: Array<{ method?: string; endpoint?: string }>,
+): Array<{ method: string; re: RegExp }> {
+  return capabilities
+    .filter((c) => typeof c.method === "string" && typeof c.endpoint === "string")
+    .map((c) => ({ method: c.method as string, path: (c.endpoint as string).replace(/^\/api(?=\/|$)/, "") }))
+    .filter((c) => !PASSTHROUGH_BLOCKED.some((re) => re.test(c.path)))
+    .map((c) => endpointToMatcher(c.method, c.path));
+}
+
 export function registerRiskModelsTools(
   sdk: Pick<
     RiskModelsClient,
@@ -121,7 +172,10 @@ export function registerRiskModelsTools(
     | "call"
   >,
   server: McpLikeServer,
+  opts: { capabilities?: Array<{ method?: string; endpoint?: string; [k: string]: unknown }> } = {},
 ): void {
+  const passthroughAllowlist = buildPassthroughAllowlist(opts.capabilities ?? []);
+
   server.registerTool(
     "riskmodels_decompose",
     {
@@ -717,16 +771,21 @@ export function registerRiskModelsTools(
     },
     async ({ method, path, query, body }) => {
       try {
-        let p = path.trim();
-        if (!p.startsWith("/")) p = `/${p}`;
-        p = p.replace(/^\/api(?=\/)/, ""); // list_endpoints shows "/api/..."; baseUrl already includes /api
-        const blocked = [/^\/cli\/query/i, /^\/plaid/i, /^\/chat\b/i];
-        if (blocked.some((re) => re.test(p))) {
+        // Normalize FIRST (resolves ./.. and strips /api), then allowlist-match the
+        // normalized path against registered, non-blocked capabilities. This is
+        // traversal-safe: "/x/../cli/query" normalizes to "/cli/query", which is
+        // not in the allowlist, so it is rejected — a prefix denylist on the raw
+        // path would have let it through after URL normalization.
+        const norm = normalizeApiPath(path);
+        const allowed = passthroughAllowlist.some((a) => a.method === method && a.re.test(norm));
+        if (!allowed) {
           return errorResult(
-            new Error(`Path ${p} is not available via the passthrough (SQL/Plaid/chat). Use the REST API directly.`),
+            new Error(
+              `Path ${norm} (${method}) is not an invocable capability. Run riskmodels_list_endpoints for the allowed set; SQL/Plaid/chat are not exposed via the passthrough.`,
+            ),
           );
         }
-        return textResult(await sdk.call(method, p, { query, body }));
+        return textResult(await sdk.call(method, norm, { query, body }));
       } catch (error) {
         return errorResult(error);
       }

--- a/lib/mcp/tools/riskmodels-tools.ts
+++ b/lib/mcp/tools/riskmodels-tools.ts
@@ -118,6 +118,7 @@ export function registerRiskModelsTools(
     | "whitepaperExample"
     | "getReturns"
     | "getReturnAttribution"
+    | "call"
   >,
   server: McpLikeServer,
 ): void {
@@ -388,6 +389,344 @@ export function registerRiskModelsTools(
     async ({ exampleId }) => {
       try {
         return textResult(await sdk.whitepaperExample(exampleId as WhitepaperExampleId));
+      } catch (error) {
+        return errorResult(error);
+      }
+    },
+  );
+
+  // --- Entity resolution (free discovery) ---
+
+  server.registerTool(
+    "riskmodels_search_tickers",
+    {
+      title: "RiskModels Ticker Search",
+      annotations: { readOnlyHint: true },
+      description:
+        'Resolve a symbol or company name to RiskModels tickers (GET /tickers). Free — use this first to turn a name like "Nvidia" into a ticker before any analysis tool. mag7=true returns the Magnificent Seven.',
+      inputSchema: {
+        search: z.string().optional().describe('Symbol or company-name fragment, e.g. "nvidia" or "NVDA"'),
+        mag7: z.boolean().optional().describe("Return the MAG7 set"),
+        include_metadata: z.boolean().optional().describe("Include extra metadata per match"),
+      },
+    },
+    async ({ search, mag7, include_metadata }) => {
+      try {
+        const query: Record<string, string | number | boolean> = {};
+        if (search !== undefined) query.search = search;
+        if (mag7 !== undefined) query.mag7 = mag7;
+        if (include_metadata !== undefined) query.include_metadata = include_metadata;
+        return textResult(await sdk.call("GET", "/tickers", { query }));
+      } catch (error) {
+        return errorResult(error);
+      }
+    },
+  );
+
+  server.registerTool(
+    "riskmodels_search_filers",
+    {
+      title: "RiskModels 13F Filer Search",
+      annotations: { readOnlyHint: true },
+      description:
+        "Find 13F filers by name (GET /13f/filers/search). Free — resolve a manager like \"Berkshire\" to a bw_filer_id before pulling its snapshot, holdings, or concentration.",
+      inputSchema: {
+        q: z.string().min(1).describe("Filer name fragment, e.g. \"berkshire\""),
+        limit: z.number().int().min(1).max(100).optional().describe("Max results (default 25)"),
+      },
+    },
+    async ({ q, limit }) => {
+      try {
+        const query: Record<string, string | number | boolean> = { q };
+        if (limit !== undefined) query.limit = limit;
+        return textResult(await sdk.call("GET", "/13f/filers/search", { query }));
+      } catch (error) {
+        return errorResult(error);
+      }
+    },
+  );
+
+  server.registerTool(
+    "riskmodels_search_etfs",
+    {
+      title: "RiskModels ETF Search",
+      annotations: { readOnlyHint: true },
+      description:
+        "Find ETFs in the canonical universe by symbol or name (GET /data/etf/search). Free — resolve a hedge/benchmark ETF before pulling its metrics or holdings.",
+      inputSchema: {
+        q: z.string().optional().describe("Symbol or name fragment, e.g. \"semiconductor\" or \"SMH\""),
+        limit: z.number().int().min(1).max(100).optional().describe("Max results (default 25)"),
+      },
+    },
+    async ({ q, limit }) => {
+      try {
+        const query: Record<string, string | number | boolean> = {};
+        if (q !== undefined) query.q = q;
+        if (limit !== undefined) query.limit = limit;
+        return textResult(await sdk.call("GET", "/data/etf/search", { query }));
+      } catch (error) {
+        return errorResult(error);
+      }
+    },
+  );
+
+  // --- Cross-sectional / peer analytics ---
+
+  server.registerTool(
+    "riskmodels_get_rankings",
+    {
+      title: "RiskModels Cross-Sectional Rankings",
+      annotations: { readOnlyHint: true },
+      description:
+        "Where a stock sits in its sector/universe percentile for a given metric (GET /rankings/{ticker}) — peer analytics / manager-skill context.",
+      inputSchema: {
+        ticker: z.string().min(1).describe("Ticker symbol, e.g. NVDA"),
+        metric: z.string().optional().describe("Ranking metric (see riskmodels_get_capability id=rankings)"),
+        cohort: z.string().optional().describe("Peer cohort, e.g. sector or universe"),
+        window: z.string().optional().describe("Lookback window"),
+      },
+    },
+    async ({ ticker, metric, cohort, window }) => {
+      try {
+        const query: Record<string, string | number | boolean> = {};
+        if (metric !== undefined) query.metric = metric;
+        if (cohort !== undefined) query.cohort = cohort;
+        if (window !== undefined) query.window = window;
+        return textResult(
+          await sdk.call("GET", `/rankings/${encodeURIComponent(ticker.trim().toUpperCase())}`, { query }),
+        );
+      } catch (error) {
+        return errorResult(error);
+      }
+    },
+  );
+
+  server.registerTool(
+    "riskmodels_screen_rankings",
+    {
+      title: "RiskModels Rankings Screen",
+      annotations: { readOnlyHint: true },
+      description:
+        "Full cross-section rank screen (POST /rankings/screen): server-side percentile/decile filtering across the universe for a metric. Use to build screens, not single-ticker lookups.",
+      inputSchema: {
+        metric: z.string().min(1).describe("Ranking metric"),
+        cohort: z.string().min(1).describe("Peer cohort"),
+        window: z.string().min(1).describe("Lookback window"),
+        as_of: z.string().optional().describe("As-of date (YYYY-MM-DD)"),
+        min_percentile: z.number().optional().describe("Minimum percentile filter"),
+        decile: z.number().int().optional().describe("Restrict to a decile (1-10)"),
+        sector_filter: z.string().optional().describe("Restrict to a sector"),
+        limit: z.number().int().optional().describe("Max rows (default 100)"),
+      },
+    },
+    async ({ metric, cohort, window, as_of, min_percentile, decile, sector_filter, limit }) => {
+      try {
+        const body: Record<string, unknown> = { metric, cohort, window };
+        if (as_of !== undefined) body.as_of = as_of;
+        if (min_percentile !== undefined) body.min_percentile = min_percentile;
+        if (decile !== undefined) body.decile = decile;
+        if (sector_filter !== undefined) body.sector_filter = sector_filter;
+        if (limit !== undefined) body.limit = limit;
+        return textResult(await sdk.call("POST", "/rankings/screen", { body }));
+      } catch (error) {
+        return errorResult(error);
+      }
+    },
+  );
+
+  server.registerTool(
+    "riskmodels_get_macro_correlation",
+    {
+      title: "RiskModels Macro Factor Correlation",
+      annotations: { readOnlyHint: true },
+      description:
+        "Exposure of a stock's returns to macro drivers like rates and volatility (POST /correlation). Defaults to the L3 residual return so it isolates idiosyncratic macro sensitivity.",
+      inputSchema: {
+        ticker: z.string().min(1).describe("Ticker symbol, e.g. NVDA"),
+        factors: z.array(z.string()).optional().describe("Macro factor ids to test (default: standard set)"),
+        return_type: z.string().optional().describe('Return series to correlate (default "l3_residual")'),
+        window_days: z.number().int().optional().describe("Rolling window in days (default 252)"),
+        method: z.string().optional().describe('"pearson" (default) or "spearman"'),
+      },
+    },
+    async ({ ticker, factors, return_type, window_days, method }) => {
+      try {
+        const body: Record<string, unknown> = { ticker: ticker.trim().toUpperCase() };
+        if (factors !== undefined) body.factors = factors;
+        if (return_type !== undefined) body.return_type = return_type;
+        if (window_days !== undefined) body.window_days = window_days;
+        if (method !== undefined) body.method = method;
+        return textResult(await sdk.call("POST", "/correlation", { body }));
+      } catch (error) {
+        return errorResult(error);
+      }
+    },
+  );
+
+  server.registerTool(
+    "riskmodels_get_residual_signal",
+    {
+      title: "RiskModels Residual Mean-Reversion Signal",
+      annotations: { readOnlyHint: true },
+      description:
+        "Aggregate the L3 residual mean-reversion (stat-arb) signal across a basket (POST /signals/residual-reversion/basket). Optional weights and a minimum signal-quality quintile filter.",
+      inputSchema: {
+        tickers: z.array(z.string().min(1)).min(1).max(100).describe("Basket tickers"),
+        weights: z.array(z.number()).optional().describe("Optional weights, aligned to tickers"),
+        signal_quality_min_quintile: z
+          .number()
+          .int()
+          .min(1)
+          .max(5)
+          .optional()
+          .describe("Drop names below this signal-quality quintile (1-5)"),
+      },
+    },
+    async ({ tickers, weights, signal_quality_min_quintile }) => {
+      try {
+        const body: Record<string, unknown> = {
+          tickers: tickers.map((t: string) => t.trim().toUpperCase()),
+        };
+        if (weights !== undefined) body.weights = weights;
+        if (signal_quality_min_quintile !== undefined) body.signal_quality_min_quintile = signal_quality_min_quintile;
+        return textResult(await sdk.call("POST", "/signals/residual-reversion/basket", { body }));
+      } catch (error) {
+        return errorResult(error);
+      }
+    },
+  );
+
+  // --- 13F filer detail ---
+
+  server.registerTool(
+    "riskmodels_get_filer_snapshot",
+    {
+      title: "RiskModels 13F Filer Snapshot",
+      annotations: { readOnlyHint: true },
+      description:
+        "Composed JSON snapshot for one 13F filer (GET /13f/filers/{bw_filer_id}/snapshot): registry + latest metrics + concentration. Resolve bw_filer_id via riskmodels_search_filers first.",
+      inputSchema: {
+        bw_filer_id: z.string().min(1).describe("Filer id from riskmodels_search_filers"),
+      },
+    },
+    async ({ bw_filer_id }) => {
+      try {
+        return textResult(
+          await sdk.call("GET", `/13f/filers/${encodeURIComponent(bw_filer_id.trim())}/snapshot`),
+        );
+      } catch (error) {
+        return errorResult(error);
+      }
+    },
+  );
+
+  server.registerTool(
+    "riskmodels_get_filer_holdings",
+    {
+      title: "RiskModels 13F Filer Holdings",
+      annotations: { readOnlyHint: true },
+      description:
+        "Top-N current holdings of a 13F filer (GET /13f/filers/{bw_filer_id}/holdings). Resolve bw_filer_id via riskmodels_search_filers first.",
+      inputSchema: {
+        bw_filer_id: z.string().min(1).describe("Filer id from riskmodels_search_filers"),
+        top: z.number().int().min(1).max(200).optional().describe("Number of holdings (default 25)"),
+      },
+    },
+    async ({ bw_filer_id, top }) => {
+      try {
+        const query: Record<string, string | number | boolean> = {};
+        if (top !== undefined) query.top = top;
+        return textResult(
+          await sdk.call("GET", `/13f/filers/${encodeURIComponent(bw_filer_id.trim())}/holdings`, { query }),
+        );
+      } catch (error) {
+        return errorResult(error);
+      }
+    },
+  );
+
+  // --- ETF detail ---
+
+  server.registerTool(
+    "riskmodels_get_etf",
+    {
+      title: "RiskModels ETF Metrics",
+      annotations: { readOnlyHint: true },
+      description:
+        "Latest canonical metrics for one ETF (GET /data/etf/{ticker}): registry metadata + portfolio surface. Resolve the ticker via riskmodels_search_etfs if unsure.",
+      inputSchema: {
+        ticker: z.string().min(1).describe("ETF ticker, e.g. SMH"),
+      },
+    },
+    async ({ ticker }) => {
+      try {
+        return textResult(
+          await sdk.call("GET", `/data/etf/${encodeURIComponent(ticker.trim().toUpperCase())}`),
+        );
+      } catch (error) {
+        return errorResult(error);
+      }
+    },
+  );
+
+  server.registerTool(
+    "riskmodels_get_etf_holdings",
+    {
+      title: "RiskModels ETF Holdings",
+      annotations: { readOnlyHint: true },
+      description: "Top-N current holdings of an ETF (GET /data/etf/{ticker}/holdings).",
+      inputSchema: {
+        ticker: z.string().min(1).describe("ETF ticker, e.g. SMH"),
+        top: z.number().int().min(1).max(200).optional().describe("Number of holdings (default 25)"),
+      },
+    },
+    async ({ ticker, top }) => {
+      try {
+        const query: Record<string, string | number | boolean> = {};
+        if (top !== undefined) query.top = top;
+        return textResult(
+          await sdk.call("GET", `/data/etf/${encodeURIComponent(ticker.trim().toUpperCase())}/holdings`, { query }),
+        );
+      } catch (error) {
+        return errorResult(error);
+      }
+    },
+  );
+
+  // --- Generic passthrough: invoke any capability not covered by a typed tool ---
+
+  server.registerTool(
+    "riskmodels_call_endpoint",
+    {
+      title: "RiskModels Generic Capability Call",
+      annotations: { readOnlyHint: true },
+      description:
+        'Escape hatch for any capability without a dedicated tool. Run riskmodels_list_endpoints (and riskmodels_get_capability for params), then call with that capability\'s method + endpoint path. Path is relative to the API root (a leading "/api" is stripped). Blocked: SQL (/cli/query), Plaid, and chat endpoints — use the REST API directly for those.',
+      inputSchema: {
+        method: z.enum(["GET", "POST"]).describe("HTTP method from list_endpoints"),
+        path: z
+          .string()
+          .min(1)
+          .describe('Endpoint path from list_endpoints, e.g. "/industry-panel" or "/data/benchmark/SPY"'),
+        query: z
+          .record(z.string(), z.union([z.string(), z.number(), z.boolean()]))
+          .optional()
+          .describe("Query parameters"),
+        body: z.record(z.string(), z.unknown()).optional().describe("JSON body (POST)"),
+      },
+    },
+    async ({ method, path, query, body }) => {
+      try {
+        let p = path.trim();
+        if (!p.startsWith("/")) p = `/${p}`;
+        p = p.replace(/^\/api(?=\/)/, ""); // list_endpoints shows "/api/..."; baseUrl already includes /api
+        const blocked = [/^\/cli\/query/i, /^\/plaid/i, /^\/chat\b/i];
+        if (blocked.some((re) => re.test(p))) {
+          return errorResult(
+            new Error(`Path ${p} is not available via the passthrough (SQL/Plaid/chat). Use the REST API directly.`),
+          );
+        }
+        return textResult(await sdk.call(method, p, { query, body }));
       } catch (error) {
         return errorResult(error);
       }

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -359,7 +359,9 @@ export function createMcpServer(opts: McpServerOptions = {}): McpServer {
 
   // --- Tools ---
 
-  registerRiskModelsTools(sdk, server);
+  registerRiskModelsTools(sdk, server, {
+    capabilities: loadJson<Array<{ method?: string; endpoint?: string }>>("capabilities.json") ?? [],
+  });
 
   server.registerTool(
     "riskmodels_list_endpoints",

--- a/packages/riskmodels-sdk/src/client.ts
+++ b/packages/riskmodels-sdk/src/client.ts
@@ -267,6 +267,21 @@ export class RiskModelsClient {
     return attachApiCall(raw, apiCall);
   }
 
+  /**
+   * Generic dispatch to any RiskModels capability by method + path — backs the
+   * typed Tier-A tool wrappers and the MCP passthrough. Constrained to this
+   * client's baseUrl host; `path` is relative to the `/api` base
+   * (e.g. "/rankings/NVDA", "/13f/filers/search").
+   */
+  async call(
+    method: "GET" | "POST",
+    path: string,
+    options: { query?: Record<string, string | number | boolean>; body?: unknown } = {},
+  ): Promise<Record<string, unknown>> {
+    const { raw, apiCall } = await this.request(method, path, options);
+    return attachApiCall(raw, apiCall);
+  }
+
   private async request(
     method: "GET" | "POST",
     path: string,

--- a/tests/onboarding-upgrade.test.ts
+++ b/tests/onboarding-upgrade.test.ts
@@ -256,4 +256,49 @@ describe("RiskModels MCP live-paper tools", () => {
     expect(payload.chart_instruction).toContain("grouped bars for comparisons");
     expect(payload.chart_data).toHaveLength(1);
   });
+
+  it("passthrough allowlists registered capabilities and is traversal-safe", async () => {
+    const tools = new Map<string, (args: any) => Promise<{ content: Array<{ type: "text"; text: string }> }>>();
+    const server = {
+      registerTool: (name: string, _c: any, h: any) => tools.set(name, h),
+      registerResource: () => undefined,
+    };
+    const calls: Array<{ method: string; path: string }> = [];
+    const sdk = {
+      decompose: async () => ({}),
+      getHedgeLevels: async () => ({}),
+      compare: async () => ({}),
+      hedgePosition: async () => ({}),
+      analyzePortfolio: async () => ({}),
+      hedgePortfolio: async () => ({}),
+      portfolioDecompose: async () => ({}),
+      whitepaperExample: async () => ({}),
+      getReturns: async () => ({}),
+      getReturnAttribution: async () => ({}),
+      call: async (method: string, path: string) => {
+        calls.push({ method, path });
+        return { ok: true };
+      },
+    };
+    registerRiskModelsTools(sdk as any, server as any, {
+      capabilities: [
+        { id: "rankings", method: "GET", endpoint: "/api/rankings/{ticker}" },
+        { id: "cli-query", method: "POST", endpoint: "/api/cli/query" }, // blocked → excluded from allowlist
+      ],
+    });
+    const passthrough = tools.get("riskmodels_call_endpoint")!;
+
+    // Allowed registered capability dispatches with the normalized path.
+    await passthrough({ method: "GET", path: "/api/rankings/NVDA" });
+    expect(calls).toEqual([{ method: "GET", path: "/rankings/NVDA" }]);
+
+    // Blocked capability rejected — even via path traversal that would normalize
+    // to it downstream (the bug this guards against).
+    for (const p of ["/cli/query", "/x/../cli/query", "/api/x/%2e%2e/cli/query", "/internal/secret"]) {
+      const r = await passthrough({ method: "POST", path: p, body: { sql: "select 1" } });
+      expect(r.content[0].text).toContain("not an invocable capability");
+    }
+    // Only the single allowed call ever dispatched.
+    expect(calls).toHaveLength(1);
+  });
 });

--- a/tests/onboarding-upgrade.test.ts
+++ b/tests/onboarding-upgrade.test.ts
@@ -233,6 +233,18 @@ describe("RiskModels MCP live-paper tools", () => {
       "riskmodels_hedge_portfolio",
       "riskmodels_portfolio_decompose",
       "riskmodels_whitepaper_example",
+      "riskmodels_search_tickers",
+      "riskmodels_search_filers",
+      "riskmodels_search_etfs",
+      "riskmodels_get_rankings",
+      "riskmodels_screen_rankings",
+      "riskmodels_get_macro_correlation",
+      "riskmodels_get_residual_signal",
+      "riskmodels_get_filer_snapshot",
+      "riskmodels_get_filer_holdings",
+      "riskmodels_get_etf",
+      "riskmodels_get_etf_holdings",
+      "riskmodels_call_endpoint",
     ]);
     // riskmodels_render_artifact is hosted-only — registered separately via
     // registerRiskModelsRenderTool (needs GCP Cloud Run auth), intentionally


### PR DESCRIPTION
## Why
We just exposed returns (#157), but ~26 REST capabilities still had **no MCP tool** — so the broadened pitch ("13F reviews, peer analytics, macro, stat-arb") wasn't actually actionable in pure-MCP clients (Claude.ai/Desktop), which can only invoke registered tools. This adds the headline capabilities as typed tools **and** a generic passthrough so the *entire* API is invocable, not just discoverable.

## New typed tools (11) — thin wrappers over a new generic SDK `call(method, path, {query,body})`
| Group | Tools |
|---|---|
| Entity resolution (free) | `search_tickers`, `search_filers`, `search_etfs` |
| Peer / cross-section | `get_rankings`, `screen_rankings` |
| Macro | `get_macro_correlation` |
| Stat-arb | `get_residual_signal` |
| 13F detail | `get_filer_snapshot`, `get_filer_holdings` |
| ETF detail | `get_etf`, `get_etf_holdings` |

## Generic passthrough (1)
`riskmodels_call_endpoint(method, path, query?, body?)` — dispatches any capability from `list_endpoints`. Strips a leading `/api`; **host-constrained** to the client baseUrl (can't reach other hosts); **denylists** `/cli/query` (SQL), `/plaid`, `/chat`. This is what makes the long tail reachable in pure-MCP clients without 20+ wrappers.

## Design
- One new SDK method `call()`; every new tool is a registration over it.
- All in the shared `lib/mcp/tools/riskmodels-tools.ts` → **both** the hosted endpoint and the stdio package inherit them (shared 10 → 22; live hosted ~17 → ~29).
- Params sourced from `capabilities.json`.

## Verification
- `tsc --noEmit` clean; `mcp` build clean; **10/10** onboarding tests.
- Live endpoint checks (demo key): ticker/filer/ETF search, `rankings/NVDA`, `POST /correlation`, `etf/SPY` + `/holdings` → all 200. (`SMH` 404'd — not in the canonical ETF surface; coverage, not wiring.)

## Sequencing
Independent of #158 (copy + version bumps) — no file overlap. Merge both, then run the publish chain (sdk 0.1.3 → mcp 1.0.6 → registry) so npm ships returns **and** these tools together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)