### PR TITLE
feat(openbb): snapshot widget as a data table (not PDF)

### DIFF
--- a/app/openbb/README.md
+++ b/app/openbb/README.md
@@ -47,7 +47,8 @@ curl "http://localhost:3000/openbb/widgets/metrics?ticker=AAPL" \
 | `GET /openbb/agents.json` | Agent defs (empty stub until MCP wired) | ✅ |
 | `GET /openbb/prompts.json` | Prompt defs (empty stub) | ✅ |
 | `GET /openbb/widgets/metrics?ticker=` | Single-name risk table | ✅ live |
-| `GET /openbb/widgets/snapshot?ticker=` | Risk-snapshot tearsheet (`pdf` widget) | ✅ live |
+| `GET /openbb/widgets/snapshot-table?ticker=` | Risk snapshot as a table (L3 decomposition + hedge ratios) | ✅ live |
+| `GET /openbb/widgets/snapshot?ticker=` | Risk-snapshot PDF (kept for API; **not** a widget — OpenBB's pdf.js viewer wouldn't render it) | ⚠️ deprecated as widget |
 | `GET /openbb/widgets/returns-chart?ticker=&years=` | Cumulative total-return line chart | ✅ live |
 | `GET /openbb/widgets/risk-composition?ticker=&years=` | L3 explained-risk over time (line chart) | ✅ live |
 | `GET /openbb/widgets/rankings-top?metric=&cohort=&window=&limit=` | Top-ranked names table | ✅ live |

