### PR TITLE
fix(openbb): allow X-OpenBB-User header so Workspace connect clears CORS

### DIFF
--- a/app/openbb/_lib/cors.ts
+++ b/app/openbb/_lib/cors.ts
@@ -1,22 +1,46 @@
 /**
  * CORS for the OpenBB Workspace adapter.
  *
- * OpenBB Workspace (pro.openbb.co) calls a custom backend cross-origin and
- * requires the backend to (a) echo the Workspace origin and (b) permit the
- * auth header the user configured. We pass the user's RiskModels key through
- * the `X-API-KEY` header, so it must be in Access-Control-Allow-Headers.
+ * OpenBB Workspace (pro.openbb.co) calls a custom backend cross-origin, with
+ * credentials, and attaches custom headers: the user's RiskModels key as
+ * `X-API-KEY` plus `X-OpenBB-User` (the Workspace account email). The browser
+ * preflights these, so EVERY header OpenBB sends must appear in
+ * Access-Control-Allow-Headers or the browser blocks the real request — which
+ * shows up as a generic 500 in the Connect dialog.
  *
- * This is deliberately separate from the shared `@/lib/cors` (which gates the
- * public /api surface to riskmodels.app / .net origins) — the OpenBB origins
- * have no business being allowed on the rest of the API.
+ * Credentialed CORS forbids the "*" wildcard for Allow-Headers, so we echo back
+ * the browser's `Access-Control-Request-Headers` (the standard robust pattern)
+ * and fall back to the known set for non-preflight calls. This way any header
+ * OpenBB adds in future (telemetry, tracing, …) is permitted without a code
+ * change.
+ *
+ * Deliberately separate from the shared `@/lib/cors` (which gates the public
+ * /api surface to riskmodels.app / .net origins) — the OpenBB origins have no
+ * business being allowed on the rest of the API.
  */
 
-const OPENBB_ORIGINS = [
-  "https://pro.openbb.co",
-  "https://my.openbb.co",
-];
+const OPENBB_ORIGINS = ["https://pro.openbb.co", "https://my.openbb.co"];
 
-export function openbbCors(requestOrigin?: string | null): Record<string, string> {
+// Fallback for non-preflight requests (which carry no Access-Control-Request-
+// Headers). Lists the headers OpenBB is known to send.
+const DEFAULT_ALLOW_HEADERS =
+  "Content-Type, Authorization, X-API-KEY, X-OpenBB-User";
+
+type HeaderBearing = { headers: { get(name: string): string | null } };
+
+export function openbbCors(
+  req?: HeaderBearing | string | null,
+): Record<string, string> {
+  // Back-compat: callers may pass an origin string or the request itself.
+  let requestOrigin: string | null = null;
+  let requestedHeaders: string | null = null;
+  if (typeof req === "string") {
+    requestOrigin = req;
+  } else if (req && req.headers) {
+    requestOrigin = req.headers.get("origin");
+    requestedHeaders = req.headers.get("access-control-request-headers");
+  }
+
   const isDev = process.env.NODE_ENV === "development";
   const allowed = [...OPENBB_ORIGINS];
   if (isDev) allowed.push("http://localhost:1420", "http://localhost:5050");
@@ -27,9 +51,9 @@ export function openbbCors(requestOrigin?: string | null): Record<string, string
   return {
     "Access-Control-Allow-Origin": origin,
     "Access-Control-Allow-Methods": "GET, OPTIONS",
-    "Access-Control-Allow-Headers": "Content-Type, Authorization, X-API-KEY",
+    "Access-Control-Allow-Headers": requestedHeaders || DEFAULT_ALLOW_HEADERS,
     "Access-Control-Allow-Credentials": "true",
     "Access-Control-Max-Age": "86400",
-    Vary: "Origin",
+    Vary: "Origin, Access-Control-Request-Headers",
   };
 }

--- a/app/openbb/agents.json/route.ts
+++ b/app/openbb/agents.json/route.ts
@@ -11,12 +11,12 @@ import { openbbCors } from "../_lib/cors";
 export const dynamic = "force-dynamic";
 
 export async function GET(req: NextRequest) {
-  return NextResponse.json({}, { headers: openbbCors(req.headers.get("origin")) });
+  return NextResponse.json({}, { headers: openbbCors(req) });
 }
 
 export async function OPTIONS(req: NextRequest) {
   return new NextResponse(null, {
     status: 204,
-    headers: openbbCors(req.headers.get("origin")),
+    headers: openbbCors(req),
   });
 }

--- a/app/openbb/apps.json/route.ts
+++ b/app/openbb/apps.json/route.ts
@@ -12,13 +12,13 @@ export const dynamic = "force-dynamic";
 
 export async function GET(req: NextRequest) {
   return NextResponse.json(APPS, {
-    headers: openbbCors(req.headers.get("origin")),
+    headers: openbbCors(req),
   });
 }
 
 export async function OPTIONS(req: NextRequest) {
   return new NextResponse(null, {
     status: 204,
-    headers: openbbCors(req.headers.get("origin")),
+    headers: openbbCors(req),
   });
 }

--- a/app/openbb/prompts.json/route.ts
+++ b/app/openbb/prompts.json/route.ts
@@ -10,12 +10,12 @@ import { openbbCors } from "../_lib/cors";
 export const dynamic = "force-dynamic";
 
 export async function GET(req: NextRequest) {
-  return NextResponse.json({}, { headers: openbbCors(req.headers.get("origin")) });
+  return NextResponse.json({}, { headers: openbbCors(req) });
 }
 
 export async function OPTIONS(req: NextRequest) {
   return new NextResponse(null, {
     status: 204,
-    headers: openbbCors(req.headers.get("origin")),
+    headers: openbbCors(req),
   });
 }

--- a/app/openbb/route.ts
+++ b/app/openbb/route.ts
@@ -26,13 +26,13 @@ export async function GET(req: NextRequest) {
       prompts: "/openbb/prompts.json",
       docs: "https://riskmodels.app/docs",
     },
-    { headers: openbbCors(req.headers.get("origin")) },
+    { headers: openbbCors(req) },
   );
 }
 
 export async function OPTIONS(req: NextRequest) {
   return new NextResponse(null, {
     status: 204,
-    headers: openbbCors(req.headers.get("origin")),
+    headers: openbbCors(req),
   });
 }

