### PR TITLE
feat(openbb): agent runs as free MAG7 demo (OpenBB can't forward keys)

### DIFF
--- a/app/openbb/agents.json/route.ts
+++ b/app/openbb/agents.json/route.ts
@@ -22,7 +22,7 @@ export async function GET(req: NextRequest) {
     "riskmodels-analyst": {
       name: "RiskModels Analyst",
       description:
-        "Institutional risk analyst — hedge layering, L1/L2/L3 factor decomposition, cross-sectional rankings, residual signal, and portfolio hedging across US equities and ETFs. Answers with real RiskModels data and shows the tools it used.",
+        "Free demo of the RiskModels institutional analyst — L1/L2/L3 factor decomposition, hedge layering, and residual signal for the Magnificent 7 (AAPL, MSFT, GOOGL, AMZN, NVDA, META, TSLA), with real RiskModels data. Get a key at riskmodels.app for the full US universe + portfolio hedging.",
       image: `${u.protocol}//${u.host}/logo.png`,
       endpoints: { query: queryUrl },
       features: { streaming: true },

--- a/app/openbb/query/route.ts
+++ b/app/openbb/query/route.ts
@@ -97,13 +97,11 @@ export async function POST(req: NextRequest) {
         controller.close();
         return;
       }
-      if (!key) {
-        say(
-          "To use the RiskModels analyst, add your API key in **OpenBB → Connections → RiskModels** as header `X-API-KEY: rm_agent_live_…` (get a free key at riskmodels.app).",
-        );
-        controller.close();
-        return;
-      }
+      // OpenBB never forwards the user's key to the copilot agent (its
+      // QueryRequest.api_keys is OpenAI-only), so the agent runs as a free MAG7
+      // demo (keyless, rate-limited) via /api/landing/chat. A key — only present
+      // for direct API callers — unlocks the full universe via /api/chat.
+      const isDemo = !key;
 
       // Flush an early status so OpenBB starts the stream, then heartbeat while
       // the (blocking) tool-calling agent runs so the SSE doesn't idle-timeout.
@@ -123,14 +121,19 @@ export async function POST(req: NextRequest) {
       }, 5000);
 
       try {
-        const res = await fetch(`${upstreamBase()}/chat`, {
-          method: "POST",
-          headers: {
-            Authorization: `Bearer ${key}`,
-            "Content-Type": "application/json",
+        const res = await fetch(
+          `${upstreamBase()}${isDemo ? "/landing/chat" : "/chat"}`,
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              ...(isDemo ? {} : { Authorization: `Bearer ${key}` }),
+            },
+            body: JSON.stringify(
+              isDemo ? { messages } : { messages, model: ANALYST_MODEL },
+            ),
           },
-          body: JSON.stringify({ messages, model: ANALYST_MODEL }),
-        });
+        );
         clearInterval(heartbeat);
 
         const json = (await res.json().catch(() => ({}))) as {
@@ -171,8 +174,17 @@ export async function POST(req: NextRequest) {
         const content = json?.message?.content;
         if (typeof content === "string" && content.trim()) {
           for (const c of chunkText(content)) say(c);
+          if (isDemo) {
+            say(
+              "\n\n— *Free demo · Magnificent 7 only. Get a key at riskmodels.app for the full US universe + portfolio hedging.*",
+            );
+          }
         } else {
-          say("I couldn't find an answer for that. Try naming a specific US ticker.");
+          say(
+            isDemo
+              ? "This free demo covers the Magnificent 7 — AAPL, MSFT, GOOGL, AMZN, NVDA, META, TSLA. For any US ticker plus portfolio hedging, get a key at riskmodels.app."
+              : "I couldn't find an answer for that. Try naming a specific US ticker.",
+          );
         }
       } catch {
         clearInterval(heartbeat);


### PR DESCRIPTION
OpenBB doesn't forward the backend connection's `X-API-KEY` to the copilot agent — `QueryRequest.api_keys` is OpenAI-only (confirmed in the openbb-ai SDK) — so the agent couldn't bill the end user and returned "add your key" for every question (incl. NVDA).

Per CEO decision: back the agent with the existing **keyless MAG7 demo**.
- No key (always, via OpenBB) → `POST /api/landing/chat` (Magnificent 7 only, rate-limited, no billing).
- A key (direct API callers only) → `/api/chat` (full universe).
- Demo answers append an upgrade CTA; non-MAG7 tickers get a "get a key for the full universe" nudge; `agents.json` description sets demo expectations.

Cost-controlled GTM funnel: a free institutional analyst for the MAG7 inside OpenBB that converts to riskmodels.app keys. Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)