### PR TITLE
feat(chat): pluggable LLM backend — Moonshot/Kimi (cheaper) via one env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,6 +60,17 @@ STRIPE_SECRET_KEY=sk_live_...   # or sk_test_... for dev
 # "not configured yet" message.
 OPENAI_API_KEY=sk-...
 
+# --- Chat LLM backend selection (resolveAgentBackend) ---
+# Priority: explicit claude-* model → Anthropic; else MOONSHOT_API_KEY → Moonshot
+# (Kimi, OpenAI-compatible, cheaper); else AGENT_BACKEND=claude → Claude; else OpenAI.
+# Setting MOONSHOT_API_KEY points BOTH /api/chat and /api/landing/chat at Moonshot.
+# End-user billing is unchanged (priced per RiskModels capability, not per model).
+# MOONSHOT_API_KEY=sk-...
+# MOONSHOT_MODEL=kimi-k2-0711-preview
+# MOONSHOT_BASE_URL=https://api.moonshot.ai/v1
+# ANTHROPIC_API_KEY=sk-ant-...    # (in Doppler) — claude-* models
+# AGENT_BACKEND=claude            # optional: force Claude default when no Moonshot key
+
 # --- Analyst doctrine (institutional prompt middle + tail; SSOT in BWMACRO chat_doctrine/) ---
 # Without these, chat uses a minimal operational stub until deploy wires full doctrine.
 # ANALYST_SYSTEM_PROMPT_APPEND='<paste markdown with {{TOOLS_AND_PERFORMANCE}} placeholder>'

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -4,26 +4,16 @@ import { calculateRequestCost } from "@/lib/agent/capabilities";
 import { getCorsHeaders } from "@/lib/cors";
 import { ChatPostSchema } from "@/lib/api/schemas";
 import { runChatAgent, AgentUpstreamError } from "@/lib/chat/agent-runner";
+import { resolveAgentBackend, hasChatBackend } from "@/lib/chat/llm-backend";
 import { getRiskMetadata } from "@/lib/dal/risk-metadata";
 import { addMetadataHeaders, buildMetadataBody } from "@/lib/dal/response-headers";
 import type { ToolCallResult } from "@/lib/chat/tool-executor";
 
 export const dynamic = "force-dynamic";
 
-/**
- * Default model when the request omits `model`. Flips with the AGENT_BACKEND
- * env flag (Doppler): `claude` → `claude-sonnet-4-6`; anything else (incl.
- * unset) → `gpt-4o-mini`, today's behavior. A request-supplied `model:`
- * always wins over this default (see `const model = modelOpt?.trim() || ...`).
- *
- * Phase 2A note: the trial surface on `.net` /activation passes
- * `model: "claude-sonnet-4-6"` explicitly, so it doesn't depend on this flag.
- * Flip AGENT_BACKEND only when you want *all* default chat traffic on Claude.
- */
-const DEFAULT_MODEL =
-  process.env.AGENT_BACKEND?.toLowerCase() === "claude"
-    ? "claude-sonnet-4-6"
-    : "gpt-4o-mini";
+// Backend (model + client) is resolved per-request by resolveAgentBackend():
+// Moonshot/Kimi when MOONSHOT_API_KEY is set, else Claude (AGENT_BACKEND=claude)
+// or OpenAI. A request-supplied claude-* `model:` always forces Anthropic.
 const MAX_TOOL_ROUNDS = 5;
 
 /** A rendered artifact surfaced to the chat UI for inline display. */