--- a/app/openbb/templates.json/route.ts
+++ b/app/openbb/templates.json/route.ts
@@ -16,13 +16,13 @@ export const dynamic = "force-dynamic";
 
 export async function GET(req: NextRequest) {
   return NextResponse.json(APPS, {
-    headers: openbbCors(req.headers.get("origin")),
+    headers: openbbCors(req),
   });
 }
 
 export async function OPTIONS(req: NextRequest) {
   return new NextResponse(null, {
     status: 204,
-    headers: openbbCors(req.headers.get("origin")),
+    headers: openbbCors(req),
   });
 }

--- a/app/openbb/widgets.json/route.ts
+++ b/app/openbb/widgets.json/route.ts
@@ -65,13 +65,13 @@ const WIDGETS = {
 
 export async function GET(req: NextRequest) {
   return NextResponse.json(WIDGETS, {
-    headers: openbbCors(req.headers.get("origin")),
+    headers: openbbCors(req),
   });
 }
 
 export async function OPTIONS(req: NextRequest) {
   return new NextResponse(null, {
     status: 204,
-    headers: openbbCors(req.headers.get("origin")),
+    headers: openbbCors(req),
   });
 }

--- a/app/openbb/widgets/metrics/route.ts
+++ b/app/openbb/widgets/metrics/route.ts
@@ -32,7 +32,7 @@ function money(v: unknown): string {
 }
 
 export async function GET(req: NextRequest) {
-  const cors = openbbCors(req.headers.get("origin"));
+  const cors = openbbCors(req);
   // OpenBB widget validation probes endpoints without query params; default to
   // the same ticker declared in widgets.json params[].value.
   const ticker = (req.nextUrl.searchParams.get("ticker") || "AAPL")
@@ -92,6 +92,6 @@ export async function GET(req: NextRequest) {
 export async function OPTIONS(req: NextRequest) {
   return new NextResponse(null, {
     status: 204,
-    headers: openbbCors(req.headers.get("origin")),
+    headers: openbbCors(req),
   });
 }

--- a/app/openbb/widgets/snapshot/route.ts
+++ b/app/openbb/widgets/snapshot/route.ts
@@ -16,7 +16,7 @@ import { bearerFromRequest, upstreamGetBytes } from "../../_lib/upstream";
 export const dynamic = "force-dynamic";
 
 export async function GET(req: NextRequest) {
-  const cors = openbbCors(req.headers.get("origin"));
+  const cors = openbbCors(req);
   // OpenBB widget validation probes endpoints without query params; default to
   // the same ticker declared in widgets.json params[].value.
   const ticker = (req.nextUrl.searchParams.get("ticker") || "AAPL")
@@ -57,6 +57,6 @@ export async function GET(req: NextRequest) {
 export async function OPTIONS(req: NextRequest) {
   return new NextResponse(null, {
     status: 204,
-    headers: openbbCors(req.headers.get("origin")),
+    headers: openbbCors(req),
   });
 }


### PR DESCRIPTION
## Problem
After fixing `templates.json` (#188) and `logo.png` (#189), OpenBB "Connect backend" Test **still** returned Status 500.

## Root cause (DevTools, confirmed)
Workspace fetches the manifests **from the browser** (credentialed, cross-origin). The blocked `GET /openbb/widgets.json` request carried:
- `x-api-key: rm_agent_live_…` ✅ allowed
- **`x-openbb-user: conrad@bwmacro.com`** ⛔ not in `Access-Control-Allow-Headers`

Our `Access-Control-Allow-Headers` was a fixed `Content-Type, Authorization, X-API-KEY`. The preflight returned 204, but the browser blocked the *actual* GET because `X-OpenBB-User` wasn't permitted → CORS error → OpenBB's generic 500.

(Network tab showed `OPTIONS widgets.json → 204` then `GET widgets.json → CORS error`, with "Provisional headers are shown" — the classic preflight-ok / actual-request-blocked signature.)

## Fix
- `openbbCors` now **echoes the browser's `Access-Control-Request-Headers`** back in `Access-Control-Allow-Headers` (the robust pattern for credentialed CORS, where `*` is forbidden), falling back to a set that includes `X-OpenBB-User`.
- Adds `Access-Control-Request-Headers` to `Vary`.
- All `app/openbb/**` route handlers pass the request to `openbbCors` so the preflight reflects whatever headers OpenBB sends (future-proof against new OpenBB headers).

## Verification
After deploy: preflight `OPTIONS /openbb/widgets.json` returns `Access-Control-Allow-Headers` echoing the requested headers (incl. `x-openbb-user`); browser GET succeeds; OpenBB Test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)