### PR TITLE
feat(openbb): Workspace custom-backend adapter — widgets.json + apps.json + live metrics & snapshot-PDF widgets (E.21)

### DIFF
--- a/app/openbb/README.md
+++ b/app/openbb/README.md
@@ -1,0 +1,62 @@
+# OpenBB Workspace adapter (E.21)
+
+A thin translation layer that exposes the RiskModels public API as an
+[OpenBB Workspace custom backend](https://docs.openbb.co/workspace/developers/data-integration).
+It serves `widgets.json` + `apps.json` and per-widget endpoints that reshape
+`/api/*` responses into OpenBB table/chart/metric/HTML formats.
+
+## Design
+
+- **Pure translation layer.** No engine access. Each widget calls the same
+  public REST API an external consumer would (`_lib/upstream.ts`), so billing,
+  rate limits, and entitlements are identical to a direct API call.
+- **Per-user auth passthrough.** The OpenBB user pastes their own
+  `rm_agent_live_*` key into the Workspace "Add data" auth UI as an
+  `X-API-KEY` header. The adapter forwards it as a Bearer token. No shared
+  secret; each user is billed against their own key.
+- **Scoped CORS.** `_lib/cors.ts` allows only the OpenBB origins (and the
+  `X-API-KEY` header) — kept separate from the shared `@/lib/cors`.
+- **No mock data.** `widgets.json` lists only widgets whose data endpoint is
+  wired. Missing upstream fields render as `—`, never fabricated.
+
+## Connect in OpenBB Workspace
+
+1. `pro.openbb.co` → right-click a dashboard → **Add data** → **Custom backend**.
+2. Base URL: `https://riskmodels.app/openbb`
+   (subdomain `openbb.riskmodels.app` maps here via a Vercel domain rewrite).
+3. Add header `X-API-KEY` = your `rm_agent_live_*` key.
+
+## Local test
+
+```bash
+npm run dev   # http://localhost:3000
+curl http://localhost:3000/openbb/widgets.json | jq
+curl "http://localhost:3000/openbb/widgets/metrics?ticker=AAPL" \
+  -H "X-API-KEY: rm_agent_live_..." | jq
+```
+
+## Endpoint layout
+
+| Path | Purpose | Status |
+|------|---------|--------|
+| `GET /openbb` | Backend info | ✅ |
+| `GET /openbb/widgets.json` | Widget defs | ✅ |
+| `GET /openbb/apps.json` | App defs | ✅ |
+| `GET /openbb/widgets/metrics?ticker=` | Single-name risk table | ✅ live |
+| `GET /openbb/widgets/snapshot?ticker=` | Risk-snapshot tearsheet (`pdf` widget) | ✅ live |
+
+## Widget roadmap (add one route per item, then list it in `widgets.json`)
+
+- **Charts** → `/ticker-returns`, `/returns`, `/correlation`, `/macro-factors`,
+  `/l3-decomposition`, `/returns-decomposition`
+- **Tables** → `/rankings/screen`, `/rankings/top`, `/universe/{name}/members`,
+  `/etf-holdings`, `/filer-holdings`
+- **HTML / image** → `/snapshot` (multi-position portfolio tearsheet), MCP
+  `render_artifact` PNGs. (Single-name `snapshot.pdf` is already live above as
+  the `pdf` widget. `snapshot.png` needs `PLAYWRIGHT_PDF_ENABLED=true` upstream
+  — prefer the PDF widget, which is pure server-side.)
+- **Portfolio** → `/portfolio/risk-snapshot` + L1/L2/L3 hedge layering
+- **Apps** → fill out the three-app set in `apps.json`
+  (Single-Name Risk · Portfolio Risk & Hedge · Screener)
+
+Then register the published npm `riskmodels` MCP server as a Workspace AI agent.

--- a/app/openbb/_lib/cors.ts
+++ b/app/openbb/_lib/cors.ts
@@ -1,0 +1,35 @@
+/**
+ * CORS for the OpenBB Workspace adapter.
+ *
+ * OpenBB Workspace (pro.openbb.co) calls a custom backend cross-origin and
+ * requires the backend to (a) echo the Workspace origin and (b) permit the
+ * auth header the user configured. We pass the user's RiskModels key through
+ * the `X-API-KEY` header, so it must be in Access-Control-Allow-Headers.
+ *
+ * This is deliberately separate from the shared `@/lib/cors` (which gates the
+ * public /api surface to riskmodels.app / .net origins) — the OpenBB origins
+ * have no business being allowed on the rest of the API.
+ */
+
+const OPENBB_ORIGINS = [
+  "https://pro.openbb.co",
+  "https://my.openbb.co",
+];
+
+export function openbbCors(requestOrigin?: string | null): Record<string, string> {
+  const isDev = process.env.NODE_ENV === "development";
+  const allowed = [...OPENBB_ORIGINS];
+  if (isDev) allowed.push("http://localhost:1420", "http://localhost:5050");
+
+  const origin =
+    requestOrigin && allowed.includes(requestOrigin) ? requestOrigin : allowed[0];
+
+  return {
+    "Access-Control-Allow-Origin": origin,
+    "Access-Control-Allow-Methods": "GET, OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type, Authorization, X-API-KEY",
+    "Access-Control-Allow-Credentials": "true",
+    "Access-Control-Max-Age": "86400",
+    Vary: "Origin",
+  };
+}

--- a/app/openbb/_lib/upstream.ts
+++ b/app/openbb/_lib/upstream.ts
@@ -1,0 +1,87 @@
+/**
+ * Upstream helpers for the OpenBB adapter.
+ *
+ * The adapter is a pure translation layer: it never reads the engine directly,
+ * it calls the same public REST API any external consumer would, with the
+ * OpenBB user's own key. That keeps billing, rate limits, and entitlements
+ * identical to a direct API consumer — the adapter has no privileged access.
+ */
+
+/** Public API base, e.g. https://riskmodels.app/api. No trailing slash. */
+export function upstreamBase(): string {
+  return (
+    process.env.NEXT_PUBLIC_RISKMODELS_API_URL || "https://riskmodels.app/api"
+  ).replace(/\/+$/, "");
+}
+
+/**
+ * The OpenBB user pastes their `rm_agent_live_*` key into the Workspace
+ * "Add data" auth UI as an `X-API-KEY` header. We forward it as a standard
+ * Bearer token. Returns null when absent so callers can 401 cleanly.
+ */
+export function bearerFromRequest(req: Request): string | null {
+  const raw =
+    req.headers.get("x-api-key") || req.headers.get("authorization") || "";
+  if (!raw) return null;
+  return raw.startsWith("Bearer ") ? raw.slice(7).trim() : raw.trim();
+}
+
+/** GET an upstream path with the forwarded key. Returns the parsed JSON + status. */
+export async function upstreamGet(
+  path: string,
+  key: string,
+): Promise<{ status: number; body: unknown }> {
+  const url = `${upstreamBase()}${path.startsWith("/") ? path : `/${path}`}`;
+  const res = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${key}`,
+      Accept: "application/json",
+    },
+    // The adapter runs server-side on Vercel; no caching so entitlements/billing
+    // are evaluated per request.
+    cache: "no-store",
+  });
+
+  let body: unknown = null;
+  try {
+    body = await res.json();
+  } catch {
+    body = { error: "upstream returned non-JSON", status: res.status };
+  }
+  return { status: res.status, body };
+}
+
+/**
+ * GET an upstream binary asset (e.g. a snapshot PDF) with the forwarded key.
+ * Returns the raw bytes on success, or the parsed JSON error body on failure
+ * (the API returns JSON errors even on the binary routes).
+ */
+export async function upstreamGetBytes(
+  path: string,
+  key: string,
+): Promise<{
+  status: number;
+  contentType: string | null;
+  bytes: ArrayBuffer | null;
+  error: unknown;
+}> {
+  const url = `${upstreamBase()}${path.startsWith("/") ? path : `/${path}`}`;
+  const res = await fetch(url, {
+    headers: { Authorization: `Bearer ${key}` },
+    cache: "no-store",
+  });
+
+  const contentType = res.headers.get("content-type");
+  if (res.status < 200 || res.status >= 300) {
+    let error: unknown = { error: `Upstream returned ${res.status}` };
+    try {
+      error = await res.json();
+    } catch {
+      /* non-JSON error body — keep the generic message */
+    }
+    return { status: res.status, contentType, bytes: null, error };
+  }
+
+  const bytes = await res.arrayBuffer();
+  return { status: res.status, contentType, bytes, error: null };
+}

--- a/app/openbb/apps.json/route.ts
+++ b/app/openbb/apps.json/route.ts
@@ -1,0 +1,64 @@
+/**
+ * apps.json — OpenBB Workspace App definitions.
+ *
+ * Skeleton ships one app containing the live metrics widget so the
+ * connect-and-render path is exercised end to end. The full three-app set
+ * (Single-Name Risk, Portfolio Risk & Hedge, Screener — see E.21) lands as
+ * each widget's data endpoint is wired. Layout coords are best-effort and get
+ * tuned on first connect against the live Workspace grid.
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { openbbCors } from "../_lib/cors";
+
+export const dynamic = "force-dynamic";
+
+const APPS = [
+  {
+    name: "RiskModels — Single-Name Risk",
+    description:
+      "Hedge layering, volatility, and residual signal for one ticker, powered by the RiskModels API.",
+    allowCustomization: true,
+    tabs: {
+      overview: {
+        id: "overview",
+        name: "Overview",
+        layout: [
+          {
+            i: "rm_single_name_metrics",
+            x: 0,
+            y: 0,
+            w: 20,
+            h: 12,
+            state: { params: { ticker: "AAPL" } },
+          },
+          {
+            i: "rm_single_name_snapshot",
+            x: 20,
+            y: 0,
+            w: 20,
+            h: 20,
+            state: { params: { ticker: "AAPL" } },
+          },
+        ],
+      },
+    },
+    groups: [
+      // Wire the ticker param across widgets once >1 widget is live, so changing
+      // the ticker in one updates the whole tab.
+      { name: "ticker", type: "param", paramName: "ticker", defaultValue: "AAPL" },
+    ],
+  },
+];
+
+export async function GET(req: NextRequest) {
+  return NextResponse.json(APPS, {
+    headers: openbbCors(req.headers.get("origin")),
+  });
+}
+
+export async function OPTIONS(req: NextRequest) {
+  return new NextResponse(null, {
+    status: 204,
+    headers: openbbCors(req.headers.get("origin")),
+  });
+}

--- a/app/openbb/route.ts
+++ b/app/openbb/route.ts
@@ -1,0 +1,36 @@
+/**
+ * OpenBB Workspace custom-backend root.
+ *
+ * Connect this backend in OpenBB Workspace via "Add data" → base URL
+ * `https://riskmodels.app/openbb` (the subdomain openbb.riskmodels.app maps
+ * here via a Vercel domain rewrite). Auth: add an `X-API-KEY` header set to
+ * your `rm_agent_live_*` key.
+ *
+ * Backlog: E.21.
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { openbbCors } from "./_lib/cors";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(req: NextRequest) {
+  return NextResponse.json(
+    {
+      name: "RiskModels — OpenBB Workspace backend",
+      description:
+        "Institutional single-name and portfolio risk: L1/L2/L3 hedge layering, residual signal, rankings, and institutional snapshot tearsheets.",
+      version: "0.1.0",
+      widgets: "/openbb/widgets.json",
+      apps: "/openbb/apps.json",
+      docs: "https://riskmodels.app/docs",
+    },
+    { headers: openbbCors(req.headers.get("origin")) },
+  );
+}
+
+export async function OPTIONS(req: NextRequest) {
+  return new NextResponse(null, {
+    status: 204,
+    headers: openbbCors(req.headers.get("origin")),
+  });
+}

--- a/app/openbb/widgets.json/route.ts
+++ b/app/openbb/widgets.json/route.ts
@@ -1,0 +1,74 @@
+/**
+ * widgets.json — OpenBB Workspace widget definitions.
+ *
+ * Only widgets whose data endpoint is actually wired live here (no-mock-data
+ * rule). The single-name metrics table is the skeleton's live widget; the
+ * follow-up widgets (returns chart, L3 decomposition, snapshot PDF, rankings
+ * screen, portfolio risk) are tracked in app/openbb/README.md and added one
+ * route at a time.
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { openbbCors } from "../_lib/cors";
+
+export const dynamic = "force-dynamic";
+
+const WIDGETS = {
+  rm_single_name_metrics: {
+    name: "RiskModels — Single-Name Risk Metrics",
+    description:
+      "L1/L2/L3 hedge ratios and betas, annualised volatility, Lstar residual level, and recommended hedge level for one ticker.",
+    category: "Risk",
+    type: "table",
+    endpoint: "openbb/widgets/metrics",
+    gridData: { w: 20, h: 12 },
+    params: [
+      {
+        paramName: "ticker",
+        value: "AAPL",
+        label: "Ticker",
+        type: "text",
+        description: "US equity ticker (e.g. AAPL, NVDA, BRK.B).",
+      },
+    ],
+    data: {
+      table: {
+        showAll: true,
+        columnsDefs: [
+          { field: "metric", headerName: "Metric", cellDataType: "text" },
+          { field: "value", headerName: "Value", cellDataType: "text" },
+        ],
+      },
+    },
+  },
+  rm_single_name_snapshot: {
+    name: "RiskModels — Risk Snapshot Tearsheet",
+    description:
+      "Institutional one-page risk tearsheet (PDF): L3 explained-risk decomposition, portfolio volatility, and position-level hedge ratios for one ticker.",
+    category: "Risk",
+    type: "pdf",
+    endpoint: "openbb/widgets/snapshot",
+    gridData: { w: 20, h: 20 },
+    params: [
+      {
+        paramName: "ticker",
+        value: "AAPL",
+        label: "Ticker",
+        type: "text",
+        description: "US equity ticker (e.g. AAPL, NVDA, BRK.B).",
+      },
+    ],
+  },
+} as const;
+
+export async function GET(req: NextRequest) {
+  return NextResponse.json(WIDGETS, {
+    headers: openbbCors(req.headers.get("origin")),
+  });
+}
+
+export async function OPTIONS(req: NextRequest) {
+  return new NextResponse(null, {
+    status: 204,
+    headers: openbbCors(req.headers.get("origin")),
+  });
+}

--- a/app/openbb/widgets/metrics/route.ts
+++ b/app/openbb/widgets/metrics/route.ts
@@ -1,0 +1,101 @@
+/**
+ * Live widget data endpoint: single-name risk metrics → OpenBB table rows.
+ *
+ * GET /openbb/widgets/metrics?ticker=AAPL
+ * Auth: X-API-KEY header (the OpenBB user's rm_agent_live_* key), forwarded
+ * upstream as a Bearer token. Maps the real /metrics/{ticker} response — no
+ * synthetic values; missing fields render as "—".
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { openbbCors } from "../../_lib/cors";
+import { bearerFromRequest, upstreamGet } from "../../_lib/upstream";
+
+export const dynamic = "force-dynamic";
+
+type Row = { metric: string; value: string };
+
+function num(v: unknown, digits = 3): string {
+  if (v === null || v === undefined || v === "") return "—";
+  const n = Number(v);
+  return Number.isFinite(n) ? n.toFixed(digits) : "—";
+}
+
+function money(v: unknown): string {
+  if (v === null || v === undefined || v === "") return "—";
+  const n = Number(v);
+  if (!Number.isFinite(n)) return "—";
+  if (n >= 1e12) return `$${(n / 1e12).toFixed(2)}T`;
+  if (n >= 1e9) return `$${(n / 1e9).toFixed(2)}B`;
+  if (n >= 1e6) return `$${(n / 1e6).toFixed(2)}M`;
+  return `$${n.toFixed(2)}`;
+}
+
+export async function GET(req: NextRequest) {
+  const cors = openbbCors(req.headers.get("origin"));
+  const ticker = (req.nextUrl.searchParams.get("ticker") || "").trim().toUpperCase();
+
+  if (!ticker) {
+    return NextResponse.json(
+      { error: "Missing required `ticker` parameter." },
+      { status: 400, headers: cors },
+    );
+  }
+
+  const key = bearerFromRequest(req);
+  if (!key) {
+    return NextResponse.json(
+      { error: "Missing API key. Add an X-API-KEY header with your rm_agent_live_* key." },
+      { status: 401, headers: cors },
+    );
+  }
+
+  const { status, body } = await upstreamGet(
+    `/metrics/${encodeURIComponent(ticker)}`,
+    key,
+  );
+
+  if (status < 200 || status >= 300) {
+    const message =
+      (body as { error?: string; message?: string })?.error ||
+      (body as { message?: string })?.message ||
+      `Upstream returned ${status}`;
+    return NextResponse.json({ error: message }, { status, headers: cors });
+  }
+
+  const d = body as {
+    ticker?: string;
+    teo?: string;
+    metrics?: Record<string, unknown>;
+    meta?: Record<string, unknown>;
+    _data_health?: { data_as_of?: string };
+  };
+  const m = d.metrics ?? {};
+
+  const rows: Row[] = [
+    { metric: "Ticker", value: d.ticker ?? ticker },
+    { metric: "As of", value: d._data_health?.data_as_of ?? d.teo ?? "—" },
+    { metric: "Price (close)", value: money(m.price_close) },
+    { metric: "Market cap", value: money(m.market_cap) },
+    { metric: "Volatility — 252d (annualised)", value: num(m.vol_252d_ann) },
+    { metric: "Volatility — 23d", value: num(m.vol_23d) },
+    { metric: "Market beta (L1)", value: num(m.l1_mkt_beta) },
+    { metric: "Sector beta (L2)", value: num(m.l2_sec_beta) },
+    { metric: "Subsector beta (L3)", value: num(m.l3_sub_beta) },
+    { metric: "Market hedge ratio (L3)", value: num(m.l3_mkt_hr) },
+    { metric: "Sector hedge ratio (L3)", value: num(m.l3_sec_hr) },
+    { metric: "Subsector hedge ratio (L3)", value: num(m.l3_sub_hr) },
+    { metric: "Lstar residual level", value: String(m.lstar_level ?? "—") },
+    { metric: "Recommended hedge level", value: String(m.recommended_hedge_level ?? "—") },
+    { metric: "Sector ETF", value: String(d.meta?.sector_etf ?? "—") },
+    { metric: "Subsector ETF", value: String(d.meta?.subsector_etf ?? "—") },
+  ];
+
+  return NextResponse.json(rows, { headers: cors });
+}
+
+export async function OPTIONS(req: NextRequest) {
+  return new NextResponse(null, {
+    status: 204,
+    headers: openbbCors(req.headers.get("origin")),
+  });
+}

--- a/app/openbb/widgets/snapshot/route.ts
+++ b/app/openbb/widgets/snapshot/route.ts
@@ -1,0 +1,67 @@
+/**
+ * Live widget data endpoint: institutional risk-snapshot tearsheet → OpenBB
+ * `pdf` (file viewer) widget.
+ *
+ * GET /openbb/widgets/snapshot?ticker=AAPL
+ * Auth: X-API-KEY header (forwarded upstream as Bearer). Fetches the real
+ * server-rendered PDF from /metrics/{ticker}/snapshot.pdf, base64-encodes it,
+ * and returns the OpenBB file-viewer contract so the tearsheet renders inline.
+ * No synthetic content — whatever the API renders is what shows.
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { openbbCors } from "../../_lib/cors";
+import { bearerFromRequest, upstreamGetBytes } from "../../_lib/upstream";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(req: NextRequest) {
+  const cors = openbbCors(req.headers.get("origin"));
+  const ticker = (req.nextUrl.searchParams.get("ticker") || "").trim().toUpperCase();
+
+  if (!ticker) {
+    return NextResponse.json(
+      { error: "Missing required `ticker` parameter." },
+      { status: 400, headers: cors },
+    );
+  }
+
+  const key = bearerFromRequest(req);
+  if (!key) {
+    return NextResponse.json(
+      { error: "Missing API key. Add an X-API-KEY header with your rm_agent_live_* key." },
+      { status: 401, headers: cors },
+    );
+  }
+
+  const { status, bytes, error } = await upstreamGetBytes(
+    `/metrics/${encodeURIComponent(ticker)}/snapshot.pdf`,
+    key,
+  );
+
+  if (!bytes) {
+    const message =
+      (error as { error?: string; message?: string })?.error ||
+      (error as { message?: string })?.message ||
+      `Upstream returned ${status}`;
+    return NextResponse.json({ error: message }, { status, headers: cors });
+  }
+
+  const content = Buffer.from(bytes).toString("base64");
+  return NextResponse.json(
+    {
+      data_format: {
+        data_type: "pdf",
+        filename: `${ticker}_risk_snapshot.pdf`,
+      },
+      content,
+    },
+    { headers: cors },
+  );
+}
+
+export async function OPTIONS(req: NextRequest) {
+  return new NextResponse(null, {
+    status: 204,
+    headers: openbbCors(req.headers.get("origin")),
+  });
+}


### PR DESCRIPTION
## What

Lists RiskModels on **OpenBB Workspace** (`pro.openbb.co`) as a custom backend + App. A thin translation layer under `/openbb` that calls the same public `/api` any external consumer would — with the OpenBB user's own key — so billing, rate limits, and entitlements are unchanged.

Reachable at `https://riskmodels.app/openbb` today; `openbb.riskmodels.app` maps in later via a Vercel domain rewrite.

## Endpoints

| Path | Purpose |
|------|---------|
| `GET /openbb` | Backend info |
| `GET /openbb/widgets.json` | Widget defs |
| `GET /openbb/apps.json` | App defs (Single-Name Risk) |
| `GET /openbb/widgets/metrics?ticker=` | **Live** — L1/L2/L3 betas + hedge ratios + vol + Lstar as an OpenBB table |
| `GET /openbb/widgets/snapshot?ticker=` | **Live** — institutional risk-snapshot tearsheet via the OpenBB `pdf` file-viewer contract |

## Design

- **Per-user auth passthrough** — OpenBB user pastes their `rm_agent_live_*` key as an `X-API-KEY` header; the adapter forwards it as `Authorization: Bearer`. No shared secret; each user billed on their own key.
- **Scoped CORS** (`_lib/cors.ts`) — only `pro`/`my.openbb.co` + `X-API-KEY`, kept separate from the shared `@/lib/cors` public-API gate.
- **No mock data** — `widgets.json` lists only wired endpoints; missing upstream fields render as `—`, never fabricated.
- Pure translation layer — no engine access; same entitlements as a direct API call.

## Verification

- Typecheck clean.
- Live-verified end to end against **prod** (AAPL, free MAG7 tier): metrics table returns real betas/vol/Lstar; snapshot widget returns the correct `{data_format:{data_type:"pdf",...},content}` shape and the base64 decodes to a valid PDF tearsheet.
- CORS preflight echoes `pro.openbb.co` + `X-API-KEY`; missing-key → 401.

## Follow-ups (tracked in BWMACRO MASTER_BACKLOG E.21)

Wire remaining widgets (charts, rankings/holdings tables, portfolio risk + hedge layering), fill out the 3-app set, register the npm `riskmodels` MCP server as a Workspace agent, deploy + connect-test in the live Workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)