### PR TITLE
fix(mcp/auth): friction fixes from a live agent walkthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Charts below are **generated from live API data** (MAG7 batch correlation + `get
 RiskModels includes a first-class [MCP (Model Context Protocol)](https://modelcontextprotocol.io) server, enabling AI agents to directly query risk data and perform factor analysis.
 
 **MCP Connection (hosted API):**
-- **SSE Endpoint:** `https://riskmodels.app/api/mcp/sse`
+- **Endpoint (Streamable HTTP, POST):** `https://riskmodels.app/api/mcp/sse`
 - **Authentication:** Bearer token (API key or OAuth2 JWT)
 - **Discovery:** `https://riskmodels.app/.well-known/mcp.json` (see [OPENAPI_SPEC.yaml](./OPENAPI_SPEC.yaml))
 

--- a/lib/agent/errors.ts
+++ b/lib/agent/errors.ts
@@ -160,7 +160,7 @@ export function createAgentErrorResponse(
       action,
       ...(action === "retry" && { retry_after_seconds: 60 }),
       ...(action === "authenticate" && {
-        authenticate_url: "/api/auth/provision",
+        authenticate_url: "/api/auth/provision-free",
       }),
       ...(action === "top_up" && { top_up_url: "/api/billing/top-up" }),
       ...(action === "upgrade" && { upgrade_url: "/pricing" }),
@@ -245,7 +245,7 @@ export function createAuthErrorResponse(
     message,
     "authenticate",
     {
-      auth_url: "/api/auth/provision",
+      auth_url: "/api/auth/provision-free",
       docs_url: "/docs/api/authentication",
     },
   );

--- a/lib/llms-txt.ts
+++ b/lib/llms-txt.ts
@@ -23,7 +23,7 @@ ETF hedge ratios, metrics, portfolio snapshots, and a hosted MCP surface.
 You are an AI assistant reading this because someone pointed you at riskmodels.app. There are two distinct requests — handle the one they made:
 
 **1. "Set it up for this chat" / "help me analyze …"** — set yourself up now, in this conversation, with no install:
-- Discovery is free and needs no key — read the endpoints and capabilities in this file.
+- Discovery docs (this file, the OpenAPI spec, and /.well-known/mcp.json) are free and need no key.
 - For live data on the Magnificent 7, use the **Public sample API key** below (if present) as \`Authorization: Bearer …\`. If you can make HTTP POSTs, you may self-provision a free key: \`POST /api/auth/provision-free\`. For the full ~3,000-name universe, tell the human to grab a free key at https://riskmodels.app/get-key (browser, no terminal).
 - Make one real call to confirm the connection, then tell the human what you can analyze and ask what they want to look at. **Do not tell a human to open a terminal for this case.**
 
@@ -65,7 +65,7 @@ MCP URL with \`mcp-remote\` and AUTHORIZATION=Bearer … (see Quickstart / MCP R
 ## Where to integrate without a local install
 
 - Hosted MCP (Streamable HTTP): https://riskmodels.app/api/mcp/sse — use with an MCP client and
-  Bearer token; discovery tools need no key; data tools bill per underlying REST route.
+  Bearer token (or the no-key OAuth connector flow). The MCP endpoint authenticates every call (including initialize), so discovery tools cost nothing but still require a key or OAuth; data tools additionally bill per underlying REST route.
 - OpenAPI: https://riskmodels.app/openapi (or /api-docs in the portal)
 - Python SDK (PyPI): riskmodels-py — see https://riskmodels.app/docs/python-sdk
 

--- a/lib/supabase/auth-helper.ts
+++ b/lib/supabase/auth-helper.ts
@@ -173,7 +173,7 @@ export async function authenticateOrRespond(
           message: 'Valid API key or authentication required',
           _agent: hadBearer
             ? { action: 'check_key', help_url: 'https://riskmodels.app/get-key' }
-            : { action: 'authenticate', authenticate_url: '/api/auth/provision' },
+            : { action: 'authenticate', authenticate_url: '/api/auth/provision-free' },
         },
         { status: 401, headers },
       ),


### PR DESCRIPTION
Found while testing the public MCP + API surface end-to-end as a new agent/dev (the server itself works: `initialize` 200, public-key MAG7 call 200, `provision-free` 201). These are the friction points that would trip a new caller or a registry reviewer.

## Changes
1. **401 hint → instant free path.** `_agent.authenticate_url` now points to **`/api/auth/provision-free`** (one field: `agent_name` → 201) instead of `/api/auth/provision` (which requires `agent_name`+`agent_id`+`contact_email`). Updated `lib/agent/errors.ts` (2) and `lib/supabase/auth-helper.ts` (1). `app/api/feedback/route.ts` already used `provision-free` — this aligns the rest, so an agent that hits a 401 can self-onboard in one call.
2. **Honest discovery claim.** `lib/llms-txt.ts` said "discovery tools need no key" / "discovery is free and needs no key." Verified false at the MCP layer: an **anonymous `initialize` returns 401**. Reworded to: discovery *docs* (llms.txt / OpenAPI / mcp.json) need no key, but the **MCP endpoint authenticates every call including `initialize`** (use the no-key OAuth connector, the public sample key, or `provision-free`). Discovery tools are free of *charge*, not free of *auth*.
3. **Transport label.** README said "**SSE Endpoint**"; `/.well-known/mcp.json` declares `transport: streamable-http`. Relabeled to "**Endpoint (Streamable HTTP, POST)**" to match.

## Not included (flagged for a decision)
- **Bigger lever:** allowing an **anonymous `initialize` + `tools/list`** so a dev/registry preview sees the tools *before* the OAuth wall. That's an architectural/billing-policy change — left out deliberately; happy to scope it.
- A throwaway free account `agent_name=hyperagent-smoke-test` was created during testing — please revoke.

Edits were applied to the exact `main` bytes via script (not hand-retyped); each string replacement was assertion-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)