### PR TITLE
feat(openbb): RiskModels Analyst AI agent (agents.json + query SSE)

### DIFF
--- a/app/openbb/README.md
+++ b/app/openbb/README.md
@@ -44,7 +44,8 @@ curl "http://localhost:3000/openbb/widgets/metrics?ticker=AAPL" \
 | `GET /openbb` | Backend info | ✅ |
 | `GET /openbb/widgets.json` | Widget defs | ✅ |
 | `GET /openbb/apps.json` | App defs | ✅ |
-| `GET /openbb/agents.json` | Agent defs (empty stub until MCP wired) | ✅ |
+| `GET /openbb/agents.json` | AI agent discovery — registers **RiskModels Analyst** | ✅ live |
+| `POST /openbb/query` | AI agent endpoint (SSE) — proxies to `/api/chat` (Claude + risk tools) | ✅ live |
 | `GET /openbb/prompts.json` | Prompt defs (empty stub) | ✅ |
 | `GET /openbb/widgets/metrics?ticker=` | Single-name risk table | ✅ live |
 | `GET /openbb/widgets/snapshot-table?ticker=` | Risk snapshot as a table (L3 decomposition + hedge ratios) | ✅ live |
@@ -73,4 +74,19 @@ skipped (POST-only upstream; OpenBB widgets fetch via GET).
 - **Apps** → fill out the three-app set in `apps.json`
   (Single-Name Risk · Portfolio Risk & Hedge · Screener)
 
-Then register the published npm `riskmodels` MCP server as a Workspace AI agent.
+## AI agent (RiskModels Analyst)
+
+`agents.json` registers one agent; `POST /openbb/query` is its endpoint. It's a
+thin adapter — it maps OpenBB's `QueryRequest` messages to our chat format and
+proxies to `POST /api/chat` (Claude + the RiskModels tool suite), forwarding the
+OpenBB user's `X-API-KEY` as a Bearer token, then streams the answer as
+`copilotMessageChunk` SSE. Auth, billing, entitlements, and the analyst doctrine
+are reused from `/api/chat` unchanged.
+
+**Add it in OpenBB:** copilot icon → **+** → base URL `https://riskmodels.app/openbb`
+(Workspace fetches `agents.json`, uses `/openbb/query` for chat).
+
+Follow-ups: token-level streaming (today it streams the final answer after the
+tool loop, with status heartbeats to hold the SSE open); surface tool calls as
+`copilotStatusUpdate` / citations; use `widgets`/`context` from the request so
+the agent can read the current dashboard.

