### PR TITLE
feat(openbb): wire chart + rankings widgets

### DIFF
--- a/app/openbb/README.md
+++ b/app/openbb/README.md
@@ -48,13 +48,22 @@ curl "http://localhost:3000/openbb/widgets/metrics?ticker=AAPL" \
 | `GET /openbb/prompts.json` | Prompt defs (empty stub) | ✅ |
 | `GET /openbb/widgets/metrics?ticker=` | Single-name risk table | ✅ live |
 | `GET /openbb/widgets/snapshot?ticker=` | Risk-snapshot tearsheet (`pdf` widget) | ✅ live |
+| `GET /openbb/widgets/returns-chart?ticker=&years=` | Cumulative total-return line chart | ✅ live |
+| `GET /openbb/widgets/risk-composition?ticker=&years=` | L3 explained-risk over time (line chart) | ✅ live |
+| `GET /openbb/widgets/rankings-top?metric=&cohort=&window=&limit=` | Top-ranked names table | ✅ live |
+| `GET /openbb/widgets/rankings?ticker=` | Single-name rankings table | ✅ live |
+
+Chart widgets use OpenBB's built-in table `chartView` (`data.table.chartView`,
+`chartType: "line"`) — the endpoint returns plain row arrays, so they render as
+a line chart and degrade to a readable table. `rankings/screen` is intentionally
+skipped (POST-only upstream; OpenBB widgets fetch via GET).
 
 ## Widget roadmap (add one route per item, then list it in `widgets.json`)
 
-- **Charts** → `/ticker-returns`, `/returns`, `/correlation`, `/macro-factors`,
-  `/l3-decomposition`, `/returns-decomposition`
-- **Tables** → `/rankings/screen`, `/rankings/top`, `/universe/{name}/members`,
-  `/etf-holdings`, `/filer-holdings`
+- **Charts** → `/correlation`, `/macro-factors`, `/returns-decomposition`
+  (`/ticker-returns` + `/l3-decomposition` covered by returns-chart /
+  risk-composition)
+- **Tables** → `/universe/{name}/members`, `/etf-holdings`, `/filer-holdings`
 - **HTML / image** → `/snapshot` (multi-position portfolio tearsheet), MCP
   `render_artifact` PNGs. (Single-name `snapshot.pdf` is already live above as
   the `pdf` widget. `snapshot.png` needs `PLAYWRIGHT_PDF_ENABLED=true` upstream

--- a/app/openbb/_lib/apps.ts
+++ b/app/openbb/_lib/apps.ts
@@ -41,19 +41,77 @@ export const APPS = [
             h: 20,
             state: { params: { ticker: "AAPL" } },
           },
+          {
+            i: "rm_cumulative_return",
+            x: 0,
+            y: 20,
+            w: 40,
+            h: 12,
+            state: { params: { ticker: "AAPL", years: "1" } },
+          },
+          {
+            i: "rm_risk_composition",
+            x: 0,
+            y: 32,
+            w: 40,
+            h: 12,
+            state: { params: { ticker: "AAPL", years: "1" } },
+          },
+          {
+            i: "rm_rankings_single",
+            x: 0,
+            y: 44,
+            w: 24,
+            h: 14,
+            state: { params: { ticker: "AAPL" } },
+          },
         ],
       },
     },
     groups: [
-      // Wire the ticker param across widgets once >1 widget is live, so changing
-      // the ticker in one updates the whole tab.
+      // Change the ticker in one widget → the whole tab follows.
       {
         name: "ticker",
         type: "param",
         paramName: "ticker",
         defaultValue: "AAPL",
-        widgetIds: ["rm_single_name_metrics", "rm_single_name_snapshot"],
+        widgetIds: [
+          "rm_single_name_metrics",
+          "rm_single_name_snapshot",
+          "rm_cumulative_return",
+          "rm_risk_composition",
+          "rm_rankings_single",
+        ],
       },
     ],
