### PR TITLE
chore(release): bump sdk 0.1.3 + mcp 1.0.6 for publish

### DIFF
--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@riskmodels/mcp",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "mcpName": "io.github.BlueWaterCorp/riskmodels",
   "description": "MCP server for RiskModels: clean dividend-adjusted US equity total returns, risk decomposition, factor/residual return attribution, and ETF hedge ratios",
   "type": "module",

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/BlueWaterCorp/RiskModels_API",
     "source": "github"
   },
-  "version": "1.0.5",
+  "version": "1.0.6",
   "packages": [
     {
       "identifier": "@riskmodels/mcp",
       "registryType": "npm",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "transport": {
         "type": "stdio",
         "command": "npx",

--- a/packages/riskmodels-sdk/package.json
+++ b/packages/riskmodels-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@riskmodels/sdk",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "TypeScript SDK for RiskModels API agent-ready risk decomposition responses",
   "type": "module",
   "sideEffects": false,


### PR DESCRIPTION
The version bumps intended for #158 didn't make it into its squash merge (only the description-copy changes landed), so `main` is still at **sdk 0.1.2 / mcp 1.0.5** — both already published to npm, so the release chain would fail with "cannot publish over existing version."

This re-applies:
- `@riskmodels/sdk` 0.1.2 → **0.1.3** (carries `getReturns`, `getReturnAttribution`, `call` from #157/#159 — verified present in built `dist/client.d.ts`)
- `@riskmodels/mcp` 1.0.5 → **1.0.6** (`package.json` + `server.json` top-level + `packages[]`)

After merge, the gated publish chain (sdk → mcp → registry) can run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)