### PR TITLE
fix(billing): unlimited internal allowance for first-party gateway traffic

### DIFF
--- a/lib/agent/billing-middleware.ts
+++ b/lib/agent/billing-middleware.ts
@@ -263,6 +263,8 @@ export interface BillingContext {
   apiKey?: string;
   tier?: "free" | "paid" | "enterprise";
   freeTierStatus?: any;
+  /** First-party gateway traffic — unlimited internal allowance (no 402/deduct). */
+  internalUnlimited?: boolean;
 }
 
 /**
@@ -421,6 +423,17 @@ export function withBilling(
           { status: 503 },
         );
       }
+
+      // First-party gateway traffic (our own portal via the service key) gets an
+      // UNLIMITED internal allowance — it must never 402 or route through Stripe.
+      // Applies when the trusted service key bills the anonymous gateway fallback
+      // user, or whenever RISKMODELS_GATEWAY_UNLIMITED=true (blanket exemption).
+      const gatewayBillingUid =
+        process.env.RISKMODELS_GATEWAY_BILLING_USER_ID?.trim();
+      const internalUnlimited =
+        isTrustedServiceGateway &&
+        (process.env.RISKMODELS_GATEWAY_UNLIMITED === "true" ||
+          (!!gatewayBillingUid && userId === gatewayBillingUid));
 
       if (!userId && extractedKey && !isTrustedServiceGateway) {
         const validation = await validateApiKey(extractedKey);
@@ -609,7 +622,7 @@ export function withBilling(
       // Early balance check — cheap read to give a fast 402 before running
       // the handler. The definitive atomic check happens at deduction time
       // below, so this is a best-effort short-circuit only.
-      if (costUsd > 0 && freeTierCheck?.tier !== "free") {
+      if (costUsd > 0 && freeTierCheck?.tier !== "free" && !internalUnlimited) {
         const currentBalance = await getUserBalance(userId);
         // Block if balance is negative (user is in debt) or insufficient
         if (currentBalance < 0 || currentBalance < costUsd) {
@@ -686,6 +699,7 @@ export function withBilling(
         apiKey,
         tier: freeTierCheck?.tier,
         freeTierStatus: freeTierCheck,
+        internalUnlimited,
       };
 
       // 5. Process the request
@@ -698,7 +712,7 @@ export function withBilling(
 
       // 6. Atomically deduct balance on success (only if cost > 0).
       //    The deduct_balance RPC uses FOR UPDATE — immune to race conditions.
-      if (costUsd > 0 && success) {
+      if (costUsd > 0 && success && !internalUnlimited) {
         try {
           await deductBalance(
             userId,
@@ -1005,8 +1019,8 @@ export async function finalizeBilling(
   const costUsd = actualCostUsd ?? context.costUsd;
   const success = res.status < 400;
 
-  // Deduct balance on success
-  if (costUsd > 0 && success) {
+  // Deduct balance on success (skip for first-party unlimited internal traffic)
+  if (costUsd > 0 && success && !context.internalUnlimited) {
     try {
       await deductBalance(
         context.userId,


### PR DESCRIPTION
## Problem
First-party gateway traffic — our own portal (riskmodels.net) calling the API via `RISKMODELS_API_SERVICE_KEY` — is metered against the anonymous gateway billing user (`RISKMODELS_GATEWAY_BILLING_USER_ID`). That account's balance drained during dev/QA, so live portal snapshots started returning **`402 INSUFFICIENT_BALANCE`** → `notFound()` → 404 pages. Internal traffic should never 402 or route through Stripe.

## Change
The trusted service key already bypasses rate-limiting; this extends the same exemption to **balance metering**. A new `internalUnlimited` flag skips:
- the early balance / 402 check, and
- **both** deduct paths (the synchronous main flow **and** the finalize-billing helper).

**Scope (safe by default):**
- Exempt when the trusted service key is used **and** we're billing the anonymous gateway fallback user (`RISKMODELS_GATEWAY_BILLING_USER_ID`) — i.e. exactly the demo/portal traffic that's failing.
- Blanket exemption via env **`RISKMODELS_GATEWAY_UNLIMITED=true`**.
- **Real signed-in end-users** (forwarding their JWT through the portal) still meter against their own account — customer billing is unaffected.

## Files
- `lib/agent/billing-middleware.ts` — `internalUnlimited` flag on `BillingContext`; guards on the balance check + both `deductBalance` calls.

## Test
- `tsc --noEmit` clean.
- After deploy: portal snapshots (e.g. `/manager-skill` Berkshire) no longer 402; `X-API-Cost-USD` stays 0 for gateway calls; real API-key/JWT users still metered.

## Deploy note
Takes effect once deployed to riskmodels.app. Optionally set `RISKMODELS_GATEWAY_UNLIMITED=true` in the API env for the blanket exemption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)