+  },
+  {
+    name: "RiskModels — Screener",
+    description:
+      "Cross-sectional rankings — top names by explained-risk, residual, return, and market cap across universe/sector/subsector cohorts.",
+    allowCustomization: true,
+    tabs: {
+      screen: {
+        id: "screen",
+        name: "Screener",
+        layout: [
+          {
+            i: "rm_rankings_top",
+            x: 0,
+            y: 0,
+            w: 24,
+            h: 16,
+            state: {
+              params: {
+                metric: "gross_return",
+                cohort: "universe",
+                window: "252d",
+                limit: "10",
+              },
+            },
+          },
+        ],
+      },
+    },
   },
 ];

--- a/app/openbb/_lib/connect-probe.ts
+++ b/app/openbb/_lib/connect-probe.ts
@@ -31,3 +31,14 @@ export function snapshotConnectProbe(ticker: string) {
     content: MINIMAL_PDF_BASE64,
   };
 }
+
+/**
+ * Generic no-key placeholder for table/chart widget endpoints. One explicit
+ * "wire your key" row (not market data) so OpenBB's connect-test gets a valid
+ * array instead of a 401 → 500.
+ */
+export function noKeyRows(): Array<{ status: string }> {
+  return [
+    { status: "Add X-API-KEY (rm_agent_live_*) in OpenBB Connections to load data" },
+  ];
+}

--- a/app/openbb/widgets.json/route.ts
+++ b/app/openbb/widgets.json/route.ts
@@ -61,6 +61,201 @@ const WIDGETS = {
       },
     ],
   },
