### PR TITLE
feat(13f): ticker + name display labels on filer holdings

### DIFF
--- a/app/api/13f/filers/[bw_filer_id]/holdings/route.ts
+++ b/app/api/13f/filers/[bw_filer_id]/holdings/route.ts
@@ -2,6 +2,7 @@ import { NextResponse, type NextRequest } from "next/server";
 import { withBilling, type BillingContext } from "@/lib/agent/billing-middleware";
 import { fetchFiler } from "@/lib/dal/filers-engine";
 import { readFilerHoldingsTopN } from "@/lib/dal/funds-zarr-reader";
+import { enrichFilerHoldingsWithL3 } from "@/lib/13f/enrich-filer-holdings";
 
 export const dynamic = "force-dynamic";
 
@@ -14,7 +15,9 @@ const MAX_TOP_N = 1000;
  * Top-N current holdings at the filer's latest teo. Reads per-filer
  * ds_ph.zarr from GCS. Each holding carries `security_id` (post-D.8.1 =
  * bw_sym_id; pre-migration = a raw 9-char security identifier), `adj_mv`,
- * and `weight` (fraction of total in-portfolio AUM).
+ * `weight` (fraction of total in-portfolio AUM), and — when resolvable
+ * from the registry — display labels (`ticker`, `name`) plus latest L3
+ * explained-risk shares (same enrichment as the snapshot endpoint).
  *
  * Default `limit = 25`; caller can request up to 1000.
  */
@@ -47,7 +50,9 @@ export const GET = withBilling(
       return NextResponse.json({ error: "Filer not found" }, { status: 404 });
     }
 
