### PR TITLE
feat(v4): fill stock_specific sharpe/rank + style size/value betas

### DIFF
--- a/app/api/v4/decompose/route.ts
+++ b/app/api/v4/decompose/route.ts
@@ -4,6 +4,7 @@ import { withBilling, BillingContext } from "@/lib/agent/billing-middleware";
 import {
   resolveSymbolByTicker,
   fetchLatestMetricsWithFallback,
+  fetchRankingsFromSecurityHistory,
 } from "@/lib/dal/risk-engine-v3";
 import { getRiskMetadata } from "@/lib/dal/risk-metadata";
 import {
@@ -115,6 +116,11 @@ export const POST = withBilling(
           "stock_specific_er",
           "style_er_l3",
           "stock_specific_er_l3",
+          // per-stock SMB/HML loadings (Supabase columns) → style.exposures.*.beta
+          "size_beta",
+          "value_beta",
+          // 36m skill Sharpe (hedge zarr, overlay-served) → stock_specific.sharpe_36m
+          "stock_specific_sharpe_36m",
         ],
         "daily",
       );
@@ -131,6 +137,29 @@ export const POST = withBilling(
 
       const metadata = await getRiskMetadata();
       const m = latestData.metrics;
+
+      // stock_specific skill rank: cross-sectional percentile of the 36m Sharpe within the
+      // universe cohort (rankings zarr). Best-effort — a rankings miss leaves it null rather
+      // than failing the decomposition.
+      let stockSpecificRankPct: number | null = null;
+      try {
+        const { rankings } = await fetchRankingsFromSecurityHistory(
+          symbolRecord.symbol,
+          { metric: "stock_specific_lstar", cohort: "universe", window: "1d" },
+        );
+        const row = rankings.find(
+          (r) =>
+            r.metric === "stock_specific_lstar" &&
+            r.cohort === "universe" &&
+            r.window === "1d",
+        );
+        stockSpecificRankPct = row?.rank_percentile ?? null;
+      } catch (err) {
+        console.warn(
+          `[v4/decompose] stock_specific rankings lookup failed for ${ticker}:`,
+          err,
+        );
+      }
 
       const sectorEtf = symbolRecord.sector_etf ?? null;
       const subsectorEtf =
@@ -178,17 +207,18 @@ export const POST = withBilling(
           explained_variance: styleEv,
           hedgeable: false,
           role: "diagnostic",
-          // Per-stock size/value betas land from ERM3; null until then.
+          // Per-stock size/value loadings from the stock_specific strip (lstar basis).
           exposures: {
-            size: { factor: SIZE_FACTOR, beta: null as number | null },
-            value: { factor: VALUE_FACTOR, beta: null as number | null },
+            size: { factor: SIZE_FACTOR, beta: num(m.size_beta) },
+            value: { factor: VALUE_FACTOR, beta: num(m.value_beta) },
           },
         },
         stock_specific: {
           explained_variance: stockSpecificEv,
-          // Tier-2 skill metrics (computed on L*); null until the rankings land.
-          sharpe_36m: null as number | null,
-          rank_percentile: null as number | null,
+          // Tier-2 skill metrics (computed on L*): 36m Sharpe of the skill residual and its
+          // cross-sectional rank percentile within the universe cohort.
+          sharpe_36m: num(m.stock_specific_sharpe_36m),
+          rank_percentile: stockSpecificRankPct,
         },
       };
 

--- a/lib/dal/risk-engine-v3.ts
+++ b/lib/dal/risk-engine-v3.ts
@@ -72,9 +72,12 @@ export type V3MetricKey =
   | "stock_specific_er"
   | "style_er_l3"
   | "stock_specific_er_l3"
+  | "stock_specific_sharpe_36m"
   | "l1_mkt_beta"
   | "l2_sec_beta"
   | "l3_sub_beta"
+  | "size_beta"
+  | "value_beta"
   | "l2_ff_smb_er"
   | "l3_ff_smb_er"
   | "l3_ff_hml_er"
