### PR TITLE
chore(env): allowlist MOONSHOT_* for the Doppler→Vercel sync

### DIFF
--- a/scripts/doppler-vercel-allowlist.txt
+++ b/scripts/doppler-vercel-allowlist.txt
@@ -43,6 +43,13 @@ LLMS_TXT_PUBLIC_AGENT_KEY
 # Server-only; never reaches the browser. Read by /api/chat when `model: "claude-*"`.
 ANTHROPIC_API_KEY
 
+# Moonshot (Kimi) — OpenAI-compatible chat backend (cheaper). When MOONSHOT_API_KEY
+# is set, resolveAgentBackend() points BOTH /api/chat and /api/landing/chat at it.
+# Server-only. MOONSHOT_MODEL defaults to kimi-k2-0711-preview; BASE_URL optional.
+MOONSHOT_API_KEY
+MOONSHOT_MODEL
+MOONSHOT_BASE_URL
+
 # Shared secret for the Google Ads offline-conversion scheduled upload endpoint
 # (GET /api/internal/google-ads/offline-conversions). Used as Bearer / Basic password / ?token=.
 GOOGLE_ADS_OFFLINE_UPLOAD_TOKEN


### PR DESCRIPTION
`resolveAgentBackend()` reads `MOONSHOT_API_KEY`/`MOONSHOT_MODEL`/`MOONSHOT_BASE_URL`, but the `erm3/prd` → `riskmodels-api` Vercel sync (`npm run vercel:sync-env:doppler`) only pushes allowlisted names. Adds the three so they reach Vercel prod once set in Doppler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)