### PR TITLE
feat(risk-calendar): /api/data/risk-calendar route + get_risk_calendar chat tool (T.6)

### DIFF
--- a/app/api/13f/filers/[bw_filer_id]/holdings/route.ts
+++ b/app/api/13f/filers/[bw_filer_id]/holdings/route.ts
@@ -2,6 +2,7 @@ import { NextResponse, type NextRequest } from "next/server";
 import { withBilling, type BillingContext } from "@/lib/agent/billing-middleware";
 import { fetchFiler } from "@/lib/dal/filers-engine";
 import { readFilerHoldingsTopN } from "@/lib/dal/funds-zarr-reader";
+import { enrichFilerHoldingsWithL3 } from "@/lib/13f/enrich-filer-holdings";
 
 export const dynamic = "force-dynamic";
 
@@ -14,7 +15,9 @@ const MAX_TOP_N = 1000;
  * Top-N current holdings at the filer's latest teo. Reads per-filer
  * ds_ph.zarr from GCS. Each holding carries `security_id` (post-D.8.1 =
  * bw_sym_id; pre-migration = a raw 9-char security identifier), `adj_mv`,
- * and `weight` (fraction of total in-portfolio AUM).
+ * `weight` (fraction of total in-portfolio AUM), and — when resolvable
+ * from the registry — display labels (`ticker`, `name`) plus latest L3
+ * explained-risk shares (same enrichment as the snapshot endpoint).
  *
  * Default `limit = 25`; caller can request up to 1000.
  */
@@ -47,7 +50,9 @@ export const GET = withBilling(
       return NextResponse.json({ error: "Filer not found" }, { status: 404 });
     }
 