--- a/app/openbb/_lib/cors.ts
+++ b/app/openbb/_lib/cors.ts
@@ -50,7 +50,7 @@ export function openbbCors(
 
   return {
     "Access-Control-Allow-Origin": origin,
-    "Access-Control-Allow-Methods": "GET, OPTIONS",
+    "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
     "Access-Control-Allow-Headers": requestedHeaders || DEFAULT_ALLOW_HEADERS,
     "Access-Control-Allow-Credentials": "true",
     "Access-Control-Max-Age": "86400",

--- a/app/openbb/agents.json/route.ts
+++ b/app/openbb/agents.json/route.ts
@@ -1,9 +1,13 @@
 /**
- * agents.json — empty stub for OpenBB unified "Connect backend" probes.
+ * agents.json — OpenBB Workspace AI agent discovery.
  *
- * Data-only backends have no custom agent yet (E.21 follow-up: npm riskmodels
- * MCP). Returning {} avoids 404 HTML during connect-test; agents are added
- * separately when wired.
+ * Registers the RiskModels Analyst: an OpenBB-protocol copilot agent whose
+ * `/query` endpoint (POST → SSE) proxies to our existing tool-calling chat
+ * agent (`/api/chat`, Claude + the RiskModels risk tools). Per-user key
+ * passthrough — same `X-API-KEY` the backend connection carries.
+ *
+ * The query URL is derived from the request host so it works whether reached at
+ * `riskmodels.app/openbb` or a future `openbb.riskmodels.app` rewrite.
  */
 import { NextRequest, NextResponse } from "next/server";
 import { openbbCors } from "../_lib/cors";
@@ -11,7 +15,21 @@ import { openbbCors } from "../_lib/cors";
 export const dynamic = "force-dynamic";
 
 export async function GET(req: NextRequest) {
-  return NextResponse.json({}, { headers: openbbCors(req) });
+  const u = new URL(req.url);
+  const queryUrl = `${u.protocol}//${u.host}/openbb/query`;
+
+  const agents = {
+    "riskmodels-analyst": {
+      name: "RiskModels Analyst",
+      description:
+        "Institutional risk analyst — hedge layering, L1/L2/L3 factor decomposition, cross-sectional rankings, residual signal, and portfolio hedging across US equities and ETFs. Answers with real RiskModels data and shows the tools it used.",
+      image: `${u.protocol}//${u.host}/logo.png`,
+      endpoints: { query: queryUrl },
+      features: { streaming: true },
+    },
+  };
+
+  return NextResponse.json(agents, { headers: openbbCors(req) });
 }
 
 export async function OPTIONS(req: NextRequest) {

--- a/app/openbb/query/route.ts
+++ b/app/openbb/query/route.ts
@@ -1,0 +1,161 @@
+/**
+ * POST /openbb/query — OpenBB Workspace AI agent endpoint (SSE).
+ *
+ * Implements OpenBB's custom-agent protocol: takes a `QueryRequest`
+ * ({ messages: [{ role: "human"|"ai"|"tool", content }], ... }) and streams the
+ * answer back as Server-Sent Events (`event: copilotMessageChunk` /
+ * `data: {"delta": ...}`).
+ *
+ * Thin adapter: it maps OpenBB's messages to our chat format and proxies to the
+ * existing tool-calling analyst (`POST /api/chat`, Claude + RiskModels tools),
+ * forwarding the OpenBB user's `X-API-KEY` as a Bearer token so auth, billing,
+ * entitlements, and the institutional analyst doctrine are all reused unchanged.
+ */
+import { NextRequest } from "next/server";
+import { openbbCors } from "../_lib/cors";
+import { bearerFromRequest, upstreamBase } from "../_lib/upstream";
+
+export const dynamic = "force-dynamic";
+// Claude + a few tool rounds can run 10–40s; keep the function alive.
+export const maxDuration = 120;
+
+// Analyst model. /api/chat defaults to gpt-4o-mini unless AGENT_BACKEND=claude,
+// so we pass Claude explicitly (ANTHROPIC_API_KEY is configured).
+const ANALYST_MODEL = "claude-sonnet-4-6";
+
+type InboundMessage = { role?: string; content?: unknown };
+type ChatMessage = { role: "user" | "assistant"; content: string };
+
+function sse(event: string, data: unknown): string {
+  return `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+/** OpenBB roles: human→user, ai→assistant. Tool / function-call messages (non-string content) are skipped. */
+function mapMessages(raw: unknown): ChatMessage[] {
+  if (!Array.isArray(raw)) return [];
+  const out: ChatMessage[] = [];
+  for (const m of raw as InboundMessage[]) {
+    const content = m?.content;
+    if (typeof content !== "string" || !content.trim()) continue;
+    if (m.role === "human") out.push({ role: "user", content });
+    else if (m.role === "ai") out.push({ role: "assistant", content });
+  }
+  return out;
+}
+
+/** Split into sentence/line-ish chunks so the answer renders progressively. */
+function chunkText(text: string): string[] {
+  const parts = text.match(/[^\n]*\n|[^.!?]*[.!?]+\s*|[^.!?]+$/g);
+  return parts && parts.length ? parts.filter((p) => p.length > 0) : [text];
+}
+
+export async function POST(req: NextRequest) {
+  const cors = openbbCors(req);
+  const key = bearerFromRequest(req);
+
+  let body: { messages?: unknown } = {};
+  try {
+    body = await req.json();
+  } catch {
+    /* empty / invalid body → handled below */
+  }
+  const messages = mapMessages(body?.messages);
+
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      const send = (event: string, data: unknown) => {
+        try {
+          controller.enqueue(encoder.encode(sse(event, data)));
+        } catch {
+          /* stream already closed */
+        }
+      };
+      const say = (delta: string) => send("copilotMessageChunk", { delta });
+
+      if (!messages.length) {
+        say(
+          'Ask me about a name\'s risk — e.g. "What\'s driving AAPL\'s risk and how would I hedge it?"',
+        );
+        controller.close();
+        return;
+      }
+      if (!key) {
+        say(
+          "To use the RiskModels analyst, add your API key in **OpenBB → Connections → RiskModels** as header `X-API-KEY: rm_agent_live_…` (get a free key at riskmodels.app).",
+        );
+        controller.close();
+        return;
+      }
+
+      // Flush an early status so OpenBB starts the stream, then heartbeat while
+      // the (blocking) tool-calling agent runs so the SSE doesn't idle-timeout.
+      send("copilotStatusUpdate", {
+        eventType: "INFO",
+        message: "Analyzing with RiskModels…",
+        group: "reasoning",
+        hidden: false,
+      });
+      const heartbeat = setInterval(() => {
+        send("copilotStatusUpdate", {
+          eventType: "INFO",
+          message: "Working…",
+          group: "reasoning",
+          hidden: true,
+        });
+      }, 5000);
+
+      try {
+        const res = await fetch(`${upstreamBase()}/chat`, {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${key}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ messages, model: ANALYST_MODEL }),
+        });
+        clearInterval(heartbeat);
+
+        const json = (await res.json().catch(() => ({}))) as {
+          message?: { content?: string };
+          error?: string;
+          message_text?: string;
+        };
+        if (!res.ok) {
+          const err =
+            (json as { message?: string })?.message ||
+            json?.error ||
+            "Sorry — the analyst is unavailable right now. Please try again.";
+          say(typeof err === "string" ? err : "Sorry — the analyst is unavailable.");
+          controller.close();
+          return;
+        }
+
+        const content = json?.message?.content;
+        if (typeof content === "string" && content.trim()) {
+          for (const c of chunkText(content)) say(c);
+        } else {
+          say("I couldn't find an answer for that. Try naming a specific US ticker.");
+        }
+      } catch {
+        clearInterval(heartbeat);
+        say("Sorry — the analyst hit an error. Please try again.");
+      }
+      controller.close();
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      ...cors,
+      "Content-Type": "text/event-stream; charset=utf-8",
+      "Cache-Control": "no-cache, no-transform",
+      Connection: "keep-alive",
+      "X-Accel-Buffering": "no",
+    },
+  });
+}
+
+export async function OPTIONS(req: NextRequest) {
+  return new Response(null, { status: 204, headers: openbbCors(req) });
+}


### PR DESCRIPTION
Registers a **Workspace AI agent** — the last major open E.21 step.

- `agents.json` advertises **RiskModels Analyst** (name/description/image/`endpoints.query`/features).
- `POST /openbb/query` implements OpenBB's custom-agent protocol: parse `QueryRequest` messages (human→user, ai→assistant) → proxy to the existing tool-calling analyst (`POST /api/chat`, Claude + RiskModels tools) with the user's `X-API-KEY` forwarded as Bearer → stream the answer as `copilotMessageChunk` SSE (`data: {"delta"}`).
- Reuses `/api/chat`'s auth, billing, entitlements, and analyst doctrine unchanged (that inactive route is now the agent backend). Status heartbeats hold the SSE open during the batch tool loop; `maxDuration=120`. CORS now allows POST.
- Contract (agents.json schema, QueryRequest, SSE event/data) taken from the **openbb-ai SDK source**, not guessed.

**Add in OpenBB:** copilot → **+** → base URL `https://riskmodels.app/openbb`.

Follow-ups: token-level streaming, tool-call status/citations, dashboard-context awareness. Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)