### PR TITLE
feat(mcp): Lstar MCP tools + capabilities foundation (E.11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to the RiskModels API surface and public assets.
 
 
-## [0.6.1] — 2026-06-13
+## [0.6.1] — 2026-06-30
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to the RiskModels API surface and public assets.
 
 
+## [0.6.1] — 2026-06-13
+
+### Added
+
+- **MCP `riskmodels_get_lstar` + `riskmodels_batch_lstar`** — Dedicated SDK-backed tools for `GET /lstar` and `POST /batch/lstar` (marginal-ER dispatch rule, dispatched HRs + residual return series). Unblocks agent discovery without routing through `returns-decomposition` or generic passthrough.
+- **`capabilities.json` `lstar` entry** — Standalone capability mirroring `lib/agent/capabilities.ts` ($0.02/request, `lstar_v1`). Also fixes MCP passthrough allowlist for `/lstar`.
+
+### Changed
+
+- **Python SDK semantic map** — `lstar_rr` normalizes to `lstar_residual_return`; `COLUMN_AGENT_HINTS` documents `lstar_residual_return` and `lstar_level`.
+
+
 ## [0.6.0] — 2026-06-09
 
 ### Added

--- a/lib/mcp/tools/riskmodels-tools.ts
+++ b/lib/mcp/tools/riskmodels-tools.ts
@@ -266,6 +266,92 @@ export function registerRiskModelsTools(
   );
 
   server.registerTool(
+    "riskmodels_get_lstar",
+    {
+      title: "RiskModels Lstar Recommended Hedge Level",
+      annotations: { readOnlyHint: true },
+      description:
+        "Per-(ticker, date) Lstar dispatch (GET /lstar): picks the simplest cascade level (L1/L2/L3) whose marginal explained-return clears the threshold (default 1%), then returns the chosen level's dispatched hedge ratios and daily residual_return[] aligned with dates[]. Use for stat-arb / manager-skill work on the idiosyncratic leg at the recommended hedge depth. Billing: $0.02/request.",
+      inputSchema: {
+        ticker: z.string().min(1).describe("Ticker symbol, e.g. NVDA or AAPL"),
+        years: z
+          .number()
+          .int()
+          .min(1)
+          .max(15)
+          .optional()
+          .describe("Calendar years of daily history (default 1, max 15)"),
+        market_factor_etf: z.string().optional().describe("Market factor ETF (default SPY)"),
+        axis: z
+          .enum(["industry", "style"])
+          .optional()
+          .describe("Cascade axis: industry (default) or style (SMB/HML spreads)"),
+        threshold: z
+          .number()
+          .optional()
+          .describe("Marginal ER threshold for level selection (default 0.01)"),
+      },
+    },
+    async ({ ticker, years, market_factor_etf, axis, threshold }) => {
+      try {
+        const query: Record<string, string | number | boolean> = {
+          ticker: ticker.trim().toUpperCase(),
+        };
+        if (years !== undefined) query.years = years;
+        if (market_factor_etf !== undefined) query.market_factor_etf = market_factor_etf;
+        if (axis !== undefined) query.axis = axis;
+        if (threshold !== undefined) query.threshold = threshold;
+        return textResult(await sdk.call("GET", "/lstar", { query }));
+      } catch (error) {
+        return errorResult(error);
+      }
+    },
+  );
+
+  server.registerTool(
+    "riskmodels_batch_lstar",
+    {
+      title: "RiskModels Batch Lstar Residual Returns",
+      annotations: { readOnlyHint: true },
+      description:
+        "Batch Lstar-dispatched residual returns for up to 100 tickers (POST /batch/lstar). Same marginal-ER selection rule as GET /lstar. Returns per-ticker dates, lstar level, residual_return[], and dispatched HRs. Billing: $0.005/ticker, minimum $0.01/call.",
+      inputSchema: {
+        tickers: z.array(z.string().min(1)).min(1).max(100).describe("Ticker symbols (1-100)"),
+        years: z
+          .number()
+          .int()
+          .min(1)
+          .max(15)
+          .optional()
+          .describe("Calendar years of daily history (default 1)"),
+        market_factor_etf: z.string().optional().describe("Market factor ETF (default SPY)"),
+        threshold: z
+          .number()
+          .optional()
+          .describe("Marginal ER threshold for Lstar selection (default 0.01)"),
+        format: z
+          .enum(["json", "parquet", "csv"])
+          .optional()
+          .describe("Response format (default json)"),
+      },
+    },
+    async ({ tickers, years, market_factor_etf, threshold, format }) => {
+      try {
+        const body: Record<string, unknown> = {
+          tickers: tickers.map((t: string) => t.trim().toUpperCase()),
+        };
+        if (years !== undefined) body.years = years;
+        if (market_factor_etf !== undefined) body.market_factor_etf = market_factor_etf;
+        if (threshold !== undefined) body.threshold = threshold;
+        if (format !== undefined) body.format = format;
+        return textResult(await sdk.call("POST", "/batch/lstar", { body }));
+      } catch (error) {
+        return errorResult(error);
+      }
+    },
+  );
+
+  server.registerTool(
     "riskmodels_get_hedge_levels",
     {
       title: "RiskModels L1/L2/L3 hedge_levels",

--- a/mcp/data/capabilities.json
+++ b/mcp/data/capabilities.json
@@ -748,6 +748,57 @@
     "tags": ["rankings", "cross-sectional", "screen", "percentile"]
   },
   {
+    "id": "lstar",
+    "name": "Lstar Recommended Hedge Level",
+    "description": "Per-(ticker, date) recommended hedge level (L1/L2/L3) with the chosen level's dispatched hedge ratios and daily residual return at that level (`residual_return[]`, aligned with `dates`). Selection rule picks the simplest level whose marginal explained-return clears the threshold (default 1%); routes mega-caps with noisy subsector hedges down to L2.",
+    "endpoint": "/api/lstar",
+    "method": "GET",
+    "parameters": {
+      "ticker": {
+        "type": "string",
+        "required": true,
+        "description": "Stock ticker symbol"
+      },
+      "market_factor_etf": {
+        "type": "string",
+        "required": false,
+        "description": "Market factor ETF",
+        "default": "SPY"
+      },
+      "years": {
+        "type": "integer",
+        "required": false,
+        "description": "Calendar years of daily history",
+        "default": 1
+      },
+      "threshold": {
+        "type": "number",
+        "required": false,
+        "description": "Marginal-ER threshold for level selection. Chat / agentic surfaces should leave at the 1% default; SDK callers may override.",
+        "default": 0.01
+      }
+    },
+    "pricing": {
+      "model": "per_request",
+      "tier": "premium",
+      "cost_usd": 0.02,
+      "currency": "USD",
+      "billing_code": "lstar_v1"
+    },
+    "performance": {
+      "avg_latency_ms": 130,
+      "p95_latency_ms": 220,
+      "availability_sla": 99.9,
+      "rate_limit_per_minute": 60
+    },
+    "confidence": {
+      "data_quality_score": 0.99,
+      "update_frequency": "daily",
+      "sources": ["erm3_models", "security_history"]
+    },
+    "tags": ["risk", "decomposition", "lstar", "hedge"]
+  },
+  {
     "id": "batch-lstar",
     "name": "Batch Lstar Residual Returns",
     "description": "Up to 100 tickers: per-date Lstar level (L1/L2/L3) with dispatched hedge ratios and Lstar-dispatched daily residual return. Same selection rule as GET /lstar.",

--- a/sdk/riskmodels/mapping.py
+++ b/sdk/riskmodels/mapping.py
@@ -34,6 +34,7 @@ METRICS_V3_TO_SEMANTIC: dict[str, str] = {
     "l2_rr": "l2_residual_return",
     "l3_cfr": "l3_combined_factor_return",
     "l3_rr": "l3_residual_return",
+    "lstar_rr": "lstar_residual_return",
     # Hierarchical regression betas (one per level — see OPENAPI_SPEC.yaml MetricsV3)
     "l1_mkt_beta": "l1_market_beta",
     "l2_sec_beta": "l2_sector_beta",
@@ -97,6 +98,8 @@ COLUMN_AGENT_HINTS: dict[str, str] = {
     "l2_residual_return": "Daily simple residual return at L2; decimal — not l2_residual_er.",
     "l3_combined_factor_return": "Daily simple combined factor return through L3 (subsector); decimal — not ER.",
     "l3_residual_return": "Daily simple residual return at L3; decimal — not l3_residual_er (idiosyncratic variance share).",
+    "lstar_residual_return": "Daily simple residual at the Lstar-dispatched level; decimal, not a variance fraction.",
+    "lstar_level": "Dispatched cascade depth per (ticker,date): 1=L1 market, 2=L2 sector, 3=L3 subsector, 0/null=no recommendation.",
     "l1_market_beta": "Hierarchical regression beta to SPY at L1 (always SPY). Dimensionless coefficient — NOT a hedge ratio.",
     "l2_sector_beta": "Hierarchical regression beta to the symbol's sector ETF at L2 (e.g. XLK for AAPL). Dimensionless — NOT a hedge ratio.",
     "l3_subsector_beta": "Hierarchical regression beta to the symbol's subsector ETF at L3 (e.g. RSPT for AAPL). Dimensionless — NOT a hedge ratio.",

--- a/sdk/tests/test_rename_completeness.py
+++ b/sdk/tests/test_rename_completeness.py
@@ -14,6 +14,10 @@ def test_metrics_v3_to_semantic_is_injective_on_targets():
     assert len(targets) == len(set(targets)), "duplicate semantic targets"
 
 
+def test_metrics_v3_to_semantic_maps_lstar_rr():
+    assert METRICS_V3_TO_SEMANTIC["lstar_rr"] == "lstar_residual_return"
+
+
 def test_ticker_returns_column_rename_maps_all_wire_keys():
     expected = {
         "l1_cfr": "l1_combined_factor_return",

--- a/tests/onboarding-upgrade.test.ts
+++ b/tests/onboarding-upgrade.test.ts
@@ -226,6 +226,8 @@ describe("RiskModels MCP live-paper tools", () => {
       "riskmodels_decompose",
       "riskmodels_get_returns",
       "riskmodels_get_return_attribution",
+      "riskmodels_get_lstar",
+      "riskmodels_batch_lstar",
       "riskmodels_get_hedge_levels",
       "riskmodels_compare",
       "riskmodels_hedge_position",


### PR DESCRIPTION
## Summary
- Adds dedicated MCP tools `riskmodels_get_lstar` and `riskmodels_batch_lstar` (SDK-backed wrappers for `GET /lstar` and `POST /batch/lstar`).
- Adds standalone `lstar` row to `mcp/data/capabilities.json` so passthrough allowlist and discovery match the live REST routes.
- Python SDK: `lstar_rr` → `lstar_residual_return` semantic rename + column hints.

Closes the gap tracked as **E.11** — REST/SDK shipped earlier but agents still had to route through `returns-decomposition?include_lstar=true` or generic passthrough.

## Test plan
- [x] `npm run typecheck`
- [x] `npm test -- tests/onboarding-upgrade.test.ts` (MCP tool registration)
- [ ] Merge then verify `riskmodels_list_endpoints` surfaces `/lstar` + `/batch/lstar` tools


Made with [Cursor](https://cursor.com)