### PR TITLE
fix(chat): default Moonshot model to a valid id (kimi-k2.5)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,7 +66,7 @@ OPENAI_API_KEY=sk-...
 # Setting MOONSHOT_API_KEY points BOTH /api/chat and /api/landing/chat at Moonshot.
 # End-user billing is unchanged (priced per RiskModels capability, not per model).
 # MOONSHOT_API_KEY=sk-...
-# MOONSHOT_MODEL=kimi-k2-0711-preview
+# MOONSHOT_MODEL=kimi-k2.5      # or kimi-k2.6 (agentic), kimi-k2.7-code
 # MOONSHOT_BASE_URL=https://api.moonshot.ai/v1
 # ANTHROPIC_API_KEY=sk-ant-...    # (in Doppler) — claude-* models
 # AGENT_BACKEND=claude            # optional: force Claude default when no Moonshot key

--- a/lib/chat/llm-backend.ts
+++ b/lib/chat/llm-backend.ts
@@ -19,7 +19,7 @@ import OpenAI from "openai";
  *
  * Env (Doppler):
  *   MOONSHOT_API_KEY   — the Moonshot key (enables this backend when set)
- *   MOONSHOT_MODEL     — Kimi model id (default kimi-k2-0711-preview)
+ *   MOONSHOT_MODEL     — Kimi model id (default kimi-k2.5)
  *   MOONSHOT_BASE_URL  — override (default https://api.moonshot.ai/v1)
  */
 export interface AgentBackend {
@@ -65,7 +65,7 @@ export function resolveAgentBackend(requestedModel?: string): AgentBackend {
   //   else OpenAI.
   if (moonshotClient) {
     return {
-      model: process.env.MOONSHOT_MODEL?.trim() || "kimi-k2-0711-preview",
+      model: process.env.MOONSHOT_MODEL?.trim() || "kimi-k2.5",
       openai: moonshotClient,
       allowParallel: false,
       omitParallelToolCalls: true,


### PR DESCRIPTION
Hardcoded fallback `kimi-k2-0711-preview` 404'd on the account. Valid Kimi K2 models: `kimi-k2.5` (cost), `kimi-k2.6` (agentic), `kimi-k2.7-code`. Default → `kimi-k2.5` (tool-calling verified live). `MOONSHOT_MODEL` env overrides; prod set to `kimi-k2.5` in `erm3/prd`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)