### PR TITLE
fix(openbb): sensible default for Top Rankings widget

### DIFF
--- a/app/openbb/_lib/apps.ts
+++ b/app/openbb/_lib/apps.ts
@@ -103,9 +103,9 @@ export const APPS = [
             h: 16,
             state: {
               params: {
-                metric: "gross_return",
+                metric: "mkt_cap",
                 cohort: "universe",
-                window: "252d",
+                window: "1d",
                 limit: "10",
               },
             },

--- a/app/openbb/widgets.json/route.ts
+++ b/app/openbb/widgets.json/route.ts
@@ -149,7 +149,7 @@ const WIDGETS = {
   rm_rankings_top: {
     name: "RiskModels — Top Rankings",
     description:
-      "Top-ranked names by a chosen metric, cohort, and window (cross-sectional percentile ranks).",
+      "Top-ranked names by a chosen metric, cohort, and window (cross-sectional percentile ranks). Point-in-time metrics (market cap, explained risk L1/L2/L3, stock-specific) rank at the 1-day window; return and residual metrics use the longer windows.",
     category: "Risk",
     type: "table",
     source: ["RiskModels API"],
@@ -158,7 +158,7 @@ const WIDGETS = {
     params: [
       {
         paramName: "metric",
-        value: "gross_return",
+        value: "mkt_cap",
         label: "Metric",
         type: "text",
         description: "Ranking metric.",
@@ -187,10 +187,10 @@ const WIDGETS = {
       },
       {
         paramName: "window",
-        value: "252d",
+        value: "1d",
         label: "Window",
         type: "text",
-        description: "Look-back window.",
+        description: "Look-back window. Use 1d for point-in-time metrics.",
         options: [
           { value: "1d", label: "1 day" },
           { value: "21d", label: "21 days" },


### PR DESCRIPTION
Default the Screener's Top Rankings widget to `mkt_cap / universe / 1d` (recognizable large-caps, always populated) instead of `gross_return / 252d` (opened with an obscure BW-BBG id as #1). Verified against prod: point-in-time metrics only rank at `window=1d`; return/residual metrics use longer windows — now documented in the widget + window param descriptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)