+  rm_cumulative_return: {
+    name: "RiskModels — Cumulative Total Return",
+    description:
+      "Total-return index (base 100) for one ticker, compounded from daily gross returns.",
+    category: "Risk",
+    source: ["RiskModels API"],
+    endpoint: "widgets/returns-chart",
+    gridData: { w: 40, h: 12 },
+    params: [
+      {
+        paramName: "ticker",
+        value: "AAPL",
+        label: "Ticker",
+        type: "text",
+        description: "US equity ticker (e.g. AAPL, NVDA, BRK.B).",
+      },
+      {
+        paramName: "years",
+        value: "1",
+        label: "Years",
+        type: "text",
+        description: "Look-back window in years.",
+        options: [
+          { value: "1", label: "1" },
+          { value: "2", label: "2" },
+          { value: "3", label: "3" },
+          { value: "5", label: "5" },
+        ],
+      },
+    ],
+    data: {
+      table: {
+        chartView: { enabled: true, chartType: "line" },
+        showAll: false,
+        columnsDefs: [
+          { headerName: "Date", field: "date", chartDataType: "category" },
+          { headerName: "Total return (indexed to 100)", field: "indexed_return" },
+        ],
+      },
+    },
+  },
+  rm_risk_composition: {
+    name: "RiskModels — L3 Explained-Risk Over Time",
+    description:
+      "Daily L3 variance decomposition (Market / Sector / Subsector / Residual, % of total) for one ticker. Equities only.",
+    category: "Risk",
+    source: ["RiskModels API"],
+    endpoint: "widgets/risk-composition",
+    gridData: { w: 40, h: 12 },
+    params: [
+      {
+        paramName: "ticker",
+        value: "AAPL",
+        label: "Ticker",
+        type: "text",
+        description: "US equity ticker (e.g. AAPL, NVDA, BRK.B).",
+      },
+      {
+        paramName: "years",
+        value: "1",
+        label: "Years",
+        type: "text",
+        description: "Look-back window in years.",
+        options: [
+          { value: "1", label: "1" },
+          { value: "2", label: "2" },
+          { value: "3", label: "3" },
+          { value: "5", label: "5" },
+        ],
+      },
+    ],
+    data: {
+      table: {
+        chartView: { enabled: true, chartType: "line" },
+        showAll: false,
+        columnsDefs: [
+          { headerName: "Date", field: "date", chartDataType: "category" },
+          { headerName: "Market %", field: "Market" },
+          { headerName: "Sector %", field: "Sector" },
+          { headerName: "Subsector %", field: "Subsector" },
+          { headerName: "Residual %", field: "Residual" },
+        ],
+      },
+    },
+  },
+  rm_rankings_top: {
+    name: "RiskModels — Top Rankings",
+    description:
+      "Top-ranked names by a chosen metric, cohort, and window (cross-sectional percentile ranks).",
+    category: "Risk",
+    type: "table",
+    source: ["RiskModels API"],
+    endpoint: "widgets/rankings-top",
+    gridData: { w: 24, h: 14 },
+    params: [
+      {
+        paramName: "metric",
+        value: "gross_return",
+        label: "Metric",
+        type: "text",
+        description: "Ranking metric.",
+        options: [
+          { value: "gross_return", label: "Gross return" },
+          { value: "mkt_cap", label: "Market cap" },
+          { value: "sector_residual", label: "Sector residual" },
+          { value: "subsector_residual", label: "Subsector residual" },
+          { value: "er_l1", label: "Explained risk (L1)" },
+          { value: "er_l2", label: "Explained risk (L2)" },
+          { value: "er_l3", label: "Explained risk (L3)" },
+          { value: "stock_specific_lstar", label: "Stock-specific (Lstar)" },
+        ],
+      },
+      {
+        paramName: "cohort",
+        value: "universe",
+        label: "Cohort",
+        type: "text",
+        description: "Ranking cohort.",
+        options: [
+          { value: "universe", label: "Universe" },
+          { value: "sector", label: "Sector" },
+          { value: "subsector", label: "Subsector" },
+        ],
+      },
+      {
+        paramName: "window",
+        value: "252d",
+        label: "Window",
+        type: "text",
+        description: "Look-back window.",
+        options: [
+          { value: "1d", label: "1 day" },
+          { value: "21d", label: "21 days" },
+          { value: "63d", label: "63 days" },
+          { value: "252d", label: "252 days" },
+        ],
+      },
+      {
+        paramName: "limit",
+        value: "10",
+        label: "Limit",
+        type: "text",
+        description: "Number of names.",
+        options: [
+          { value: "10", label: "10" },
+          { value: "25", label: "25" },
+          { value: "50", label: "50" },
+          { value: "100", label: "100" },
+        ],
+      },
+    ],
+    data: {
+      table: {
+        showAll: true,
+        columnsDefs: [
+          { field: "rank", headerName: "Rank" },
+          { field: "ticker", headerName: "Ticker" },
+          { field: "percentile", headerName: "Percentile" },
+          { field: "cohort_size", headerName: "Cohort size" },
+        ],
+      },
+    },
+  },
+  rm_rankings_single: {
+    name: "RiskModels — Single-Name Rankings",
+    description:
+      "One ticker's cross-sectional rank + percentile across every metric, cohort, and window.",
+    category: "Risk",
+    type: "table",
+    source: ["RiskModels API"],
+    endpoint: "widgets/rankings",
+    gridData: { w: 24, h: 14 },
+    params: [
+      {
+        paramName: "ticker",
+        value: "AAPL",
+        label: "Ticker",
+        type: "text",
+        description: "US equity ticker (e.g. AAPL, NVDA, BRK.B).",
+      },
+    ],
+    data: {
+      table: {
+        showAll: true,
+        columnsDefs: [
+          { field: "metric", headerName: "Metric" },
+          { field: "cohort", headerName: "Cohort" },
+          { field: "window", headerName: "Window" },
+          { field: "percentile", headerName: "Percentile" },
+          { field: "rank_ordinal", headerName: "Rank" },
+          { field: "cohort_size", headerName: "Cohort size" },
+        ],
+      },
+    },
+  },
 } as const;
 
 export async function GET(req: NextRequest) {

--- a/app/openbb/widgets/rankings-top/route.ts
+++ b/app/openbb/widgets/rankings-top/route.ts
@@ -1,0 +1,62 @@
+/**
+ * Live widget: top-ranked names by metric/cohort/window → OpenBB table.
+ *
+ * GET /openbb/widgets/rankings-top?metric=gross_return&cohort=universe&window=252d&limit=10
+ * Maps the real /rankings/top snapshot. Enum params are validated upstream; a
+ * bad combo returns the upstream error message (no fabricated rows).
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { noKeyRows } from "../../_lib/connect-probe";
+import { openbbCors } from "../../_lib/cors";
+import { bearerFromRequest, upstreamGet } from "../../_lib/upstream";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(req: NextRequest) {
+  const cors = openbbCors(req);
+  const sp = req.nextUrl.searchParams;
+  const metric = (sp.get("metric") || "gross_return").trim();
+  const cohort = (sp.get("cohort") || "universe").trim();
+  const window = (sp.get("window") || "252d").trim();
+  const limit = (sp.get("limit") || "10").trim();
+
+  const key = bearerFromRequest(req);
+  if (!key) return NextResponse.json(noKeyRows(), { headers: cors });
+
+  const qs = new URLSearchParams({ metric, cohort, window, limit }).toString();
+  const { status, body } = await upstreamGet(`/rankings/top?${qs}`, key);
+  if (status < 200 || status >= 300) {
+    const message =
+      (body as { error?: string; message?: string })?.error ||
+      (body as { message?: string })?.message ||
+      `Upstream returned ${status}`;
+    return NextResponse.json({ error: message }, { status, headers: cors });
+  }
+
+  const rankings =
+    (body as {
+      rankings?: Array<{
+        ticker?: string;
+        symbol?: string;
+        rank_ordinal?: number | null;
+        rank_percentile?: number | null;
+        cohort_size?: number | null;
+      }>;
+    }).rankings ?? [];
+
+  const rows = rankings.map((r) => ({
+    rank: r.rank_ordinal ?? null,
+    ticker: r.ticker ?? r.symbol ?? "—",
+    percentile:
+      r.rank_percentile != null && Number.isFinite(Number(r.rank_percentile))
+        ? Number(Number(r.rank_percentile).toFixed(1))
+        : null,
+    cohort_size: r.cohort_size ?? null,
+  }));
+
+  return NextResponse.json(rows, { headers: cors });
+}
+
+export async function OPTIONS(req: NextRequest) {
+  return new NextResponse(null, { status: 204, headers: openbbCors(req) });
+}

--- a/app/openbb/widgets/rankings/route.ts
+++ b/app/openbb/widgets/rankings/route.ts
@@ -1,0 +1,63 @@
+/**
+ * Live widget: single-name cross-sectional rankings → OpenBB table.
+ *
+ * GET /openbb/widgets/rankings?ticker=AAPL
+ * Maps the real /rankings/{ticker} response — one row per (metric · cohort ·
+ * window) with the name's ordinal rank + percentile in its cohort.
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { noKeyRows } from "../../_lib/connect-probe";
+import { openbbCors } from "../../_lib/cors";
+import { bearerFromRequest, upstreamGet } from "../../_lib/upstream";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(req: NextRequest) {
+  const cors = openbbCors(req);
+  const ticker = (req.nextUrl.searchParams.get("ticker") || "AAPL").trim().toUpperCase();
+
+  const key = bearerFromRequest(req);
+  if (!key) return NextResponse.json(noKeyRows(), { headers: cors });
+
+  const { status, body } = await upstreamGet(
+    `/rankings/${encodeURIComponent(ticker)}`,
+    key,
+  );
+  if (status < 200 || status >= 300) {
+    const message =
+      (body as { error?: string; message?: string })?.error ||
+      (body as { message?: string })?.message ||
+      `Upstream returned ${status}`;
+    return NextResponse.json({ error: message }, { status, headers: cors });
+  }
+
+  const rankings =
+    (body as {
+      rankings?: Array<{
+        metric?: string;
+        cohort?: string;
+        window?: string;
+        rank_ordinal?: number | null;
+        rank_percentile?: number | null;
+        cohort_size?: number | null;
+      }>;
+    }).rankings ?? [];
+
+  const rows = rankings.map((r) => ({
+    metric: r.metric ?? "—",
+    cohort: r.cohort ?? "—",
+    window: r.window ?? "—",
+    percentile:
+      r.rank_percentile != null && Number.isFinite(Number(r.rank_percentile))
+        ? Number(Number(r.rank_percentile).toFixed(1))
+        : null,
+    rank_ordinal: r.rank_ordinal ?? null,
+    cohort_size: r.cohort_size ?? null,
+  }));
+
+  return NextResponse.json(rows, { headers: cors });
+}
+
+export async function OPTIONS(req: NextRequest) {
+  return new NextResponse(null, { status: 204, headers: openbbCors(req) });
+}

--- a/app/openbb/widgets/returns-chart/route.ts
+++ b/app/openbb/widgets/returns-chart/route.ts
@@ -1,0 +1,53 @@
+/**
+ * Live widget: cumulative total return → OpenBB line chart (table-backed).
+ *
+ * GET /openbb/widgets/returns-chart?ticker=AAPL&years=1
+ * Maps the real /ticker-returns daily series into an index-to-100 total-return
+ * curve (compounding `returns_gross`). Returns plain rows; widgets.json renders
+ * them as a line via the built-in chartView (degrades to a table).
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { noKeyRows } from "../../_lib/connect-probe";
+import { openbbCors } from "../../_lib/cors";
+import { bearerFromRequest, upstreamGet } from "../../_lib/upstream";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(req: NextRequest) {
+  const cors = openbbCors(req);
+  const ticker = (req.nextUrl.searchParams.get("ticker") || "AAPL").trim().toUpperCase();
+  const years = (req.nextUrl.searchParams.get("years") || "1").trim();
+
+  const key = bearerFromRequest(req);
+  if (!key) return NextResponse.json(noKeyRows(), { headers: cors });
+
+  const { status, body } = await upstreamGet(
+    `/ticker-returns?ticker=${encodeURIComponent(ticker)}&years=${encodeURIComponent(years)}`,
+    key,
+  );
+  if (status < 200 || status >= 300) {
+    const message =
+      (body as { error?: string; message?: string })?.error ||
+      (body as { message?: string })?.message ||
+      `Upstream returned ${status}`;
+    return NextResponse.json({ error: message }, { status, headers: cors });
+  }
+
+  const data =
+    (body as { data?: Array<{ date: string; returns_gross: number | null }> }).data ?? [];
+
+  // Index to 100 at the first observation, then compound daily total returns.
+  let idx = 100;
+  const rows = data.map((r, i) => {
+    if (i > 0 && typeof r.returns_gross === "number" && Number.isFinite(r.returns_gross)) {
+      idx *= 1 + r.returns_gross;
+    }
+    return { date: r.date, indexed_return: Number(idx.toFixed(2)) };
+  });
+
+  return NextResponse.json(rows, { headers: cors });
+}
+
+export async function OPTIONS(req: NextRequest) {
+  return new NextResponse(null, { status: 204, headers: openbbCors(req) });
+}

--- a/app/openbb/widgets/risk-composition/route.ts
+++ b/app/openbb/widgets/risk-composition/route.ts
@@ -1,0 +1,66 @@
+/**
+ * Live widget: L3 explained-risk composition over time → OpenBB line chart.
+ *
+ * GET /openbb/widgets/risk-composition?ticker=AAPL&years=1
+ * Maps the real /ticker-returns daily L3 explained-risk fractions
+ * (l3_mkt_er / l3_sec_er / l3_sub_er / l3_res_er, which sum to 1) into percent
+ * series. ETFs have no L3 decomposition → empty series (never fabricated).
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { noKeyRows } from "../../_lib/connect-probe";
+import { openbbCors } from "../../_lib/cors";
+import { bearerFromRequest, upstreamGet } from "../../_lib/upstream";
+
+export const dynamic = "force-dynamic";
+
+const pct = (x: unknown): number | null => {
+  if (x === null || x === undefined) return null;
+  const n = Number(x);
+  return Number.isFinite(n) ? Number((n * 100).toFixed(2)) : null;
+};
+
+export async function GET(req: NextRequest) {
+  const cors = openbbCors(req);
+  const ticker = (req.nextUrl.searchParams.get("ticker") || "AAPL").trim().toUpperCase();
+  const years = (req.nextUrl.searchParams.get("years") || "1").trim();
+
+  const key = bearerFromRequest(req);
+  if (!key) return NextResponse.json(noKeyRows(), { headers: cors });
+
+  const { status, body } = await upstreamGet(
+    `/ticker-returns?ticker=${encodeURIComponent(ticker)}&years=${encodeURIComponent(years)}`,
+    key,
+  );
+  if (status < 200 || status >= 300) {
+    const message =
+      (body as { error?: string; message?: string })?.error ||
+      (body as { message?: string })?.message ||
+      `Upstream returned ${status}`;
+    return NextResponse.json({ error: message }, { status, headers: cors });
+  }
+
+  const data =
+    (body as {
+      data?: Array<{
+        date: string;
+        l3_mkt_er?: number | null;
+        l3_sec_er?: number | null;
+        l3_sub_er?: number | null;
+        l3_res_er?: number | null;
+      }>;
+    }).data ?? [];
+
+  const rows = data.map((r) => ({
+    date: r.date,
+    Market: pct(r.l3_mkt_er),
+    Sector: pct(r.l3_sec_er),
+    Subsector: pct(r.l3_sub_er),
+    Residual: pct(r.l3_res_er),
+  }));
+
+  return NextResponse.json(rows, { headers: cors });
+}
+
+export async function OPTIONS(req: NextRequest) {
+  return new NextResponse(null, { status: 204, headers: openbbCors(req) });
+}


### PR DESCRIPTION
## What
Four new live OpenBB Workspace widgets on the RiskModels custom backend (E.21), all pure translation-layer routes over the public API with per-user key passthrough and the no-mock-data rule.

### Charts (OpenBB built-in table `chartView` → line; degrades to a table)
- **`widgets/returns-chart`** — cumulative total return indexed to 100, compounded from `/ticker-returns` daily `returns_gross`.
- **`widgets/risk-composition`** — daily **L3 explained-risk fractions** (Market/Sector/Subsector/Residual %, verified to sum to 1) from the same series. Equities only (ETFs → empty series, never fabricated).

### Tables
- **`widgets/rankings-top`** — top-N by metric/cohort/window with dropdown params, from `/rankings/top`.
- **`widgets/rankings`** — one ticker's rank + percentile across every metric/cohort/window, from `/rankings/{ticker}`.

### Wiring
- Registered all four in `widgets.json`.
- Added them to the **Single-Name Risk** app + a new **Screener** app (`_lib/apps.ts`).
- Shared `noKeyRows()` connect-probe so the connect-test never 401→500s.
- README updated.

## Notes
- Chose OpenBB's **built-in table chart** contract over raw Plotly (verified against OpenBB's `chart_widget` reference example) — the endpoint returns plain row arrays, renders as a chart, and degrades to a readable table. Zero blank/500 risk.
- `rankings/screen` intentionally skipped — it's **POST-only** upstream (405 on GET); OpenBB widgets fetch via GET.
- Endpoint shapes + value semantics (`returns_gross` = daily total-return fraction; `l3_*_er` sum to 1) probed against prod before building.
- Typecheck clean (0 TS errors).

## Verification
Post-deploy: fetch each adapter endpoint with a live key and confirm real rows; then re-run/refresh in Workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)