### PR TITLE
feat(analytics): wire PostHog client tracking

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,10 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=eyJ...
 # App URL (production: https://riskmodels.app, preview: Vercel preview URL)
 NEXT_PUBLIC_APP_URL=https://riskmodels.app
 
+# PostHog (client — GTM funnel + click diagnostics; sync from Doppler site_app/prd)
+# NEXT_PUBLIC_POSTHOG_KEY=phc_...
+# NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
+
 # Gateway auth for trusted server-to-server reads from Risk_Models
 # Set in Doppler as RISKMODELS_API_SERVICE_KEY
 RISKMODELS_API_SERVICE_KEY=rm_service_...

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,9 +5,11 @@ import 'katex/dist/katex.min.css';
 import '@/styles/globals.css';
 import Navbar from '@/components/Navbar';
 import Footer from '@/components/Footer';
+import { Suspense } from 'react';
 import { ChatBubble } from '@/components/chat/ChatBubble';
 import { GoogleAdsTag } from '@/components/GoogleAdsTag';
 import { GoogleTagManager, GoogleTagManagerNoScript } from '@/components/GoogleTagManager';
+import { PostHogProvider } from '@/components/posthog-provider';
 import { UTMTracker } from '@/components/UTMTracker';
 import { CANONICAL_SITE_URL } from '@/lib/constants';
 
@@ -103,15 +105,19 @@ export default async function RootLayout({
       </head>
       <body className={`${inter.className} ${jetbrainsMono.variable}`}>
         <GoogleTagManagerNoScript />
-        <div className="flex flex-col min-h-screen">
-          <Navbar />
-          <main className="flex-1 min-h-0 pt-24 sm:pt-28 md:pt-32 lg:pt-36">
-            {children}
-          </main>
-          <Footer />
-        </div>
-        <ChatBubble />
-        <UTMTracker />
+        <Suspense fallback={null}>
+          <PostHogProvider>
+            <div className="flex flex-col min-h-screen">
+              <Navbar />
+              <main className="flex-1 min-h-0 pt-24 sm:pt-28 md:pt-32 lg:pt-36">
+                {children}
+              </main>
+              <Footer />
+            </div>
+            <ChatBubble />
+            <UTMTracker />
+          </PostHogProvider>
+        </Suspense>
       </body>
     </html>
   );

--- a/components/posthog-provider.tsx
+++ b/components/posthog-provider.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { useEffect, Suspense } from 'react';
+import { usePathname, useSearchParams } from 'next/navigation';
+import { initPostHog, trackPageView, resetUser } from '@/lib/posthog-client';
+
+function PostHogProviderInner({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    initPostHog();
+  }, []);
+
+  useEffect(() => {
+    if (pathname) {
+      trackPageView(pathname);
+    }
+  }, [pathname, searchParams]);
+
+  return <>{children}</>;
+}
+
+export function PostHogProvider({ children }: { children: React.ReactNode }) {
+  return (
+    <Suspense fallback={<>{children}</>}>
+      <PostHogProviderInner>{children}</PostHogProviderInner>
+    </Suspense>
+  );
+}
+
+export { resetUser };

--- a/lib/posthog-client.ts
+++ b/lib/posthog-client.ts
@@ -1,0 +1,87 @@
+import posthog from 'posthog-js';
+
+const POSTHOG_HOST = process.env.NEXT_PUBLIC_POSTHOG_HOST || 'https://us.i.posthog.com';
+
+export function initPostHog() {
+  if (typeof window !== 'undefined' && process.env.NEXT_PUBLIC_POSTHOG_KEY) {
+    posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
+      api_host: POSTHOG_HOST,
+      defaults: '2026-05-30',
+      person_profiles: 'identified_only',
+      loaded: (ph) => {
+        if (process.env.NODE_ENV === 'development') {
+          ph.debug();
+        }
+      },
+      capture_pageview: false,
+      capture_pageleave: true,
+      autocapture: true,
+    });
+  }
+}
+
+export function identifyUser(userId: string, properties: Record<string, unknown>) {
+  if (typeof window !== 'undefined') {
+    posthog.identify(userId, properties);
+  }
+}
+
+export function trackEvent(eventName: string, properties?: Record<string, unknown>) {
+  if (typeof window !== 'undefined') {
+    posthog.capture(eventName, properties);
+  }
+}
+
+export function trackPageView(pageName?: string) {
+  if (typeof window !== 'undefined') {
+    posthog.capture('$pageview', {
+      $current_url: window.location.href,
+      page_name: pageName,
+      site: 'riskmodels.app',
+    });
+  }
+}
+
+export function resetUser() {
+  if (typeof window !== 'undefined') {
+    posthog.reset();
+  }
+}
+
+/** GTM funnel diagnostics for riskmodels.app */
+export const gtmAnalytics = {
+  signupFormViewed: (source?: string) =>
+    trackEvent('signup_form_viewed', { source, site: 'riskmodels.app' }),
+  signupFormSubmitted: (email?: string) => {
+    const emailDomain = email?.includes('@') ? email.split('@')[1] : undefined;
+    trackEvent('signup_form_submitted', { email_domain: emailDomain, site: 'riskmodels.app' });
+  },
+  signupError: (errorMessage: string) =>
+    trackEvent('signup_error_encountered', { error_message: errorMessage, site: 'riskmodels.app' }),
+  signupSuccess: (method?: string) =>
+    trackEvent('signup_successful', { method, site: 'riskmodels.app' }),
+
+  ctaClicked: (buttonText: string, location: string) =>
+    trackEvent('cta_clicked', {
+      button_text: buttonText,
+      location,
+      page: typeof window !== 'undefined' ? window.location.pathname : undefined,
+      site: 'riskmodels.app',
+    }),
+
+  apiKeyCreated: () => trackEvent('api_key_created', { site: 'riskmodels.app' }),
+  apiKeyCopied: (keyPrefix?: string) =>
+    trackEvent('api_key_copied', { key_prefix: keyPrefix?.slice(0, 8), site: 'riskmodels.app' }),
+  apiKeyRevoked: () => trackEvent('api_key_revoked', { site: 'riskmodels.app' }),
+
+  apiDocsPageViewed: (section?: string) =>
+    trackEvent('api_docs_page_viewed', { section, site: 'riskmodels.app' }),
+  apiEndpointExpanded: (endpoint: string, method?: string) =>
+    trackEvent('api_endpoint_expanded', { endpoint, method, site: 'riskmodels.app' }),
+  apiExampleCopied: (endpoint: string) =>
+    trackEvent('api_example_copied', { endpoint, site: 'riskmodels.app' }),
+  tryApiClicked: (endpoint: string) =>
+    trackEvent('try_api_clicked', { endpoint, site: 'riskmodels.app' }),
+};
+
+export default posthog;

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,7 @@
         "parquetjs-lite": "^0.8.7",
         "pdf-lib": "^1.17.1",
         "plaid": "^41.4.0",