@@ -106,12 +96,12 @@ export const POST = withBilling(
     // At least one backend must be configured. The runner picks per-request
     // based on the resolved model (claude-* → Anthropic, else OpenAI), so we
     // only hard-fail here if neither key is present.
-    if (!process.env.OPENAI_API_KEY && !process.env.ANTHROPIC_API_KEY) {
+    if (!hasChatBackend()) {
       return NextResponse.json(
         {
           error: "Service unavailable",
           message:
-            "AI chat is not configured (need OPENAI_API_KEY or ANTHROPIC_API_KEY)",
+            "AI chat is not configured (need MOONSHOT_API_KEY, ANTHROPIC_API_KEY, or OPENAI_API_KEY)",
         },
         { status: 503, headers: getCorsHeaders(origin) },
       );
@@ -144,7 +134,7 @@ export const POST = withBilling(
       parallel_tool_calls: bodyParallelToolCalls,
       execute_tools_sequentially: bodyExecSequential,
     } = validation.data;
-    const model = modelOpt?.trim() || DEFAULT_MODEL;
+    const backend = resolveAgentBackend(modelOpt);
 
     const llmEst = calculateRequestCost(
       "chat-risk-analyst",
@@ -168,11 +158,13 @@ export const POST = withBilling(
     try {
       runResult = await runChatAgent({
         userMessages,
-        model,
+        model: backend.model,
+        openai: backend.openai,
         userId: context.userId,
         requestId: context.requestId,
         maxToolRounds: MAX_TOOL_ROUNDS,
-        allowParallelOpenAI: bodyParallelToolCalls !== false,
+        allowParallelOpenAI: backend.allowParallel && bodyParallelToolCalls !== false,
+        omitParallelToolCalls: backend.omitParallelToolCalls,
         execParallel: !bodyExecSequential,
       });
     } catch (e) {

--- a/app/api/landing/chat/route.ts
+++ b/app/api/landing/chat/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { getCorsHeaders } from "@/lib/cors";
 import { ChatPostSchema } from "@/lib/api/schemas";
 import { runChatAgent, AgentUpstreamError } from "@/lib/chat/agent-runner";
+import { resolveAgentBackend, hasChatBackend } from "@/lib/chat/llm-backend";
 
 /**
  * POST /api/landing/chat — unauthenticated MAG7-only preview of the
@@ -42,9 +43,8 @@ const ALLOWED_TOOLS = [
   "get_rankings",
 ] as const;
 
-// Claude, not gpt-4o-mini: the OpenAI account is out of quota, and Claude is a
-// quality upgrade for the demo. runChatAgent dispatches claude-* → Anthropic.
-const LANDING_MODEL = "claude-sonnet-4-6";
+// Model + client come from resolveAgentBackend() (Moonshot/Kimi when
+// MOONSHOT_API_KEY is set, else Claude/OpenAI) — shared with /api/chat.
 const LANDING_MAX_ROUNDS = 2;
 const LANDING_MAX_TOKENS = 700;
 const MAX_MSGS_PER_HOUR = 10;
@@ -110,11 +110,12 @@ export async function POST(request: NextRequest) {
   const origin = request.headers.get("origin");
   const corsHeaders = getCorsHeaders(origin);
 
-  if (!process.env.ANTHROPIC_API_KEY) {
+  if (!hasChatBackend()) {
     return NextResponse.json(
       {
         error: "Service unavailable",
-        message: "AI chat demo is not configured (missing ANTHROPIC_API_KEY).",
+        message:
+          "AI chat demo is not configured (need MOONSHOT_API_KEY, ANTHROPIC_API_KEY, or OPENAI_API_KEY).",
       },
       { status: 503, headers: corsHeaders },
     );
@@ -167,11 +168,14 @@ export async function POST(request: NextRequest) {
   const fetchStart = performance.now();
   const requestId = `landing_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
 
+  const backend = resolveAgentBackend();
+
   let runResult;
   try {
     runResult = await runChatAgent({
       userMessages,
-      model: LANDING_MODEL,
+      model: backend.model,
+      openai: backend.openai,
       userId: "landing-demo",
       requestId,
       maxToolRounds: LANDING_MAX_ROUNDS,
@@ -180,6 +184,8 @@ export async function POST(request: NextRequest) {
       skipBilling: true,
       preFlightGuard: mag7Guard,
       execParallel: true,
+      allowParallelOpenAI: backend.allowParallel,
+      omitParallelToolCalls: backend.omitParallelToolCalls,
     });
   } catch (e) {
     if (e instanceof AgentUpstreamError) {

--- a/app/openbb/query/route.ts
+++ b/app/openbb/query/route.ts
@@ -19,10 +19,6 @@ export const dynamic = "force-dynamic";
 // Claude + a few tool rounds can run 10–40s; keep the function alive.
 export const maxDuration = 120;
 
-// Analyst model. /api/chat defaults to gpt-4o-mini unless AGENT_BACKEND=claude,
-// so we pass Claude explicitly (ANTHROPIC_API_KEY is configured).
-const ANALYST_MODEL = "claude-sonnet-4-6";
-
 // Friendly labels for the tools the analyst actually called (from
 // tool_calls_summary) — surfaced to the user as a "Consulted:" status.
 const TOOL_LABELS: Record<string, string> = {
@@ -129,9 +125,9 @@ export async function POST(req: NextRequest) {
               "Content-Type": "application/json",
               ...(isDemo ? {} : { Authorization: `Bearer ${key}` }),
             },
-            body: JSON.stringify(
-              isDemo ? { messages } : { messages, model: ANALYST_MODEL },
-            ),
+            // No model override — /api/chat and /api/landing/chat resolve the
+            // backend themselves (Moonshot/Kimi when configured).
+            body: JSON.stringify({ messages }),
           },
         );
         clearInterval(heartbeat);

--- a/lib/chat/agent-runner.ts
+++ b/lib/chat/agent-runner.ts
@@ -22,6 +22,8 @@ export interface RunChatAgentOptions {
   allowedToolNames?: readonly string[];
   execParallel?: boolean;
   allowParallelOpenAI?: boolean;
+  /** Omit the `parallel_tool_calls` param entirely (OpenAI-compatible providers like Moonshot that don't accept it). */
+  omitParallelToolCalls?: boolean;
   openai?: OpenAI;
   /** Skip per-tool deductBalance (keyless demo). */
   skipBilling?: boolean;
@@ -83,6 +85,7 @@ export async function runChatAgent(
     allowedToolNames,
     execParallel = true,
     allowParallelOpenAI = true,
+    omitParallelToolCalls = false,
     skipBilling = false,
     preFlightGuard,
   } = opts;
@@ -122,9 +125,11 @@ export async function runChatAgent(
         messages,
         tools,
         tool_choice: "auto",
-        ...(parallelOpenAI
-          ? { parallel_tool_calls: true }
-          : { parallel_tool_calls: false }),
+        ...(omitParallelToolCalls
+          ? {}
+          : parallelOpenAI
+            ? { parallel_tool_calls: true }
+            : { parallel_tool_calls: false }),
         ...(maxCompletionTokens ? { max_tokens: maxCompletionTokens } : {}),
       });
     } catch (e) {

--- a/lib/chat/llm-backend.ts
+++ b/lib/chat/llm-backend.ts
@@ -1,0 +1,90 @@
+import OpenAI from "openai";
+
+/**
+ * Resolves which LLM backend the tool-calling chat agent should use.
+ *
+ * Moonshot (Kimi) is OpenAI-compatible and cheaper, so when MOONSHOT_API_KEY is
+ * present it becomes the default backend for both the full analyst (/api/chat)
+ * and the keyless MAG7 demo (/api/landing/chat). Billing to the end user is
+ * unchanged — that's priced per RiskModels capability, not per upstream model —
+ * so this only lowers our own inference cost.
+ *
+ * Precedence:
+ *   1. An explicit `claude-*` requested model → Anthropic (runner dispatches on
+ *      the `claude-` prefix; lets a specific caller force Claude).
+ *   2. MOONSHOT_API_KEY set → Moonshot (Kimi), via an OpenAI client pointed at
+ *      the Moonshot base URL.
+ *   3. AGENT_BACKEND=claude → Claude default.
+ *   4. else → OpenAI (requested model or gpt-4o-mini).
+ *
+ * Env (Doppler):
+ *   MOONSHOT_API_KEY   — the Moonshot key (enables this backend when set)
+ *   MOONSHOT_MODEL     — Kimi model id (default kimi-k2-0711-preview)
+ *   MOONSHOT_BASE_URL  — override (default https://api.moonshot.ai/v1)
+ */
+export interface AgentBackend {
+  model: string;
+  /** Custom OpenAI-compatible client (Moonshot). Undefined → runner's default OpenAI/Anthropic. */
+  openai?: OpenAI;
+  allowParallel: boolean;
+  /** Moonshot: don't send parallel_tool_calls at all (tool_choice=required is unsupported; keep the wire minimal). */
+  omitParallelToolCalls: boolean;
+}
+
+export function resolveAgentBackend(requestedModel?: string): AgentBackend {
+  const req = requestedModel?.trim();
+
+  // Explicit Claude model always routes to Anthropic.
+  if (req?.startsWith("claude-")) {
+    return { model: req, allowParallel: true, omitParallelToolCalls: false };
+  }
+
+  const moonshotKey = process.env.MOONSHOT_API_KEY?.trim();
+  const moonshotClient = moonshotKey
+    ? new OpenAI({
+        apiKey: moonshotKey,
+        baseURL: process.env.MOONSHOT_BASE_URL?.trim() || "https://api.moonshot.ai/v1",
+      })
+    : undefined;
+
+  // An explicit non-Claude model is honored: kimi/moonshot ids route through the
+  // Moonshot client (when configured); anything else through the default OpenAI.
+  if (req) {
+    const isKimi = /^(kimi|moonshot)/i.test(req);
+    return {
+      model: req,
+      openai: isKimi ? moonshotClient : undefined,
+      allowParallel: !isKimi,
+      omitParallelToolCalls: isKimi,
+    };
+  }
+
+  // Default backend (no model requested):
+  //   Moonshot when configured → cheapest;
+  //   else Claude when its key is present (configured + working today);
+  //   else OpenAI.
+  if (moonshotClient) {
+    return {
+      model: process.env.MOONSHOT_MODEL?.trim() || "kimi-k2-0711-preview",
+      openai: moonshotClient,
+      allowParallel: false,
+      omitParallelToolCalls: true,
+    };
+  }
+  if (
+    process.env.AGENT_BACKEND?.toLowerCase() === "claude" ||
+    process.env.ANTHROPIC_API_KEY?.trim()
+  ) {
+    return { model: "claude-sonnet-4-6", allowParallel: true, omitParallelToolCalls: false };
+  }
+  return { model: "gpt-4o-mini", allowParallel: true, omitParallelToolCalls: false };
+}
+
+/** True when any usable chat backend is configured. */
+export function hasChatBackend(): boolean {
+  return Boolean(
+    process.env.MOONSHOT_API_KEY?.trim() ||
+      process.env.ANTHROPIC_API_KEY?.trim() ||
+      process.env.OPENAI_API_KEY?.trim(),
+  );
+}


### PR DESCRIPTION
Adds `resolveAgentBackend()` so both `/api/chat` and `/api/landing/chat` resolve model + client centrally. **Set `MOONSHOT_API_KEY` in Doppler → both point at Moonshot (Kimi)** — OpenAI-compatible, cheaper. End-user billing unchanged (priced per RiskModels capability), so this only lowers our own inference cost.

Precedence: explicit `claude-*` → Anthropic; explicit `kimi/moonshot` model → Moonshot client; else default = Moonshot (if key) → Claude (if `ANTHROPIC_API_KEY`) → OpenAI. Moonshot omits `parallel_tool_calls` (no `tool_choice=required`) via a new runner flag. `/openbb/query` no longer forces a model.

Safe to deploy before the key exists — falls back to Claude (working), not the out-of-quota OpenAI key. Env documented in `.env.example`. Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)