--- a/app/openbb/widgets.json/route.ts
+++ b/app/openbb/widgets.json/route.ts
@@ -42,15 +42,14 @@ const WIDGETS = {
     },
   },
   rm_single_name_snapshot: {
-    name: "RiskModels — Risk Snapshot Tearsheet",
+    name: "RiskModels — Risk Snapshot",
     description:
-      "Institutional one-page risk tearsheet (PDF): L3 explained-risk decomposition, portfolio volatility, and position-level hedge ratios for one ticker.",
+      "Single-name risk snapshot: L3 explained-risk decomposition (Market/Sector/Subsector/Residual), systematic share, volatility, recommended hedge level, and L3 hedge ratios.",
     category: "Risk",
-    type: "pdf",
+    type: "table",
     source: ["RiskModels API"],
-    runButton: true,
-    endpoint: "widgets/snapshot",
-    gridData: { w: 20, h: 20 },
+    endpoint: "widgets/snapshot-table",
+    gridData: { w: 20, h: 14 },
     params: [
       {
         paramName: "ticker",
@@ -60,6 +59,15 @@ const WIDGETS = {
         description: "US equity ticker (e.g. AAPL, NVDA, BRK.B).",
       },
     ],
+    data: {
+      table: {
+        showAll: true,
+        columnsDefs: [
+          { field: "metric", headerName: "Metric", cellDataType: "text" },
+          { field: "value", headerName: "Value", cellDataType: "text" },
+        ],
+      },
+    },
   },
   rm_cumulative_return: {
     name: "RiskModels — Cumulative Total Return",

--- a/app/openbb/widgets/snapshot-table/route.ts
+++ b/app/openbb/widgets/snapshot-table/route.ts
@@ -1,0 +1,92 @@
+/**
+ * Live widget: single-name risk snapshot → OpenBB table (raw data).
+ *
+ * GET /openbb/widgets/snapshot-table?ticker=AAPL
+ * The data-first replacement for the PDF snapshot widget (OpenBB's pdf.js
+ * viewer wouldn't render our tearsheet). One call to /metrics/{ticker} carries
+ * the whole story: L3 explained-risk decomposition, systematic share,
+ * volatility, hedge level, and L3 hedge ratios. Missing fields render as "—".
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { noKeyRows } from "../../_lib/connect-probe";
+import { openbbCors } from "../../_lib/cors";
+import { bearerFromRequest, upstreamGet } from "../../_lib/upstream";
+
+export const dynamic = "force-dynamic";
+
+type Row = { metric: string; value: string };
+
+function num(v: unknown, digits = 3): string {
+  if (v === null || v === undefined || v === "") return "—";
+  const n = Number(v);
+  return Number.isFinite(n) ? n.toFixed(digits) : "—";
+}
+function pct1(v: unknown): string {
+  if (v === null || v === undefined || v === "") return "—";
+  const n = Number(v);
+  return Number.isFinite(n) ? `${(n * 100).toFixed(1)}%` : "—";
+}
+function money(v: unknown): string {
+  if (v === null || v === undefined || v === "") return "—";
+  const n = Number(v);
+  if (!Number.isFinite(n)) return "—";
+  if (n >= 1e12) return `$${(n / 1e12).toFixed(2)}T`;
+  if (n >= 1e9) return `$${(n / 1e9).toFixed(2)}B`;
+  if (n >= 1e6) return `$${(n / 1e6).toFixed(2)}M`;
+  return `$${n.toFixed(2)}`;
+}
+
+export async function GET(req: NextRequest) {
+  const cors = openbbCors(req);
+  const ticker = (req.nextUrl.searchParams.get("ticker") || "AAPL").trim().toUpperCase();
+
+  const key = bearerFromRequest(req);
+  if (!key) return NextResponse.json(noKeyRows(), { headers: cors });
+
+  const { status, body } = await upstreamGet(`/metrics/${encodeURIComponent(ticker)}`, key);
+  if (status < 200 || status >= 300) {
+    const message =
+      (body as { error?: string; message?: string })?.error ||
+      (body as { message?: string })?.message ||
+      `Upstream returned ${status}`;
+    return NextResponse.json({ error: message }, { status, headers: cors });
+  }
+
+  const d = body as {
+    ticker?: string;
+    teo?: string;
+    metrics?: Record<string, unknown>;
+    _data_health?: { data_as_of?: string };
+  };
+  const m = d.metrics ?? {};
+
+  // Systematic = market + sector + subsector explained risk (1 − residual).
+  // Null when the name has no L3 decomposition (e.g. ETFs).
+  const systematic =
+    m.l3_mkt_er == null
+      ? null
+      : Number(m.l3_mkt_er ?? 0) + Number(m.l3_sec_er ?? 0) + Number(m.l3_sub_er ?? 0);
+
+  const rows: Row[] = [
+    { metric: "Ticker", value: d.ticker ?? ticker },
+    { metric: "As of", value: d._data_health?.data_as_of ?? d.teo ?? "—" },
+    { metric: "Price (close)", value: money(m.price_close) },
+    { metric: "L3 explained risk — Market", value: pct1(m.l3_mkt_er) },
+    { metric: "L3 explained risk — Sector", value: pct1(m.l3_sec_er) },
+    { metric: "L3 explained risk — Subsector", value: pct1(m.l3_sub_er) },
+    { metric: "L3 explained risk — Residual (stock-specific)", value: pct1(m.l3_res_er) },
+    { metric: "Systematic (market + sector + subsector)", value: pct1(systematic) },
+    { metric: "Volatility — 252d (annualised)", value: num(m.vol_252d_ann) },
+    { metric: "Recommended hedge level", value: String(m.recommended_hedge_level ?? "—") },
+    { metric: "Lstar residual level", value: String(m.lstar_level ?? "—") },
+    { metric: "L3 hedge ratio — Market", value: num(m.l3_mkt_hr) },
+    { metric: "L3 hedge ratio — Sector", value: num(m.l3_sec_hr) },
+    { metric: "L3 hedge ratio — Subsector", value: num(m.l3_sub_hr) },
+  ];
+
+  return NextResponse.json(rows, { headers: cors });
+}
+
+export async function OPTIONS(req: NextRequest) {
+  return new NextResponse(null, { status: 204, headers: openbbCors(req) });
+}


### PR DESCRIPTION
OpenBB's in-app pdf.js viewer renders our snapshot PDF blank (the PDF is valid — renders in poppler — but shows blank 1/1 in Workspace). Per CEO direction, serve the snapshot as **raw data** instead.

New `widgets/snapshot-table` maps one `/metrics/{ticker}` call into a labeled snapshot table: L3 explained-risk decomposition (Market/Sector/Subsector/Residual, sum to 1), systematic share, 252d volatility, recommended hedge level, Lstar level, and L3 hedge ratios. Nulls → `—`.

`rm_single_name_snapshot` flipped from `type:"pdf"` → `type:"table"`. The PDF route + `/api/.../snapshot.pdf` stay for API consumers, just no longer wired to a widget. Tables render reliably in OpenBB (the metrics widget proves it). Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)