### PR TITLE
fix(openbb): serve templates.json to stop Workspace connect 500

### DIFF
--- a/app/openbb/_lib/apps.ts
+++ b/app/openbb/_lib/apps.ts
@@ -1,0 +1,59 @@
+/**
+ * Shared OpenBB Workspace App / Template definitions.
+ *
+ * OpenBB's "Connect backend" probe fetches BOTH `apps.json` and `templates.json`
+ * during the connect-test (confirmed in Vercel logs 2026-06-30: a 404 on
+ * templates.json returns an HTML page, which OpenBB's backend JSON.parse chokes
+ * on → generic 500 in the Connect dialog). "Apps" and "templates" are the same
+ * concept in Workspace, so both routes serve this single array — whichever the
+ * running Workspace version consumes, the dashboard appears and neither 404s.
+ *
+ * Skeleton ships one app containing the live metrics widget so the
+ * connect-and-render path is exercised end to end. The full three-app set
+ * (Single-Name Risk, Portfolio Risk & Hedge, Screener — see E.21) lands as
+ * each widget's data endpoint is wired. Layout coords are best-effort and get
+ * tuned on first connect against the live Workspace grid.
+ */
+export const APPS = [
+  {
+    name: "RiskModels — Single-Name Risk",
+    description:
+      "Hedge layering, volatility, and residual signal for one ticker, powered by the RiskModels API.",
+    allowCustomization: true,
+    tabs: {
+      overview: {
+        id: "overview",
+        name: "Overview",
+        layout: [
+          {
+            i: "rm_single_name_metrics",
+            x: 0,
+            y: 0,
+            w: 20,
+            h: 12,
+            state: { params: { ticker: "AAPL" } },
+          },
+          {
+            i: "rm_single_name_snapshot",
+            x: 20,
+            y: 0,
+            w: 20,
+            h: 20,
+            state: { params: { ticker: "AAPL" } },
+          },
+        ],
+      },
+    },
+    groups: [
+      // Wire the ticker param across widgets once >1 widget is live, so changing
+      // the ticker in one updates the whole tab.
+      {
+        name: "ticker",
+        type: "param",
+        paramName: "ticker",
+        defaultValue: "AAPL",
+        widgetIds: ["rm_single_name_metrics", "rm_single_name_snapshot"],
+      },
+    ],
+  },
+];

--- a/app/openbb/apps.json/route.ts
+++ b/app/openbb/apps.json/route.ts
@@ -1,60 +1,14 @@
 /**
  * apps.json — OpenBB Workspace App definitions.
  *
- * Skeleton ships one app containing the live metrics widget so the
- * connect-and-render path is exercised end to end. The full three-app set
- * (Single-Name Risk, Portfolio Risk & Hedge, Screener — see E.21) lands as
- * each widget's data endpoint is wired. Layout coords are best-effort and get
- * tuned on first connect against the live Workspace grid.
+ * Shared with templates.json (see ../_lib/apps.ts): OpenBB's connect-test probes
+ * both files, so both serve the same array.
  */
 import { NextRequest, NextResponse } from "next/server";
 import { openbbCors } from "../_lib/cors";
+import { APPS } from "../_lib/apps";
 
 export const dynamic = "force-dynamic";
-
-const APPS = [
-  {
-    name: "RiskModels — Single-Name Risk",
-    description:
-      "Hedge layering, volatility, and residual signal for one ticker, powered by the RiskModels API.",
-    allowCustomization: true,
-    tabs: {
-      overview: {
-        id: "overview",
-        name: "Overview",
-        layout: [
-          {
-            i: "rm_single_name_metrics",
-            x: 0,
-            y: 0,
-            w: 20,
-            h: 12,
-            state: { params: { ticker: "AAPL" } },
-          },
-          {
-            i: "rm_single_name_snapshot",
-            x: 20,
-            y: 0,
-            w: 20,
-            h: 20,
-            state: { params: { ticker: "AAPL" } },
-          },
-        ],
-      },
-    },
-    groups: [
-      // Wire the ticker param across widgets once >1 widget is live, so changing
-      // the ticker in one updates the whole tab.
-      {
-        name: "ticker",
-        type: "param",
-        paramName: "ticker",
-        defaultValue: "AAPL",
-        widgetIds: ["rm_single_name_metrics", "rm_single_name_snapshot"],
-      },
-    ],
-  },
-];
 
 export async function GET(req: NextRequest) {
   return NextResponse.json(APPS, {

--- a/app/openbb/templates.json/route.ts
+++ b/app/openbb/templates.json/route.ts
@@ -1,0 +1,28 @@
+/**
+ * templates.json — OpenBB Workspace dashboard templates.
+ *
+ * OpenBB's "Connect backend" probe fetches this file during the connect-test.
+ * When it was absent, the request fell through to Next.js's 404 *HTML* page;
+ * OpenBB's backend then JSON.parse'd that HTML, threw, and surfaced a generic
+ * 500 in the Connect dialog (confirmed in Vercel logs 2026-06-30:
+ * `GET /openbb/templates.json -> 404`). "Apps" and "templates" are the same
+ * concept in Workspace, so this serves the same array as apps.json.
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { openbbCors } from "../_lib/cors";
+import { APPS } from "../_lib/apps";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(req: NextRequest) {
+  return NextResponse.json(APPS, {
+    headers: openbbCors(req.headers.get("origin")),
+  });
+}
+
+export async function OPTIONS(req: NextRequest) {
+  return new NextResponse(null, {
+    status: 204,
+    headers: openbbCors(req.headers.get("origin")),
+  });
+}


### PR DESCRIPTION
## Problem
OpenBB Workspace "Connect backend" Test returns **Server error (Status: 500)** for `https://riskmodels.app/openbb`.

## Root cause (verified in Vercel runtime logs)
During the connect-test OpenBB fetches a set of well-known manifests. Logs from a live Test click (2026-06-30 15:45):

| Path | Status |
|---|---|
| `GET /openbb/widgets.json` | 200 |
| `GET /openbb/apps.json` | 200 |
| `GET /openbb/templates.json` | **404** |

`templates.json` had no route, so it fell through to Next.js's 404 **HTML** page. OpenBB's backend `JSON.parse`s the manifest responses; parsing HTML throws → it surfaces a generic 500. (Same mechanism the prior fix `a7c0dd9` addressed for `agents.json`/`prompts.json`; this file was missed.)

## Fix
- Extract the app array to `app/openbb/_lib/apps.ts`.
- Serve it from both `apps.json` and the new `templates.json` route (apps == templates in Workspace), with the same CORS + OPTIONS handling as sibling routes.

## Verification
After deploy: `GET /openbb/templates.json` returns 200 JSON; OpenBB Test succeeds.

## Note (separate, not blocking connect)
Earlier logs (15:38) show `GET /api/metrics/AAPL -> 401 [Auth] API key invalid: Invalid API key format` — the `rm_agent_live_...` key forwarded by Workspace was rejected upstream. That only affects *widget data loading* after connect, not the connect-test itself. Worth confirming the key is valid/complete once connected. Also `GET /logo.png -> 404` (cosmetic backend logo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)