-    const snapshot = await readFilerHoldingsTopN(bwFilerId, limit);
+    const snapshot = await enrichFilerHoldingsWithL3(
+      await readFilerHoldingsTopN(bwFilerId, limit),
+    );
     if (!snapshot) {
       return NextResponse.json(
         {

--- a/lib/13f/enrich-filer-holdings.ts
+++ b/lib/13f/enrich-filer-holdings.ts
@@ -1,9 +1,14 @@
 /**
- * Enrich filer holdings from zarr with latest L3 ER + optional ticker labels
- * via `security_history_latest` (same bw_sym_id key as fund V3 reads).
+ * Enrich filer holdings from zarr with latest L3 ER (via
+ * `security_history_latest`) and display labels — ticker + company name —
+ * (via `public.symbols`; same bw_sym_id key namespace post-D.8.1).
+ *
+ * Both lookups are best-effort: a miss leaves the holding's optional
+ * fields unset rather than failing the response.
  */
 
 import { fetchBatchLatestSummary } from "@/lib/dal/risk-engine-v3";
+import { resolveDisplayLabels } from "@/lib/dal/symbols-batch";
 import type { FilerHoldingsSnapshot } from "@/lib/dal/funds-zarr-reader";
 
 export async function enrichFilerHoldingsWithL3(
@@ -12,18 +17,26 @@ export async function enrichFilerHoldingsWithL3(
   if (!snap?.holdings.length) return snap;
 
   const ids = [...new Set(snap.holdings.map((h) => h.security_id).filter(Boolean))];
-  const batch = await fetchBatchLatestSummary(ids, "daily");
+  const [batch, labels] = await Promise.all([
+    fetchBatchLatestSummary(ids, "daily"),
+    resolveDisplayLabels(ids),
+  ]);
 
   const holdings = snap.holdings.map((h) => {
     const row = batch.get(h.security_id);
     const m = row?.metrics;
-    if (!m) return { ...h };
+    const label = labels.get(h.security_id);
     return {
       ...h,
-      l3_market_er: m.l3_mkt_er ?? null,
-      l3_sector_er: m.l3_sec_er ?? null,
-      l3_subsector_er: m.l3_sub_er ?? null,
-      l3_residual_er: m.l3_res_er ?? null,
+      ...(label ? { ticker: label.ticker, name: label.name } : {}),
+      ...(m
+        ? {
+            l3_market_er: m.l3_mkt_er ?? null,
+            l3_sector_er: m.l3_sec_er ?? null,
+            l3_subsector_er: m.l3_sub_er ?? null,
+            l3_residual_er: m.l3_res_er ?? null,
+          }
+        : {}),
     };
   });
 

--- a/lib/dal/funds-zarr-reader.ts
+++ b/lib/dal/funds-zarr-reader.ts
@@ -958,6 +958,8 @@ export interface FilerHolding {
   weight: number | null;
   /** Display ticker when enriched from Supabase `symbols` / registry (optional). */
   ticker?: string | null;
+  /** Company name when enriched from Supabase `symbols` / registry (optional). */
+  name?: string | null;
   /** Latest daily L3 explained-risk shares from `security_history_latest` (optional). */
   l3_market_er?: number | null;
   l3_sector_er?: number | null;

--- a/lib/dal/symbols-batch.ts
+++ b/lib/dal/symbols-batch.ts
@@ -120,3 +120,50 @@ export async function applyScrubToFilerHoldings<
     return { ...h, security_id: scrubBwSymId(h.security_id, r) };
   });
 }
+
+/**
+ * Batch-resolve security ids to display labels from `public.symbols`
+ * (`symbol` column is the same bw_sym_id namespace the filer/fund zarrs
+ * carry post-D.8.1). Tickers and company names are public identifiers —
+ * no licensing concern (unlike the ISIN scrub above).
+ *
+ * Never throws: a Supabase failure returns whatever resolved (possibly
+ * empty) so label enrichment can't take down a holdings response.
+ */
+export interface SymbolDisplayLabel {
+  ticker: string | null;
+  name: string | null;
+}
+
+export async function resolveDisplayLabels(
+  securityIds: readonly string[],
+): Promise<Map<string, SymbolDisplayLabel>> {
+  const out = new Map<string, SymbolDisplayLabel>();
+  const unique = Array.from(new Set(securityIds.filter((s) => !!s)));
+  if (unique.length === 0) return out;
+
+  try {
+    const admin = createAdminClient();
+    const { data, error } = await admin
+      .from("symbols")
+      .select("symbol, ticker, name")
+      .in("symbol", unique);
+
+    if (error) {
+      console.error("[symbols-batch] display-label resolve error:", error);
+      return out;
+    }
+
+    for (const row of data ?? []) {
+      const r = row as { symbol?: string; ticker?: string | null; name?: string | null };
+      if (!r.symbol) continue;
+      out.set(r.symbol, {
+        ticker: r.ticker?.trim() || null,
+        name: r.name?.trim() || null,
+      });
+    }
+  } catch (e) {
+    console.error("[symbols-batch] display-label resolve exception:", e);
+  }
+  return out;
+}


### PR DESCRIPTION
## Summary
Filer holdings responses carried only opaque `security_id` (`BW-{FIGI}`), making them undisplayable. `public.symbols` keys on the same namespace, so:

- New `resolveDisplayLabels()` in `lib/dal/symbols-batch.ts` (lean sibling of the scrub resolver; never throws; tickers/names are public identifiers — no licensed-identifier concern, unlike the sym-id scrub)
- `enrichFilerHoldingsWithL3` resolves labels in parallel with the L3 batch and attaches `ticker`/`name` per holding (additive optional fields — non-breaking for existing consumers)
- `/api/13f/filers/{id}/holdings` now gets the same enrichment as `/snapshot`

## Verification
- typecheck: zero new errors (16 pre-existing in `lib/mcp/tools`, untouched)
- vitest: 375/375
- Live DAL test against prod registry: Berkshire top 3 → **AAPL / AXP / KO** ✓; unknown ids absent from map

## Why now
Unblocks the `/filers/[slug]` SEO destination pages on riskmodels.net (MASTER_BACKLOG §T.5) — "Buffett owns AAPL" is the content; FIGIs aren't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)