@@ -97,6 +100,15 @@ const HEDGE_RATIO_ZARR_OVERLAY_KEYS = new Set<V3MetricKey>([
 
 /** Lstar fields may be absent from `security_history_latest` until ERM3 sync backfill. */
 const LSTAR_ZARR_OVERLAY_KEYS = new Set<V3MetricKey>(["lstar_rr", "lstar_level"]);
+
+/**
+ * stock_specific skill scalars served straight from the hedge zarr (no Supabase column).
+ * Without an overlay these would only populate when another overlay key happens to force a
+ * zarr read; listing them here makes the zarr read fire whenever the latest row lacks them.
+ */
+const STOCK_SPECIFIC_ZARR_OVERLAY_KEYS = new Set<V3MetricKey>([
+  "stock_specific_sharpe_36m",
+]);
 
 export type V3Periodicity = "daily" | "monthly";
 
@@ -181,6 +193,10 @@ export interface LatestSummaryRow {
   l1_mkt_beta?: number | null;
   l2_sec_beta?: number | null;
   l3_sub_beta?: number | null;
+  // Per-stock style loadings from the end-of-cascade stock_specific strip (lstar basis):
+  // SMB (size_beta) / HML (value_beta) → v4 style.exposures.{size,value}.beta.
+  size_beta?: number | null;
+  value_beta?: number | null;
   updated_at: string | null;
 }
 
@@ -204,6 +220,9 @@ export const RANKING_METRICS = [
   "er_l1",
   "er_l2",
   "er_l3",
+  // 36m Sharpe of the stock_specific (L*) skill residual → v4 stock_specific.rank_percentile.
+  // Ranked under the universe cohort, window-independent (canonical '1d' only) in ERM3.
+  "stock_specific_lstar",
 ] as const;
 
 /**
@@ -663,6 +682,8 @@ export async function fetchLatestSummary(
         l1_mkt_beta: row.l1_mkt_beta ?? null,
         l2_sec_beta: row.l2_sec_beta ?? null,
         l3_sub_beta: row.l3_sub_beta ?? null,
+        size_beta: row.size_beta ?? null,
+        value_beta: row.value_beta ?? null,
       },
     };
   } catch (error) {
@@ -799,6 +820,9 @@ export async function fetchLatestMetricsWithFallback(
 
   const requestedHrOverlay = keys.some((k) => HEDGE_RATIO_ZARR_OVERLAY_KEYS.has(k));
   const requestedLstarOverlay = keys.some((k) => LSTAR_ZARR_OVERLAY_KEYS.has(k));
+  const requestedStockSpecificOverlay = keys.some((k) =>
+    STOCK_SPECIFIC_ZARR_OVERLAY_KEYS.has(k),
+  );
   const needZarrOverlay =
     fromLatest != null &&
     ((requestedHrOverlay &&
@@ -810,6 +834,11 @@ export async function fetchLatestMetricsWithFallback(
       (requestedLstarOverlay &&
         keys.some((k) => {
           if (!LSTAR_ZARR_OVERLAY_KEYS.has(k)) return false;
+          return fromLatest.metrics[k] == null;
+        })) ||
+      (requestedStockSpecificOverlay &&
+        keys.some((k) => {
+          if (!STOCK_SPECIFIC_ZARR_OVERLAY_KEYS.has(k)) return false;
           return fromLatest.metrics[k] == null;
         })));
 
@@ -831,6 +860,8 @@ export async function fetchLatestMetricsWithFallback(
         filtered[k] = z != null ? z : l ?? null;
       }
     } else if (LSTAR_ZARR_OVERLAY_KEYS.has(k)) {
+      filtered[k] = l != null ? l : z ?? null;
+    } else if (STOCK_SPECIFIC_ZARR_OVERLAY_KEYS.has(k)) {
       filtered[k] = l != null ? l : z ?? null;
     } else {
       filtered[k] = l ?? z ?? null;

--- a/lib/dal/zarr-metric-registry.ts
+++ b/lib/dal/zarr-metric-registry.ts
@@ -137,6 +137,10 @@ const REGISTRY: Partial<Record<V3MetricKey, ZarrMetricSpec>> = {
   // cleanly to ~1 (l3_res_er ≈ Style_ER_l3 + StockSpecific_ER_l3).
   style_er_l3: { role: "hedge", zarrVar: "Style_ER_l3" },
   stock_specific_er_l3: { role: "hedge", zarrVar: "StockSpecific_ER_l3" },
+  // 36-month annualized Sharpe of the stock_specific (L*) skill residual → v4
+  // stock_specific.sharpe_36m. Served straight from the hedge zarr (no Supabase
+  // column); reliably populated via STOCK_SPECIFIC_ZARR_OVERLAY_KEYS.
+  stock_specific_sharpe_36m: { role: "hedge", zarrVar: "StockSpecific_Sharpe36m_lstar" },
 
   // Fama–French style cascade — HEDGE vars only (ds_erm3_hedge_weights). The v4
   // producer (e4cab09) retired the FF *returns* levels (l2_ff_smb / l3_ff_smb_hml)


### PR DESCRIPTION
Serves the four v4 `/api/v4/decompose` leaf fields that shipped as `null`, now that ERM3 produces them (external backlog **H.81**, deferred follow-up (i)).

## What

- **style.exposures.{size,value}.beta** ← `security_history_latest` `size_beta` / `value_beta` columns (per-stock SMB/HML loadings, lstar basis). Column-only keys, matching the existing `l*_beta` keys.
- **stock_specific.sharpe_36m** ← hedge zarr `StockSpecific_Sharpe36m_lstar`, via a new `stock_specific_sharpe_36m` registry key + `STOCK_SPECIFIC_ZARR_OVERLAY_KEYS` overlay (mirrors the `style_er` hedge-zarr path, but the overlay makes it reliably fire when the latest row lacks the value).
- **stock_specific.rank_percentile** ← rankings zarr `stock_specific_lstar` metric (universe cohort, 1d), via `fetchRankingsFromSecurityHistory`. Best-effort: a rankings miss leaves it `null` rather than failing the decomposition.

## Notes
Fields stay `null` gracefully until the ERM3 Full rebuild lands the hedge/rankings vars + Supabase columns — no schema change, they fill in place. `tsc` clean; v4 + registry tests pass.

Paired with ERM3 `feat/v4-decompose-fill-null-fields` (producer side, BlueWaterCorp/ERM3#81).

🤖 Generated with [Claude Code](https://claude.com/claude-code)