### PR TITLE
fix(docs): make agent-integration Copy buttons actually copy

### DIFF
--- a/app/docs/[slug]/page.tsx
+++ b/app/docs/[slug]/page.tsx
@@ -1,5 +1,6 @@
 import { getDocBySlug, getAllDocSlugs } from '@/lib/mdx';
 import CopyPythonSnippet from '@/components/docs/CopyPythonSnippet';
+import CopyInline from '@/components/docs/CopyInline';
 import { MDXRemote } from 'next-mdx-remote/rsc';
 import remarkGfm from 'remark-gfm';
 import remarkMath from 'remark-math';
@@ -36,7 +37,7 @@ export default async function DocPage({ params }: { params: Promise<{ slug: stri
     <article className="prose prose-invert max-w-none prose-headings:font-bold prose-h1:text-4xl prose-h2:text-2xl prose-h2:mt-10 prose-h2:mb-4 prose-h3:text-xl prose-h3:mt-6 prose-p:text-zinc-400 prose-a:text-primary hover:prose-a:text-primary/80 prose-code:text-zinc-200 prose-code:bg-zinc-900 prose-code:px-1.5 prose-code:py-0.5 prose-code:rounded prose-pre:bg-zinc-900 prose-pre:border prose-pre:border-zinc-800 prose-table:border-zinc-800 prose-th:border-zinc-700 prose-td:border-zinc-800 prose-hr:border-zinc-800 prose-hr:my-10">
       <MDXRemote
         source={doc.content}
-        components={{ CopyPythonSnippet }}
+        components={{ CopyPythonSnippet, CopyInline }}
         options={{
           mdxOptions: {
             remarkPlugins: [remarkMath, remarkGfm],

--- a/components/docs/CopyInline.tsx
+++ b/components/docs/CopyInline.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { useState } from 'react';
+
+/**
+ * Minimal inline "Copy" control for the agent-integration MDX boxes.
+ * Replaces hand-written `<button onclick="...">` handlers, which React strips
+ * when MDX is rendered (lowercase `onclick` is not a real React handler), so
+ * the buttons were inert and copied nothing — the user pasted whatever was
+ * already on their clipboard. This copies the exact `value` shown in the box.
+ */
+export default function CopyInline({ value }: { value: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      /* clipboard unavailable — no-op */
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      className="ml-4 text-xs text-zinc-500 hover:text-zinc-200 transition-colors flex-shrink-0"
+      aria-label="Copy to clipboard"
+    >
+      {copied ? '✓' : 'Copy'}
+    </button>
+  );
+}

--- a/content/docs/agent-integration.mdx
+++ b/content/docs/agent-integration.mdx
@@ -18,7 +18,7 @@ Use the RiskModels API with your AI assistant of choice to perform quant researc
       <p className="text-xs text-zinc-400 mt-1">Paste this into a fresh chat. The agent reads riskmodels.app, sets itself up for the conversation, and tells you what it can analyze. Nothing to install.</p>
       <div className="flex items-center justify-between bg-zinc-950 border border-zinc-700 rounded-lg px-4 py-2.5 font-mono text-sm text-zinc-200 mt-2">
         <span>Visit riskmodels.app and set it up to use in this chat, then tell me what you can analyze.</span>
-        <button onclick="navigator.clipboard.writeText('Visit riskmodels.app and set it up to use in this chat, then tell me what you can analyze.');this.textContent='✓';setTimeout(()=>this.textContent='Copy',1500)" className="ml-4 text-xs text-zinc-500 hover:text-zinc-200 transition-colors flex-shrink-0">Copy</button>
+        <CopyInline value="Visit riskmodels.app and set it up to use in this chat, then tell me what you can analyze." />
       </div>
     </div>
     <div className="px-5 pb-4 pt-2">
@@ -26,7 +26,7 @@ Use the RiskModels API with your AI assistant of choice to perform quant researc
       <p className="text-xs text-zinc-400 mt-1">Settings → Connectors → Add custom connector, paste the URL (leave OAuth fields blank), then Connect. You sign in at riskmodels.app and approve once — no API key to handle, billing on your account.</p>
       <div className="flex items-center justify-between bg-zinc-950 border border-zinc-700 rounded-lg px-4 py-2.5 font-mono text-sm text-zinc-200 mt-2">
         <span>https://riskmodels.app/api/mcp/sse</span>
-        <button onclick="navigator.clipboard.writeText('https://riskmodels.app/api/mcp/sse');this.textContent='✓';setTimeout(()=>this.textContent='Copy',1500)" className="ml-4 text-xs text-zinc-500 hover:text-zinc-200 transition-colors flex-shrink-0">Copy</button>
+        <CopyInline value="https://riskmodels.app/api/mcp/sse" />
       </div>
       <p className="text-xs text-zinc-600 mt-2">Prefer a terminal, or need Codex / VS Code? <code className="text-zinc-500">npx -y riskmodels@latest install</code> wires every client in one command.</p>
     </div>
@@ -46,11 +46,11 @@ Use the RiskModels API with your AI assistant of choice to perform quant researc
     <div className="px-5 pb-4 space-y-2">
       <div className="flex items-center justify-between bg-zinc-950 border border-zinc-700 rounded-lg px-4 py-2.5 font-mono text-sm text-zinc-200">
         <span>npm install -g riskmodels@latest</span>
-        <button onclick="navigator.clipboard.writeText('npm install -g riskmodels@latest');this.textContent='✓';setTimeout(()=>this.textContent='Copy',1500)" className="ml-4 text-xs text-zinc-500 hover:text-zinc-200 transition-colors flex-shrink-0">Copy</button>
+        <CopyInline value="npm install -g riskmodels@latest" />
       </div>
       <div className="flex items-center justify-between bg-zinc-950 border border-zinc-700 rounded-lg px-4 py-2.5 font-mono text-sm text-zinc-200">
         <span>riskmodels install</span>
-        <button onclick="navigator.clipboard.writeText('riskmodels install');this.textContent='✓';setTimeout(()=>this.textContent='Copy',1500)" className="ml-4 text-xs text-zinc-500 hover:text-zinc-200 transition-colors flex-shrink-0">Copy</button>
+        <CopyInline value="riskmodels install" />
       </div>
       <p className="text-xs text-zinc-600 pt-1"><code className="text-zinc-400">riskmodels install</code> prompts for your key (get one at <a href="/get-key" className="text-primary hover:underline">riskmodels.app/get-key</a>) and stores it in <code className="text-zinc-400">~/.config/riskmodels/config.json</code>.</p>
     </div>


### PR DESCRIPTION
## Problem
A new user (reported via Garrett) found the **Copy** button in the "Try it now" box on `/docs/agent-integration` copies the riskmodels link instead of the prompt.

## Root cause
The boxes used hand-written inline `onclick="navigator.clipboard.writeText(...)"` handlers. When MDX is rendered through `next-mdx-remote/rsc`, React **strips lowercase `onclick`** (it's not a real React handler) — confirmed in prod: the rendered DOM button is `<button class="...">Copy</button>` with no handler. So the buttons were **inert**; clicking copied nothing and the user pasted whatever was already on their clipboard.

## Fix
New `components/docs/CopyInline.tsx` client component (real `onClick`), wired into the docs MDX component map. All five inert buttons on the page (prompt, SSE URL, `npm install`, `riskmodels install`) now copy their exact displayed value. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)