### PR TITLE
feat(openbb): polish — %-labelled snapshot rows + analyst tool summary

### DIFF
--- a/app/openbb/query/route.ts
+++ b/app/openbb/query/route.ts
@@ -23,6 +23,23 @@ export const maxDuration = 120;
 // so we pass Claude explicitly (ANTHROPIC_API_KEY is configured).
 const ANALYST_MODEL = "claude-sonnet-4-6";
 
+// Friendly labels for the tools the analyst actually called (from
+// tool_calls_summary) — surfaced to the user as a "Consulted:" status.
+const TOOL_LABELS: Record<string, string> = {
+  search_tickers: "ticker search",
+  get_risk_metrics: "risk metrics",
+  get_correlation: "correlation",
+  get_rankings: "rankings",
+  get_l3_decomposition: "L3 decomposition",
+  get_residual_signal: "residual signal",
+  hedge_basket: "hedge basket",
+  get_fund_holdings: "fund holdings",
+  get_filer_holdings: "13F filer holdings",
+  factor_correlation: "factor correlation",
+  macro_factors: "macro factors",
+  render_artifact: "chart render",
+};
+
 type InboundMessage = { role?: string; content?: unknown };
 type ChatMessage = { role: "user" | "assistant"; content: string };
 
@@ -119,7 +136,7 @@ export async function POST(req: NextRequest) {
         const json = (await res.json().catch(() => ({}))) as {
           message?: { content?: string };
           error?: string;
-          message_text?: string;
+          tool_calls_summary?: Array<{ tool?: string }> | null;
         };
         if (!res.ok) {
           const err =
@@ -129,6 +146,26 @@ export async function POST(req: NextRequest) {
           say(typeof err === "string" ? err : "Sorry — the analyst is unavailable.");
           controller.close();
           return;
+        }
+
+        // Surface the real tools the analyst consulted (honest, from the run).
+        const tools = json?.tool_calls_summary;
+        if (Array.isArray(tools) && tools.length) {
+          const labels = [
+            ...new Set(
+              tools
+                .map((t) => (t?.tool ? TOOL_LABELS[t.tool] ?? t.tool : null))
+                .filter((x): x is string => !!x),
+            ),
+          ];
+          if (labels.length) {
+            send("copilotStatusUpdate", {
+              eventType: "INFO",
+              message: `Consulted: ${labels.join(", ")}`,
+              group: "reasoning",
+              hidden: false,
+            });
+          }
         }
 
         const content = json?.message?.content;

--- a/app/openbb/widgets/snapshot-table/route.ts
+++ b/app/openbb/widgets/snapshot-table/route.ts
@@ -67,16 +67,19 @@ export async function GET(req: NextRequest) {
       ? null
       : Number(m.l3_mkt_er ?? 0) + Number(m.l3_sec_er ?? 0) + Number(m.l3_sub_er ?? 0);
 
+  // Units live in the metric label — OpenBB's grid strips trailing %/$ from
+  // numeric-looking values, so "24.1%" renders as "24.1". Labelling the unit
+  // keeps it unambiguous regardless.
   const rows: Row[] = [
     { metric: "Ticker", value: d.ticker ?? ticker },
     { metric: "As of", value: d._data_health?.data_as_of ?? d.teo ?? "—" },
-    { metric: "Price (close)", value: money(m.price_close) },
-    { metric: "L3 explained risk — Market", value: pct1(m.l3_mkt_er) },
-    { metric: "L3 explained risk — Sector", value: pct1(m.l3_sec_er) },
-    { metric: "L3 explained risk — Subsector", value: pct1(m.l3_sub_er) },
-    { metric: "L3 explained risk — Residual (stock-specific)", value: pct1(m.l3_res_er) },
-    { metric: "Systematic (market + sector + subsector)", value: pct1(systematic) },
-    { metric: "Volatility — 252d (annualised)", value: num(m.vol_252d_ann) },
+    { metric: "Price — last close (USD)", value: money(m.price_close) },
+    { metric: "L3 explained risk — Market (%)", value: pct1(m.l3_mkt_er) },
+    { metric: "L3 explained risk — Sector (%)", value: pct1(m.l3_sec_er) },
+    { metric: "L3 explained risk — Subsector (%)", value: pct1(m.l3_sub_er) },
+    { metric: "L3 explained risk — Residual / stock-specific (%)", value: pct1(m.l3_res_er) },
+    { metric: "Systematic — market+sector+subsector (%)", value: pct1(systematic) },
+    { metric: "Volatility — 252d annualised (%)", value: pct1(m.vol_252d_ann) },
     { metric: "Recommended hedge level", value: String(m.recommended_hedge_level ?? "—") },
     { metric: "Lstar residual level", value: String(m.lstar_level ?? "—") },
     { metric: "L3 hedge ratio — Market", value: num(m.l3_mkt_hr) },


### PR DESCRIPTION
Two 'polish what's live' wins:

1. **Snapshot table units** — OpenBB's grid strips trailing `%`/`$` from numeric-looking values (`24.1%`→`24.1`). Units now live in the metric label (`L3 explained risk — Market (%)`, `Price — last close (USD)`, `Volatility — 252d annualised (%)`) so every value reads unambiguously. Vol shown as % for consistency.
2. **Analyst tool transparency** — the agent's SSE now emits a visible `copilotStatusUpdate` listing the *real* tools it consulted (from `/api/chat`'s `tool_calls_summary`) — "Consulted: risk metrics, L3 decomposition" — instead of a generic "Working…". Preserves `/api/chat`'s full billing + enforcement (kept the self-call boundary).

Follow-up (noted): true token-by-token streaming + during-call tool status needs an inline streaming refactor — deferred to avoid bypassing `withBilling`'s pre-flight balance/cap enforcement. Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)