### PR TITLE
fix(landing): switch keyless demo to Claude (OpenAI out of quota)

### DIFF
--- a/app/api/landing/chat/route.ts
+++ b/app/api/landing/chat/route.ts
@@ -42,7 +42,9 @@ const ALLOWED_TOOLS = [
   "get_rankings",
 ] as const;
 
-const LANDING_MODEL = "gpt-4o-mini";
+// Claude, not gpt-4o-mini: the OpenAI account is out of quota, and Claude is a
+// quality upgrade for the demo. runChatAgent dispatches claude-* → Anthropic.
+const LANDING_MODEL = "claude-sonnet-4-6";
 const LANDING_MAX_ROUNDS = 2;
 const LANDING_MAX_TOKENS = 700;
 const MAX_MSGS_PER_HOUR = 10;
@@ -108,11 +110,11 @@ export async function POST(request: NextRequest) {
   const origin = request.headers.get("origin");
   const corsHeaders = getCorsHeaders(origin);
 
-  if (!process.env.OPENAI_API_KEY) {
+  if (!process.env.ANTHROPIC_API_KEY) {
     return NextResponse.json(
       {
         error: "Service unavailable",
-        message: "AI chat demo is not configured (missing OPENAI_API_KEY).",
+        message: "AI chat demo is not configured (missing ANTHROPIC_API_KEY).",
       },
       { status: 503, headers: corsHeaders },
     );


### PR DESCRIPTION
`/api/landing/chat` (keyless MAG7 demo — backs both the `.net` landing page and the new OpenBB copilot agent) was hardcoded to `gpt-4o-mini` and returning OpenAI 429 "exceeded your current quota". Switch to `claude-sonnet-4-6` (Anthropic key has quota; quality upgrade). Rate limit / MAG7 guard / tool allowlist unchanged. Also unblocks the `.net` landing demo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)