-    const snapshot = await readFilerHoldingsTopN(bwFilerId, limit);
+    const snapshot = await enrichFilerHoldingsWithL3(
+      await readFilerHoldingsTopN(bwFilerId, limit),
+    );
     if (!snapshot) {
       return NextResponse.json(
         {

--- a/app/api/data/risk-calendar/route.ts
+++ b/app/api/data/risk-calendar/route.ts
@@ -1,0 +1,62 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { verifyGatewayAuth } from "@/lib/gateway-auth";
+import {
+  getRiskCalendar,
+  type RiskCalendarEventType,
+} from "@/lib/risk/risk-calendar-service";
+
+export const dynamic = "force-dynamic";
+
+const VALID_TYPES: RiskCalendarEventType[] = [
+  "earnings",
+  "ex_dividend",
+  "macro",
+  "filing_deadline",
+];
+
+/**
+ * GET /api/data/risk-calendar
+ *
+ * Risk Calendar v1 (T.6) — portfolio-relevant events: earnings, ex-dividend
+ * dates, macro releases (CPI / FOMC / payrolls), and SEC filing deadlines.
+ * Backed by the `risk_events` table (ERM3 publish_risk_events asset) unioned
+ * with `filing_calendar` at this layer.
+ *
+ * Optional filters:
+ *   ?from=YYYY-MM-DD          — event_date >= from (default: today)
+ *   ?to=YYYY-MM-DD            — event_date <= to (default: today + 30d)
+ *   ?tickers=NVDA,AAPL        — scope ticker events to a portfolio
+ *                                (macro + filing events always included);
+ *                                adds a per-ticker `coverage` report
+ *   ?types=earnings,macro     — restrict event types
+ */
+export async function GET(request: NextRequest) {
+  const denied = verifyGatewayAuth(request);
+  if (denied) return denied;
+
+  const sp = request.nextUrl.searchParams;
+  const tickersParam = sp.get("tickers");
+  const typesParam = sp.get("types");
+
+  const types = typesParam
+    ? (typesParam
+        .split(",")
+        .map((t) => t.trim())
+        .filter((t): t is RiskCalendarEventType =>
+          (VALID_TYPES as string[]).includes(t),
+        ) satisfies RiskCalendarEventType[])
+    : undefined;
+
+  try {
+    const result = await getRiskCalendar({
+      from: sp.get("from") ?? undefined,
+      to: sp.get("to") ?? undefined,
+      tickers: tickersParam ? tickersParam.split(",") : undefined,
+      types,
+    });
+    return NextResponse.json(result);
+  } catch (err) {
+    console.error("[data/risk-calendar] Error:", err);
+    return NextResponse.json({ error: "Internal error" }, { status: 500 });
+  }
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,6 +7,7 @@ import Navbar from '@/components/Navbar';
 import Footer from '@/components/Footer';
 import { ChatBubble } from '@/components/chat/ChatBubble';
 import { GoogleAdsTag } from '@/components/GoogleAdsTag';
+import { GoogleTagManager, GoogleTagManagerNoScript } from '@/components/GoogleTagManager';
 import { UTMTracker } from '@/components/UTMTracker';
 import { CANONICAL_SITE_URL } from '@/lib/constants';
 
@@ -90,6 +91,8 @@ export default async function RootLayout({
   return (
     <html lang="en" className="dark" suppressHydrationWarning>
       <head>
+        {/* Google Tag Manager: as high in <head> as possible per GTM install guidance */}
+        <GoogleTagManager />
         {/* Agent discovery: a bare fetch of riskmodels.app self-routes an AI agent to the
             machine-readable entry points, so a human only ever has to say "riskmodels.app"
             (never a path). Humans get the same pointer as a visible link in the Footer. */}
@@ -99,6 +102,7 @@ export default async function RootLayout({
         <GoogleAdsTag />
       </head>
       <body className={`${inter.className} ${jetbrainsMono.variable}`}>
+        <GoogleTagManagerNoScript />
         <div className="flex flex-col min-h-screen">
           <Navbar />
           <main className="flex-1 min-h-0 pt-24 sm:pt-28 md:pt-32 lg:pt-36">

--- a/components/GoogleTagManager.tsx
+++ b/components/GoogleTagManager.tsx
@@ -1,0 +1,30 @@
+/** Google Tag Manager for riskmodels.app — script as high in <head> as possible,
+ *  noscript fallback immediately after the opening <body> tag. */
+const GTM_CONTAINER_ID = 'GTM-5RLTJ3PC';
+
+export function GoogleTagManager() {
+  return (
+    <script
+      dangerouslySetInnerHTML={{
+        __html: `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','${GTM_CONTAINER_ID}');`,
+      }}
+    />
+  );
+}
+
+export function GoogleTagManagerNoScript() {
+  return (
+    <noscript>
+      <iframe
+        src={`https://www.googletagmanager.com/ns.html?id=${GTM_CONTAINER_ID}`}
+        height="0"
+        width="0"
+        style={{ display: 'none', visibility: 'hidden' }}
+      />
+    </noscript>
+  );
+}

--- a/lib/13f/enrich-filer-holdings.ts
+++ b/lib/13f/enrich-filer-holdings.ts
@@ -1,9 +1,14 @@
 /**
- * Enrich filer holdings from zarr with latest L3 ER + optional ticker labels
- * via `security_history_latest` (same bw_sym_id key as fund V3 reads).
+ * Enrich filer holdings from zarr with latest L3 ER (via
+ * `security_history_latest`) and display labels — ticker + company name —
+ * (via `public.symbols`; same bw_sym_id key namespace post-D.8.1).
+ *
+ * Both lookups are best-effort: a miss leaves the holding's optional
+ * fields unset rather than failing the response.
  */
 
 import { fetchBatchLatestSummary } from "@/lib/dal/risk-engine-v3";
+import { resolveDisplayLabels } from "@/lib/dal/symbols-batch";
 import type { FilerHoldingsSnapshot } from "@/lib/dal/funds-zarr-reader";
 
 export async function enrichFilerHoldingsWithL3(
@@ -12,18 +17,26 @@ export async function enrichFilerHoldingsWithL3(
   if (!snap?.holdings.length) return snap;
 
   const ids = [...new Set(snap.holdings.map((h) => h.security_id).filter(Boolean))];
-  const batch = await fetchBatchLatestSummary(ids, "daily");
+  const [batch, labels] = await Promise.all([
+    fetchBatchLatestSummary(ids, "daily"),
+    resolveDisplayLabels(ids),
+  ]);
 
   const holdings = snap.holdings.map((h) => {
     const row = batch.get(h.security_id);
     const m = row?.metrics;
-    if (!m) return { ...h };
+    const label = labels.get(h.security_id);
     return {
       ...h,
-      l3_market_er: m.l3_mkt_er ?? null,
-      l3_sector_er: m.l3_sec_er ?? null,
-      l3_subsector_er: m.l3_sub_er ?? null,
-      l3_residual_er: m.l3_res_er ?? null,
+      ...(label ? { ticker: label.ticker, name: label.name } : {}),
+      ...(m
+        ? {
+            l3_market_er: m.l3_mkt_er ?? null,
+            l3_sector_er: m.l3_sec_er ?? null,
+            l3_subsector_er: m.l3_sub_er ?? null,
+            l3_residual_er: m.l3_res_er ?? null,
+          }
+        : {}),
     };
   });
 

--- a/lib/chat/tools.ts
+++ b/lib/chat/tools.ts
@@ -32,6 +32,7 @@ import {
 import { DEFAULT_USER_SEGMENT } from "@/lib/dal/hedge-recommendation";
 import { getL3DecompositionService } from "@/lib/risk/l3-decomposition-service";
 import { getResidualSignalForTicker } from "@/lib/risk/residual-signal-service";
+import { getRiskCalendar } from "@/lib/risk/risk-calendar-service";
 import {
   computeFactorCorrelation,
   DEFAULT_MACRO_FACTORS,
@@ -77,6 +78,11 @@ const getRiskMetricsArgs = z.object({
 
 const getResidualSignalArgs = z.object({
   ticker: TickerSchema,
+});
+
+const getRiskCalendarArgs = z.object({
+  tickers: z.array(z.string()).max(50).optional(),
+  days_ahead: z.number().int().min(1).max(120).default(14),
 });
 
 const getHedgeBasketArgs = z.object({
@@ -686,6 +692,35 @@ async function execGetResidualSignal(
   return { ...snapshot, history_points: history.length };
 }
 
+/**
+ * Risk Calendar (T.6): upcoming portfolio-relevant events. Each event is a
+ * conversation starter — earnings rows carry the realized median |1-day|
+ * earnings-day move (`hist_move_pct` over `hist_move_n` past reports; a
+ * realized stat, NOT an implied/expected move) plus the consensus EPS
+ * estimate; macro rows carry the impacted factor keys in `risk_layers`.
+ * Uncovered holdings are listed in `coverage.uncovered` — say so rather
+ * than implying they have no events.
+ */
+async function execGetRiskCalendar(
+  args: z.infer<typeof getRiskCalendarArgs>,
+) {
+  const { tickers, days_ahead } = args;
+  const to = new Date(Date.now() + days_ahead * 24 * 3600 * 1000)
+    .toISOString()
+    .slice(0, 10);
+  const result = await getRiskCalendar({ to, tickers });
+  const MAX_EVENTS = 60;
+  if (result.events.length > MAX_EVENTS) {
+    const dropped = result.events.length - MAX_EVENTS;
+    return {
+      ...result,
+      events: result.events.slice(0, MAX_EVENTS),
+      truncation_note: `${dropped} later events dropped — narrow the window or pass tickers to scope to the portfolio.`,
+    };
+  }
+  return result;
+}
+
 export interface ChatToolDef {
   /** Stable tool name (OpenAI function name) */
   name: string;
@@ -698,6 +733,29 @@ export interface ChatToolDef {
 }
 
 export const CHAT_TOOLS_REGISTRY: ChatToolDef[] = [
+  {
+    name: "get_risk_calendar",
+    openaiTool: fnTool(
+      "get_risk_calendar",
+      "Upcoming portfolio-relevant events: earnings dates (with consensus EPS estimate and the REALIZED median 1-day earnings move over recent reports — quote it as historical, never as an expected/implied move), ex-dividend dates, macro releases (CPI / FOMC / payrolls, with impacted factor keys in risk_layers), and SEC filing deadlines. Pass the user's tickers to scope ticker events to their portfolio; macro and filing events always apply. Use each event as a risk conversation starter — e.g. pair an upcoming earnings date with get_risk_metrics to discuss the holder's residual exposure into the print. If coverage.uncovered is non-empty, state that those holdings are outside the published calendar universe.",
+      {
+        tickers: {
+          type: "array",
+          items: { type: "string" },
+          description:
+            "US stock tickers to scope ticker events to (e.g. the user's holdings). Omit for the full market calendar.",
+        },
+        days_ahead: {
+          type: "number",
+          description: "Days ahead to include (default 14, max 120).",
+        },
+      },
+      [],
+    ),
+    capabilityId: null,
+    argSchema: getRiskCalendarArgs,
+    executor: async (a) => execGetRiskCalendar(getRiskCalendarArgs.parse(a)),
+  },
   {
     name: "get_risk_metrics",
     openaiTool: fnTool(

--- a/lib/dal/funds-zarr-reader.ts
+++ b/lib/dal/funds-zarr-reader.ts
@@ -958,6 +958,8 @@ export interface FilerHolding {
   weight: number | null;
   /** Display ticker when enriched from Supabase `symbols` / registry (optional). */
   ticker?: string | null;
+  /** Company name when enriched from Supabase `symbols` / registry (optional). */
+  name?: string | null;
   /** Latest daily L3 explained-risk shares from `security_history_latest` (optional). */
   l3_market_er?: number | null;
   l3_sector_er?: number | null;

--- a/lib/dal/symbols-batch.ts
+++ b/lib/dal/symbols-batch.ts
@@ -120,3 +120,50 @@ export async function applyScrubToFilerHoldings<
     return { ...h, security_id: scrubBwSymId(h.security_id, r) };
   });
 }
+
+/**
+ * Batch-resolve security ids to display labels from `public.symbols`
+ * (`symbol` column is the same bw_sym_id namespace the filer/fund zarrs
+ * carry post-D.8.1). Tickers and company names are public identifiers —
+ * no licensing concern (unlike the ISIN scrub above).
+ *
+ * Never throws: a Supabase failure returns whatever resolved (possibly
+ * empty) so label enrichment can't take down a holdings response.
+ */
+export interface SymbolDisplayLabel {
+  ticker: string | null;
+  name: string | null;
+}
+
+export async function resolveDisplayLabels(
+  securityIds: readonly string[],
+): Promise<Map<string, SymbolDisplayLabel>> {
+  const out = new Map<string, SymbolDisplayLabel>();
+  const unique = Array.from(new Set(securityIds.filter((s) => !!s)));
+  if (unique.length === 0) return out;
+
+  try {
+    const admin = createAdminClient();
+    const { data, error } = await admin
+      .from("symbols")
+      .select("symbol, ticker, name")
+      .in("symbol", unique);
+
+    if (error) {
+      console.error("[symbols-batch] display-label resolve error:", error);
+      return out;
+    }
+
+    for (const row of data ?? []) {
+      const r = row as { symbol?: string; ticker?: string | null; name?: string | null };
+      if (!r.symbol) continue;
+      out.set(r.symbol, {
+        ticker: r.ticker?.trim() || null,
+        name: r.name?.trim() || null,
+      });
+    }
+  } catch (e) {
+    console.error("[symbols-batch] display-label resolve exception:", e);
+  }
+  return out;
+}

--- a/lib/risk/risk-calendar-service.ts
+++ b/lib/risk/risk-calendar-service.ts
@@ -1,0 +1,177 @@
+/**
+ * Risk Calendar (T.6) — unified event query over `risk_events` (earnings /
+ * ex-dividend / macro, maintained by the ERM3 publish_risk_events asset)
+ * plus `filing_calendar` (SEC deadlines, maintained by publish_filing_calendar),
+ * unioned at this layer so the two pipeline tables never duplicate rows.
+ *
+ * Portfolio awareness: callers pass the user's tickers; macro and filing
+ * events always apply. `coverage` reports which requested tickers exist
+ * anywhere in the events table (the pipeline covers the top-1500-by-mcap
+ * universe) — an uncovered holding is surfaced explicitly rather than
+ * silently showing no events.
+ *
+ * `hist_move_pct` is a REALIZED stat (median |1-day| move over the last
+ * `hist_move_n` earnings reports) — never present it as an implied or
+ * expected move.
+ */
+
+import { createAdminClient } from "@/lib/supabase/admin";
+
+export type RiskCalendarEventType =
+  | "earnings"
+  | "ex_dividend"
+  | "macro"
+  | "filing_deadline";
+
+export interface RiskCalendarEvent {
+  event_date: string;
+  event_type: RiskCalendarEventType;
+  entity_id: string;
+  ticker: string | null;
+  macro_tag: string | null;
+  title: string;
+  before_after_market: string | null;
+  estimate: number | null;
+  actual: number | null;
+  previous: number | null;
+  dividend_amount: number | null;
+  currency: string | null;
+  hist_move_pct: number | null;
+  hist_move_n: number | null;
+  risk_layers: string[];
+  source: string;
+}
+
+export interface RiskCalendarCoverage {
+  requested: string[];
+  covered: string[];
+  /** Holdings with no presence in the events table — outside the published universe. */
+  uncovered: string[];
+}
+
+export interface RiskCalendarResult {
+  events: RiskCalendarEvent[];
+  window: { from: string; to: string };
+  coverage?: RiskCalendarCoverage;
+}
+
+function isoDate(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+const TICKER_RE = /^[A-Z][A-Z0-9.-]{0,9}$/;
+
+function normalizeTickers(tickers: string[] | undefined): string[] {
+  if (!tickers?.length) return [];
+  const out = new Set<string>();
+  for (const t of tickers) {
+    const u = String(t).trim().toUpperCase();
+    if (TICKER_RE.test(u)) out.add(u);
+  }
+  return [...out];
+}
+
+export async function getRiskCalendar(opts: {
+  from?: string;
+  to?: string;
+  tickers?: string[];
+  types?: RiskCalendarEventType[];
+  includeFilings?: boolean;
+}): Promise<RiskCalendarResult> {
+  const today = new Date();
+  const from = opts.from ?? isoDate(today);
+  const to =
+    opts.to ?? isoDate(new Date(today.getTime() + 30 * 24 * 3600 * 1000));
+  const tickers = normalizeTickers(opts.tickers);
+  const types = opts.types?.length ? opts.types : undefined;
+  const includeFilings =
+    (opts.includeFilings ?? true) &&
+    (!types || types.includes("filing_deadline"));
+
+  const supabase = createAdminClient();
+
+  let query = supabase
+    .from("risk_events")
+    .select(
+      "event_date,event_type,entity_id,ticker,macro_tag,title,before_after_market,estimate,actual,previous,dividend_amount,currency,hist_move_pct,hist_move_n,risk_layers,source",
+    )
+    .gte("event_date", from)
+    .lte("event_date", to)
+    .order("event_date", { ascending: true });
+
+  if (types) {
+    query = query.in(
+      "event_type",
+      types.filter((t) => t !== "filing_deadline"),
+    );
+  }
+  if (tickers.length > 0) {
+    // Ticker events scoped to the portfolio; macro events always apply.
+    query = query.or(
+      `ticker.in.(${tickers.join(",")}),event_type.eq.macro`,
+    );
+  }
+
+  const { data, error } = await query;
+  if (error) {
+    throw new Error(`risk_events query failed: ${error.message}`);
+  }
+  const events: RiskCalendarEvent[] = (data ?? []) as RiskCalendarEvent[];
+
+  if (includeFilings) {
+    const { data: filings, error: filingsError } = await supabase
+      .from("filing_calendar")
+      .select("form_type,period_label,period_end,due_date,is_universal,category")
+      .gte("due_date", from)
+      .lte("due_date", to)
+      .order("due_date", { ascending: true });
+    if (filingsError) {
+      throw new Error(`filing_calendar query failed: ${filingsError.message}`);
+    }
+    for (const f of filings ?? []) {
+      events.push({
+        event_date: f.due_date,
+        event_type: "filing_deadline",
+        entity_id: `${f.form_type}:${f.period_end}`,
+        ticker: null,
+        macro_tag: null,
+        title: `${f.form_type} filing deadline (${f.period_label})`,
+        before_after_market: null,
+        estimate: null,
+        actual: null,
+        previous: null,
+        dividend_amount: null,
+        currency: null,
+        hist_move_pct: null,
+        hist_move_n: null,
+        risk_layers: [],
+        source: "filing_calendar",
+      });
+    }
+    events.sort((a, b) => a.event_date.localeCompare(b.event_date));
+  }
+
+  const result: RiskCalendarResult = { events, window: { from, to } };
+
+  if (tickers.length > 0) {
+    // Coverage is checked against the whole table (window-independent):
+    // the pipeline always holds ≥1 earnings row per covered ticker.
+    const { data: cov, error: covError } = await supabase
+      .from("risk_events")
+      .select("ticker")
+      .in("ticker", tickers);
+    if (!covError) {
+      const covered = [
+        ...new Set((cov ?? []).map((r) => r.ticker as string)),
+      ].sort();
+      const coveredSet = new Set(covered);
+      result.coverage = {
+        requested: tickers,
+        covered,
+        uncovered: tickers.filter((t) => !coveredSet.has(t)).sort(),
+      };
+    }
+  }
+
+  return result;
+}


### PR DESCRIPTION
## Summary
- `lib/risk/risk-calendar-service.ts`: unions `risk_events` (earnings / ex-div / macro — ERM3 `publish_risk_events`, see BlueWaterCorp/ERM3#75) with `filing_calendar` at query time; portfolio scoping via `tickers` (macro + filing events always apply); per-ticker `coverage` so out-of-universe holdings surface explicitly
- `GET /api/data/risk-calendar` (gateway auth): `from` / `to` / `tickers` / `types`
- `get_risk_calendar` chat tool (free): each event is a risk conversation starter; tool description enforces realized-vs-implied framing for `hist_move_pct` and uncovered-holdings honesty

## Test plan
- [x] `tsc --noEmit`: no new errors (18 pre-existing MCP/SDK errors unchanged)
- [x] Live service test: NVDA/AAPL/ZZZFAKE portfolio query → scoped earnings with realized moves (AAPL 1.01%, NVDA 3.2%) + macro + 13F/10-Q deadlines in date order; ZZZFAKE in `coverage.uncovered`

🤖 Generated with [Claude Code](https://claude.com/claude-code)