+        "posthog-js": "^1.387.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-markdown": "^10.1.0",
@@ -1702,6 +1703,21 @@
         "pako": "^1.0.10"
       }
     },
+    "node_modules/@posthog/core": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.33.0.tgz",
+      "integrity": "sha512-Xk5O4g70SlsodD941j5GJTto2DgteKslmuhQ1kH5nR03JVOgdOw7rBesyWGhYkEdkxr8Vhvx33f1NTEZgejL2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/types": "^1.387.0"
+      }
+    },
+    "node_modules/@posthog/types": {
+      "version": "1.387.0",
+      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.387.0.tgz",
+      "integrity": "sha512-XR0B1geABbnUlSNv4RuFWvk19D870B668C/XzcKDctAZ+xCH5gmGM0oltGbA9yj+2ia9Y65nOrDYKN6Whu1oBw==",
+      "license": "MIT"
+    },
     "node_modules/@react-email/body": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@react-email/body/-/body-0.3.0.tgz",
@@ -2925,6 +2941,13 @@
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "license": "MIT"
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -4858,6 +4881,17 @@
         "node": ">=6.6.0"
       }
     },
+    "node_modules/core-js": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/cors": {
       "version": "2.8.6",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
@@ -5376,6 +5410,15 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.10",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.10.tgz",
+      "integrity": "sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/domutils": {
@@ -11261,6 +11304,38 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "license": "MIT"
     },
+    "node_modules/posthog-js": {
+      "version": "1.387.0",
+      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.387.0.tgz",
+      "integrity": "sha512-Pv1jUMySMN62zoAxdJBJPV8n62lkHdjuWhpeU7izczc5Dqbx3hhqO2hkrNTI8Yx1ezmWk2qUHZs03FuOBubdFQ==",
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "@posthog/core": "^1.33.0",
+        "@posthog/types": "^1.387.0",
+        "core-js": "^3.38.1",
+        "dompurify": "^3.3.2",
+        "fflate": "^0.4.8",
+        "preact": "^10.28.2",
+        "query-selector-shadow-dom": "^1.0.1",
+        "web-vitals": "^5.1.0"
+      }
+    },
+    "node_modules/posthog-js/node_modules/fflate": {
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
+      "integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==",
+      "license": "MIT"
+    },
+    "node_modules/preact": {
+      "version": "10.29.2",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.2.tgz",
+      "integrity": "sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -11362,6 +11437,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/query-selector-shadow-dom": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/query-selector-shadow-dom/-/query-selector-shadow-dom-1.0.1.tgz",
+      "integrity": "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==",
+      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -14211,6 +14292,12 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/web-vitals": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.3.0.tgz",
+      "integrity": "sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==",
+      "license": "Apache-2.0"
+    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -14484,7 +14571,7 @@
     },
     "packages/riskmodels-sdk": {
       "name": "@riskmodels/sdk",
-      "version": "0.1.1",
+      "version": "0.1.3",
       "devDependencies": {
         "typescript": "^5.6.0",
         "vitest": "^3.2.4"

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "parquetjs-lite": "^0.8.7",
     "pdf-lib": "^1.17.1",
     "plaid": "^41.4.0",
+    "posthog-js": "^1.387.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-markdown": "^10.1.0",


### PR DESCRIPTION
## What
Commits the previously-uncommitted client-side PostHog snippet so **riskmodels.app** emits pageviews/events in production. Until now the provider/client files lived only in the working tree, so prod sent **0 events** despite env + the admin dashboard being wired.

## Why
- `.net` already emits; `.app` did not — purely because this code was never committed to `main`.
- Env is already staged: `NEXT_PUBLIC_POSTHOG_KEY` / `NEXT_PUBLIC_POSTHOG_HOST` are in Vercel prod (via the Doppler `erm3/prd` → `riskmodels-api` sync). This merge → Vercel build inlines them. Events land in **PostHog project 275943** (same project `/admin/gtm` reads).

## Changes (PostHog-only)
- `components/posthog-provider.tsx`, `lib/posthog-client.ts` (new) — `posthog.init` guarded on the key; no-op when unset
- `app/layout.tsx` — wrap the app tree in `<PostHogProvider>`
- `package.json` / `package-lock.json` — add `posthog-js`
- `.env.example` — document the client keys

## Verify after deploy
Served bundle should contain the `phc_` key; pageviews appear in PostHog 275943 / the admin GTM panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)