### PR TITLE
fix(mcp): server.json description <=100 chars (MCP Registry limit)

### DIFF
--- a/mcp/server.json
+++ b/mcp/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.BlueWaterCorp/riskmodels",
   "title": "RiskModels",
-  "description": "Clean dividend-adjusted US equity total returns, plus institutional risk decomposition, factor-vs-residual return attribution, and executable ETF hedge ratios. Read-only, point-in-time, structured outputs.",
+  "description": "Dividend-adjusted US equity total returns, risk decomposition, attribution & ETF hedge ratios",
   "websiteUrl": "https://riskmodels.app",
   "repository": {
     "url": "https://github.com/BlueWaterCorp/RiskModels_API",
@@ -17,7 +17,10 @@
       "transport": {
         "type": "stdio",
         "command": "npx",
-        "args": ["-y", "@riskmodels/mcp"]
+        "args": [
+          "-y",
+          "@riskmodels/mcp"
+        ]
       }
     }
   ],


### PR DESCRIPTION
`mcp-publisher publish` returned **422: body.description expected length <= 100**. The returns-led `server.json` description was ~200 chars.

Trimmed to a 93-char returns-led one-liner (registry only — Smithery listing, README, `package.json`, and `.well-known` have no such cap and keep the fuller copy):

> Dividend-adjusted US equity total returns, risk decomposition, attribution & ETF hedge ratios

Version stays 1.0.6. After this, `mcp-publisher publish` validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)