### PR TITLE
docs: ChatGPT, Grok, and Gemini MCP setup paths

### DIFF
--- a/app/.well-known/mcp.json/route.ts
+++ b/app/.well-known/mcp.json/route.ts
@@ -17,20 +17,49 @@ export async function GET() {
           "Clean dividend-adjusted US equity total returns, factor risk decomposition, return attribution, and ETF hedge ratios.",
         url: sseUrl,
         transport: "streamable-http",
-        auth: {
-          type: "bearer",
-          header: "Authorization",
-          prefix: "Bearer ",
-        },
+        auth: [
+          {
+            type: "oauth2",
+            protected_resource: `${base}/.well-known/oauth-protected-resource`,
+            authorization_server: `${base}/.well-known/oauth-authorization-server`,
+            scopes: ["mcp:read"],
+            note: "Preferred for Claude Desktop, Cursor, and ChatGPT Developer Mode connectors",
+          },
+          {
+            type: "bearer",
+            header: "Authorization",
+            prefix: "Bearer ",
+            note: "For mcp-remote, curl, or agents with a personal API key",
+          },
+        ],
         capabilities: {
           tools: true,
           resources: true,
         },
       },
     },
+    documentation_url: `${base}/docs/agent-integration`,
+    llms_txt: `${base}/llms.txt`,
+    client_setup: {
+      claude_desktop_cursor:
+        "Settings → Connectors → Add custom connector → paste MCP URL → OAuth sign-in (leave client id/secret blank)",
+      chatgpt:
+        "Settings → Apps & Connectors → Advanced → enable Developer mode → Create → paste MCP URL → OAuth sign-in (Plus+ web; not the Finances/Schwab connector)",
+      grok:
+        "grok.com/connectors → New Connector → Custom → paste MCP URL → OAuth sign-in (web, iOS, Android)",
+      gemini_consumer_web:
+        "No custom MCP UI — use llms.txt + REST in chat, or get-key for full universe",
+      gemini_cli:
+        "gemini mcp add --transport http riskmodels https://riskmodels.app/api/mcp/sse then /mcp auth riskmodels",
+      gemini_enterprise:
+        "Google Cloud admin: Custom MCP Server data store; Streamable HTTP URL + OAuth (Client ID/Secret may need POST /api/oauth/register)",
+      cli: "RISKMODELS_API_KEY=… npx -y riskmodels@latest install",
+    },
     _documentation: {
       note: "Use POST on the MCP Streamable HTTP endpoint with Accept: application/json, text/event-stream",
       sse_post: sseUrl,
+      chatgpt_finances_note:
+        "ChatGPT Finances/Schwab is a separate connector. Combine holdings from Finances with RiskModels REST or add this MCP server via Developer Mode.",
     },
   };
   return NextResponse.json(payload, {

--- a/app/api-reference/page.tsx
+++ b/app/api-reference/page.tsx
@@ -398,7 +398,7 @@ export default function ApiReferencePage() {
                 <div>
                   <h2 className="text-2xl font-semibold tracking-tight mb-3">Fastest way to get started with agents</h2>
                   <p className="text-zinc-400 max-w-2xl">
-                    Paste one line into any AI chat (Claude, ChatGPT, Cursor). The agent reads riskmodels.app, wires itself up for the conversation, and tells you what it can do — no install, no terminal.
+                    Paste one line into any AI chat (Claude, ChatGPT, Grok, Gemini web, Cursor). The agent reads riskmodels.app, wires itself up for the conversation, and tells you what it can do — no install, no terminal.
                   </p>
                 </div>
 
@@ -410,7 +410,8 @@ export default function ApiReferencePage() {
                     </div>
                     <p className="text-xs text-zinc-500 mt-2">
                       Want it permanently in Claude or Cursor? Settings → Connectors → Add custom connector → paste{' '}
-                      <code className="text-zinc-400">https://riskmodels.app/api/mcp/sse</code> and Connect — sign in, no key needed. Details in the{' '}
+                      <code className="text-zinc-400">https://riskmodels.app/api/mcp/sse</code> and Connect — sign in, no key needed. ChatGPT Plus: Developer mode under Apps &amp; Connectors. Grok:{' '}
+                      <code className="text-zinc-400">grok.com/connectors</code> → Custom. Gemini: CLI or Enterprise (consumer web uses REST only). Details in the{' '}
                       <Link href="/docs/agent-integration" className="text-terminal hover:underline">agent integration guide</Link>.
                     </p>
                   </div>

--- a/app/for-agents/page.tsx
+++ b/app/for-agents/page.tsx
@@ -41,7 +41,7 @@ const DISCOVERY: LinkCard[] = [
   {
     title: 'MCP server',
     href: '/.well-known/mcp.json',
-    desc: 'Streamable-HTTP MCP endpoint with discovery + live-data tools.',
+    desc: 'Streamable-HTTP MCP manifest — Claude/Cursor/Grok/ChatGPT connectors, or Gemini Enterprise admin setup.',
     icon: Plug,
   },
   {

--- a/content/docs/agent-integration.mdx
+++ b/content/docs/agent-integration.mdx
@@ -1,6 +1,6 @@
 ---
 title: Agent Integration
-description: Use RiskModels with Cursor, Claude Desktop, and other AI agents
+description: Use RiskModels with Cursor, Claude, ChatGPT, Grok, Gemini, and other AI agents
 ---
 
 # Agent Integration
@@ -14,21 +14,58 @@ Use the RiskModels API with your AI assistant of choice to perform quant researc
       <span className="text-xs font-semibold text-primary uppercase tracking-widest">Fastest — no terminal, use it in your AI chat</span>
     </div>
     <div className="px-5 pt-4 pb-2">
-      <span className="text-sm font-semibold text-zinc-100">Try it now (any chat: Claude, ChatGPT, Cursor)</span>
-      <p className="text-xs text-zinc-400 mt-1">Paste this into a fresh chat. The agent reads riskmodels.app, sets itself up for the conversation, and tells you what it can analyze. Nothing to install.</p>
+      <span className="text-sm font-semibold text-zinc-100">Try it now (this chat — no install)</span>
+      <p className="text-xs text-zinc-400 mt-1">Works in <strong className="font-normal text-zinc-300">ChatGPT, Claude, Cursor, Grok, Gemini (web)</strong>, or any model that can fetch URLs. The agent reads <code className="text-zinc-500">/llms.txt</code> and calls the REST API for this conversation only — not a persistent MCP connector.</p>
       <div className="flex items-center justify-between bg-zinc-950 border border-zinc-700 rounded-lg px-4 py-2.5 font-mono text-sm text-zinc-200 mt-2">
         <span>Visit riskmodels.app and set it up to use in this chat, then tell me what you can analyze.</span>
         <CopyInline value="Visit riskmodels.app and set it up to use in this chat, then tell me what you can analyze." />
       </div>
     </div>
     <div className="px-5 pb-4 pt-2">
-      <span className="text-sm font-semibold text-zinc-100">Keep it (Claude Desktop / Cursor, persistent — no terminal)</span>
+      <span className="text-sm font-semibold text-zinc-100">Keep it (Claude Desktop / Cursor — persistent MCP)</span>
       <p className="text-xs text-zinc-400 mt-1">Settings → Connectors → Add custom connector, paste the URL (leave OAuth fields blank), then Connect. You sign in at riskmodels.app and approve once — no API key to handle, billing on your account.</p>
       <div className="flex items-center justify-between bg-zinc-950 border border-zinc-700 rounded-lg px-4 py-2.5 font-mono text-sm text-zinc-200 mt-2">
         <span>https://riskmodels.app/api/mcp/sse</span>
         <CopyInline value="https://riskmodels.app/api/mcp/sse" />
       </div>
       <p className="text-xs text-zinc-600 mt-2">Prefer a terminal, or need Codex / VS Code? <code className="text-zinc-500">npx -y riskmodels@latest install</code> wires every client in one command.</p>
+    </div>
+    <div className="px-5 pb-4 pt-2 border-t border-primary/20">
+      <span className="text-sm font-semibold text-zinc-100">ChatGPT — persistent MCP (Developer Mode)</span>
+      <p className="text-xs text-zinc-400 mt-1">
+        ChatGPT does <strong className="font-normal text-zinc-300">not</strong> expose RiskModels through the built-in Finances / Schwab connector — that is a separate data source.
+        To add RiskModels as its own MCP app: <strong className="font-normal text-zinc-300">Settings → Apps &amp; Connectors → Advanced settings → enable Developer mode</strong>,
+        then <strong className="font-normal text-zinc-300">Apps &amp; Connectors → Create</strong>, paste the URL below, choose <strong className="font-normal text-zinc-300">OAuth</strong>, and sign in at riskmodels.app when prompted.
+        Requires ChatGPT Plus or above (web). Discovery manifest: <a href="/.well-known/mcp.json" className="text-primary hover:underline">/.well-known/mcp.json</a>.
+      </p>
+      <div className="flex items-center justify-between bg-zinc-950 border border-zinc-700 rounded-lg px-4 py-2.5 font-mono text-sm text-zinc-200 mt-2">
+        <span>https://riskmodels.app/api/mcp/sse</span>
+        <CopyInline value="https://riskmodels.app/api/mcp/sse" />
+      </div>
+      <p className="text-xs text-zinc-600 mt-2">
+        <strong className="font-normal text-zinc-500">Portfolio + Schwab in one chat?</strong> Keep Finances for holdings, then paste tickers/weights here and ask ChatGPT to call RiskModels REST (or use the in-chat prompt above). See <a href="#chatgpt-portfolio" className="text-primary hover:underline">ChatGPT + holdings ↓</a>.
+      </p>
+    </div>
+    <div className="px-5 pb-4 pt-2 border-t border-primary/20">
+      <span className="text-sm font-semibold text-zinc-100">Grok — persistent MCP (Connectors)</span>
+      <p className="text-xs text-zinc-400 mt-1">
+        Open <a href="https://grok.com/connectors" className="text-primary hover:underline">grok.com/connectors</a> → <strong className="font-normal text-zinc-300">New Connector → Custom</strong>, paste the URL below, and complete OAuth sign-in at riskmodels.app.
+        Grok discovers tools from the server automatically (Streamable HTTP). No Developer Mode toggle — the connector UI is public on Grok web, iOS, and Android.
+      </p>
+      <div className="flex items-center justify-between bg-zinc-950 border border-zinc-700 rounded-lg px-4 py-2.5 font-mono text-sm text-zinc-200 mt-2">
+        <span>https://riskmodels.app/api/mcp/sse</span>
+        <CopyInline value="https://riskmodels.app/api/mcp/sse" />
+      </div>
+      <p className="text-xs text-zinc-600 mt-2">Details: <a href="#grok-mcp" className="text-primary hover:underline">Grok setup ↓</a> · xAI docs: <a href="https://docs.x.ai/grok/connectors" className="text-primary hover:underline">Connectors</a></p>
+    </div>
+    <div className="px-5 pb-4 pt-2 border-t border-primary/20">
+      <span className="text-sm font-semibold text-zinc-100">Gemini — depends on surface</span>
+      <p className="text-xs text-zinc-400 mt-1">
+        <strong className="font-normal text-zinc-300">gemini.google.com (consumer chat):</strong> no custom MCP UI — use the in-chat prompt above (<code className="text-zinc-500">/llms.txt</code> + REST).
+        <strong className="font-normal text-zinc-300"> Gemini CLI / Antigravity:</strong> terminal MCP with OAuth (<code className="text-zinc-500">gemini mcp add …</code>).
+        <strong className="font-normal text-zinc-300"> Gemini Enterprise:</strong> admin registers this server as a Custom MCP data store in Google Cloud (Streamable HTTP + OAuth).
+      </p>
+      <p className="text-xs text-zinc-600 mt-2">Details: <a href="#gemini" className="text-primary hover:underline">Gemini setup ↓</a></p>
     </div>
   </div>
 
@@ -82,6 +119,20 @@ Use the RiskModels API with your AI assistant of choice to perform quant researc
           <p className="text-xs text-zinc-500 mt-0.5">Add the MCP server to your Zed assistant config. Zed auto-discovers available tools so you can query live risk data inline as you code. <a href="#mcp-setup" className="text-primary hover:underline">See MCP setup ↓</a></p>
         </div>
       </div>
+      <div className="flex items-center gap-4 px-5 py-4">
+        <img src="https://www.google.com/s2/favicons?domain=x.ai&sz=64" alt="Grok" width="28" height="28" className="rounded flex-shrink-0" />
+        <div>
+          <span className="text-sm font-semibold text-zinc-100">Grok</span>
+          <p className="text-xs text-zinc-500 mt-0.5">Add a custom MCP connector at grok.com/connectors — OAuth sign-in, no Developer Mode. <a href="#grok-mcp" className="text-primary hover:underline">See Grok setup ↓</a></p>
+        </div>
+      </div>
+      <div className="flex items-center gap-4 px-5 py-4">
+        <img src="https://www.google.com/s2/favicons?domain=gemini.google.com&sz=64" alt="Gemini" width="28" height="28" className="rounded flex-shrink-0" />
+        <div>
+          <span className="text-sm font-semibold text-zinc-100">Gemini</span>
+          <p className="text-xs text-zinc-500 mt-0.5">Consumer web chat: use <code className="text-zinc-400">/llms.txt</code> in-session. Persistent MCP: Gemini CLI or Gemini Enterprise admin setup. <a href="#gemini" className="text-primary hover:underline">See Gemini setup ↓</a></p>
+        </div>
+      </div>
     </div>
   </div>
 </div>
@@ -121,6 +172,66 @@ https://riskmodels.app/api/mcp/sse
 ```
 
 Leave the OAuth Client ID / Secret fields blank, click **Add**, then **Connect**. You'll sign in at riskmodels.app and approve access once (OAuth 2.0 + PKCE — the client registers itself); the tools then load and metered calls bill your account. Nothing to install, and no API key to copy or store.
+
+<h3 id="chatgpt-mcp">ChatGPT (Developer Mode)</h3>
+
+ChatGPT supports custom remote MCP servers, but the UI is hidden until **Developer mode** is on:
+
+1. **Settings → Apps & Connectors → Advanced settings** → enable **Developer mode** (Plus / Pro / Business / Enterprise / Edu; web only).
+2. **Apps & Connectors → Create** (button appears after step 1).
+3. **Connector URL:** `https://riskmodels.app/api/mcp/sse`
+4. Choose **OAuth** (not a static API key). Complete sign-in at riskmodels.app when prompted.
+5. Enable the tools you want (e.g. `riskmodels_decompose`, `riskmodels_get_lstar`, `riskmodels_analyze_portfolio`).
+
+Machine-readable discovery: [`/.well-known/mcp.json`](/.well-known/mcp.json) · OAuth metadata: [`/.well-known/oauth-protected-resource`](/.well-known/oauth-protected-resource).
+
+**Not the same as ChatGPT Finances.** The Schwab / Finances connector only sees brokerage holdings. RiskModels is a separate MCP app for factor decomposition and hedge ratios.
+
+<h3 id="chatgpt-portfolio">ChatGPT + brokerage holdings (Finances + RiskModels)</h3>
+
+When ChatGPT already has your Schwab book via **Finances**, you do not need RiskModels MCP in the same turn — combine sources in one chat:
+
+1. Ask ChatGPT to list your holdings (tickers + weights or dollar notionals from Finances).
+2. Paste: *"Use https://riskmodels.app/llms.txt to set up RiskModels REST for this chat, then analyze factor exposure and concentration for these holdings: …"*
+3. For a full ~3k-name book, get a personal key at [/get-key](/get-key) and paste it once (or use Developer Mode MCP above for persistent tools).
+
+Example tickers ChatGPT may already see: `VTI`, `GOOG`, `MS`, `AMZN`, `IEMG`, `NFLX`. RiskModels returns L1/L2/L3 explained risk and ETF hedge ratios per name; aggregate with `POST /api/portfolio/risk-snapshot` when you have weights.
+
+<h3 id="grok-mcp">Grok (Connectors)</h3>
+
+Grok ships a first-class **Bring Your Own MCP** flow — no hidden Developer Mode:
+
+1. Open [grok.com/connectors](https://grok.com/connectors).
+2. Click **New Connector → Custom**.
+3. **MCP server URL:** `https://riskmodels.app/api/mcp/sse`
+4. Complete OAuth sign-in at riskmodels.app when prompted.
+
+Grok discovers tools from the server and exposes them in chat alongside built-in connectors (Gmail, Drive, GitHub, etc.). The server must be reachable on the public internet (RiskModels hosted endpoint satisfies this). xAI docs: [Connectors](https://docs.x.ai/grok/connectors) · [Remote MCP tools](https://docs.x.ai/developers/tools/remote-mcp) (API/SDK path for developers).
+
+<h3 id="gemini">Gemini</h3>
+
+Google exposes **three different surfaces** — pick the one you actually use:
+
+**Consumer chat (`gemini.google.com`)** — no Settings → Connectors flow for custom MCP today. Use the in-chat prompt at the top of this page (`/llms.txt` + REST) for one-session analysis, or paste holdings and ask Gemini to call the API with a key from [/get-key](/get-key).
+
+**Gemini CLI / Antigravity (terminal)** — MCP lives in the CLI, not the consumer web app:
+
+```bash
+gemini mcp add --transport http riskmodels https://riskmodels.app/api/mcp/sse
+```
+
+Start a session and run `/mcp auth riskmodels` to complete OAuth in the browser. Alternatively add to `~/.gemini/settings.json` under `mcpServers` with `httpUrl` pointing at the URL above. Google is migrating free-tier CLI users toward **Antigravity** — the same Streamable HTTP URL and OAuth pattern apply there.
+
+**Gemini Enterprise (Google Cloud admin)** — register RiskModels as a **Custom MCP Server** data store in the Google Cloud console ([setup guide](https://cloud.google.com/gemini/enterprise/docs/connectors/custom-mcp-server/set-up-custom-mcp-server)). Requirements:
+
+| Field | RiskModels value |
+| --- | --- |
+| MCP Server URL | `https://riskmodels.app/api/mcp/sse` |
+| Authorization URL | `https://riskmodels.app/oauth/authorize` |
+| Token URL | `https://riskmodels.app/api/oauth/token` |
+| Scopes | `mcp:read` |
+
+Gemini Enterprise preview supports **Streamable HTTP only** (matches our endpoint). Unlike Claude/Cursor/Grok, Enterprise typically expects a **pre-registered OAuth client** (Client ID + Secret) rather than dynamic registration — register a client via `POST /api/oauth/register` or contact [support](/get-key) for a team OAuth app, then paste the credentials into the Cloud console. End users authorize the connector from the Gemini Enterprise chat UI after an admin attaches the data store.
 
 ### Hosted via the mcp-remote proxy (Bearer key)
 

--- a/lib/llms-txt.ts
+++ b/lib/llms-txt.ts
@@ -27,9 +27,13 @@ You are an AI assistant reading this because someone pointed you at riskmodels.a
 - For live data on the Magnificent 7, use the **Public sample API key** below (if present) as \`Authorization: Bearer …\`. If you can make HTTP POSTs, you may self-provision a free key: \`POST /api/auth/provision-free\`. For the full ~3,000-name universe, tell the human to grab a free key at https://riskmodels.app/get-key (browser, no terminal).
 - Make one real call to confirm the connection, then tell the human what you can analyze and ask what they want to look at. **Do not tell a human to open a terminal for this case.**
 
-**2. "Help me set it up" / "add this to my Claude/Cursor"** — they want RiskModels available permanently. You cannot edit their app's config yourself, so relay these steps (no terminal needed):
-- **Recommended — connect by URL (no terminal, no API key):** in Claude Desktop or Cursor, open **Settings → Connectors → Add custom connector**, paste \`https://riskmodels.app/api/mcp/sse\`, leave the OAuth Client ID / Secret fields blank, then click **Add → Connect**. They sign in at riskmodels.app (Google / GitHub / email) and approve access once (OAuth 2.0 + PKCE; the client registers itself); the tools load and metered calls bill their RiskModels account. No key to copy or store.
-- **Developer alternatives (terminal):** \`npm install -g riskmodels@latest\` then \`riskmodels install\` (auto-wires Claude Desktop, Cursor, Codex, VS Code), or the \`mcp-remote\` proxy — \`npx -y mcp-remote https://riskmodels.app/api/mcp/sse\` with env \`AUTHORIZATION=Bearer <their key>\` (key from https://riskmodels.app/get-key).
+**2. "Help me set it up" / "add this to my Claude/Cursor/ChatGPT/Grok/Gemini"** — they want RiskModels available permanently. You cannot edit their app's config yourself, so relay these steps:
+- **Claude Desktop / Cursor (recommended — no terminal, no API key):** **Settings → Connectors → Add custom connector**, paste \`https://riskmodels.app/api/mcp/sse\`, leave OAuth Client ID / Secret blank, **Add → Connect**. They sign in at riskmodels.app once (OAuth 2.0 + PKCE).
+- **ChatGPT (Plus+ on web — Developer Mode):** **Settings → Apps & Connectors → Advanced settings → enable Developer mode**, then **Apps & Connectors → Create**, paste \`https://riskmodels.app/api/mcp/sse\`, choose **OAuth**, sign in at riskmodels.app. This is **not** the built-in Finances / Schwab connector. Guide: \`https://riskmodels.app/docs/agent-integration#chatgpt-mcp\`.
+- **Grok (web / iOS / Android):** **grok.com/connectors → New Connector → Custom**, paste \`https://riskmodels.app/api/mcp/sse\`, OAuth sign-in at riskmodels.app. No Developer Mode. Guide: \`https://riskmodels.app/docs/agent-integration#grok-mcp\`.
+- **Gemini consumer web (gemini.google.com):** no custom MCP UI — use case 1 (\`/llms.txt\` + REST in this chat). **Gemini CLI / Antigravity:** \`gemini mcp add --transport http riskmodels https://riskmodels.app/api/mcp/sse\` then \`/mcp auth riskmodels\`. **Gemini Enterprise:** admin registers Custom MCP data store in Google Cloud (Streamable HTTP + OAuth; may need pre-registered Client ID/Secret). Guide: \`https://riskmodels.app/docs/agent-integration#gemini\`.
+- **ChatGPT + Schwab holdings without MCP:** If they already connected Finances, keep that for positions; paste tickers here and use case 1 (REST via this file) or \`POST /api/portfolio/risk-snapshot\` with weights.
+- **Developer alternatives (terminal):** \`npm install -g riskmodels@latest\` then \`riskmodels install\`, or \`npx -y mcp-remote https://riskmodels.app/api/mcp/sse\` with \`AUTHORIZATION=Bearer <key>\`.
 
 ## Magnificent 7 (MAG7)
 
@@ -64,8 +68,9 @@ MCP URL with \`mcp-remote\` and AUTHORIZATION=Bearer … (see Quickstart / MCP R
 
 ## Where to integrate without a local install
 
-- Hosted MCP (Streamable HTTP): https://riskmodels.app/api/mcp/sse — use with an MCP client and
-  Bearer token (or the no-key OAuth connector flow). The MCP endpoint authenticates every call (including initialize), so discovery tools cost nothing but still require a key or OAuth; data tools additionally bill per underlying REST route.
+- **MCP discovery manifest:** https://riskmodels.app/.well-known/mcp.json (public JSON — paste URL into Claude/Cursor/Grok/ChatGPT connectors, or Gemini Enterprise admin console)
+- **Agent integration guide:** https://riskmodels.app/docs/agent-integration (ChatGPT Developer Mode, Grok Connectors, Gemini CLI/Enterprise, Finances + holdings workflow)
+- Hosted MCP (Streamable HTTP): https://riskmodels.app/api/mcp/sse — Bearer token, OAuth connector (Claude/Cursor/ChatGPT), or \`mcp-remote\` proxy. The MCP endpoint authenticates every call (including initialize); data tools bill per underlying REST route.
 - OpenAPI: https://riskmodels.app/openapi (or /api-docs in the portal)
 - Python SDK (PyPI): riskmodels-py — see https://riskmodels.app/docs/python-sdk
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -128,6 +128,36 @@ claude mcp add --scope user --transport stdio riskmodels -- npx -y @riskmodels/m
 
 Restart **`claude`**, then run **`claude mcp list`** — `riskmodels` should show as connected. If it does not, use the **hosted** `mcp-remote` transport with `AUTHORIZATION=Bearer <key>` (same JSON pattern as in the “Hosted endpoint” section below).
 
+### ChatGPT (Developer Mode)
+
+ChatGPT supports custom remote MCP servers on **Plus / Pro / Business / Enterprise / Edu** (web). The UI is hidden until Developer mode is enabled:
+
+1. **Settings → Apps & Connectors → Advanced settings** → turn on **Developer mode**.
+2. **Apps & Connectors → Create**.
+3. **Connector URL:** `https://riskmodels.app/api/mcp/sse`
+4. Choose **OAuth** and complete sign-in at riskmodels.app when prompted.
+
+**Not the Finances connector.** ChatGPT’s Schwab / Finances integration only exposes brokerage holdings. RiskModels is a separate MCP app for factor decomposition and hedge ratios. To analyze a Schwab book without MCP, keep Finances for positions and paste tickers into a chat with `https://riskmodels.app/llms.txt` (REST for one session).
+
+Discovery manifest: `https://riskmodels.app/.well-known/mcp.json` · full guide: [Agent integration](https://riskmodels.app/docs/agent-integration#chatgpt-mcp).
+
+### Grok (Connectors)
+
+Grok supports custom MCP without a Developer Mode toggle:
+
+1. Open [grok.com/connectors](https://grok.com/connectors).
+2. **New Connector → Custom**.
+3. **MCP server URL:** `https://riskmodels.app/api/mcp/sse`
+4. Complete OAuth sign-in at riskmodels.app.
+
+Guide: [Agent integration — Grok](https://riskmodels.app/docs/agent-integration#grok-mcp) · xAI: [Connectors](https://docs.x.ai/grok/connectors).
+
+### Gemini
+
+- **Consumer web (`gemini.google.com`):** no custom MCP connector UI — use `https://riskmodels.app/llms.txt` in chat or REST with a key.
+- **Gemini CLI / Antigravity:** `gemini mcp add --transport http riskmodels https://riskmodels.app/api/mcp/sse`, then `/mcp auth riskmodels`.
+- **Gemini Enterprise:** admin registers a Custom MCP Server data store in Google Cloud (Streamable HTTP + OAuth). See [Agent integration — Gemini](https://riskmodels.app/docs/agent-integration#gemini).
+
 `@riskmodels/sdk` powers in-tool SDK calls inside `@riskmodels/mcp`; published builds use Node ESM with `.js` import specifiers so `npx -y @riskmodels/mcp` loads under Node 18+.
 
 ### Hosted endpoint (`https://riskmodels.app/api/mcp/sse`)


### PR DESCRIPTION
## Summary
- Document persistent MCP setup for ChatGPT (Developer Mode), Grok (Connectors), and Gemini (CLI + Enterprise; honest note that consumer gemini.google.com has no custom MCP UI).
- Clarify in-chat `/llms.txt` REST vs connector flows; extend `/.well-known/mcp.json` with `client_setup` hints for each client.
- Update `llms.txt` source, MCP README, `/for-agents`, and API reference onboarding copy.

## Test plan
- [ ] Merge and verify Vercel production deploy succeeds
- [ ] `curl -s https://riskmodels.app/.well-known/mcp.json | jq '.client_setup'`
- [ ] `/docs/agent-integration#chatgpt-mcp`, `#grok-mcp`, `#gemini` render correctly


Made with [Cursor](https://cursor.com)