### PR TITLE
feat(openbb): portfolio risk + hedge-layering widgets + app

### DIFF
--- a/app/openbb/_lib/apps.ts
+++ b/app/openbb/_lib/apps.ts
@@ -114,4 +114,44 @@ export const APPS = [
       },
     },
   },
+  {
+    name: "RiskModels — Portfolio Risk & Hedge",
+    description:
+      "Multi-position portfolio: L3 explained-risk decomposition, L1/L2/L3 hedge layering, and a per-position breakdown, powered by the RiskModels API.",
+    allowCustomization: true,
+    tabs: {
+      portfolio: {
+        id: "portfolio",
+        name: "Portfolio",
+        layout: [
+          {
+            i: "rm_portfolio_risk",
+            x: 0,
+            y: 0,
+            w: 20,
+            h: 16,
+            state: { params: { positions: "AAPL:0.4, MSFT:0.35, NVDA:0.25" } },
+          },
+          {
+            i: "rm_portfolio_positions",
+            x: 20,
+            y: 0,
+            w: 20,
+            h: 16,
+            state: { params: { positions: "AAPL:0.4, MSFT:0.35, NVDA:0.25" } },
+          },
+        ],
+      },
+    },
+    groups: [
+      // One positions box drives both widgets on the tab.
+      {
+        name: "positions",
+        type: "param",
+        paramName: "positions",
+        defaultValue: "AAPL:0.4, MSFT:0.35, NVDA:0.25",
+        widgetIds: ["rm_portfolio_risk", "rm_portfolio_positions"],
+      },
+    ],
+  },
 ];

--- a/app/openbb/_lib/portfolio.ts
+++ b/app/openbb/_lib/portfolio.ts
@@ -1,0 +1,49 @@
+/**
+ * Portfolio helpers for the OpenBB adapter.
+ *
+ * /api/portfolio/risk-snapshot is POST (takes a positions array), but OpenBB
+ * widgets fetch via GET — so the widget takes a `positions` text param
+ * ("AAPL:0.4, MSFT:0.35, NVDA:0.25") which we parse and POST upstream.
+ */
+import { upstreamBase } from "./upstream";
+
+export type Position = { ticker: string; weight: number };
+
+/** Parse "AAPL:0.4, MSFT:0.35, NVDA:0.25" (or bare "AAPL,MSFT,NVDA" = equal weight). */
+export function parsePositions(raw: string | null): Position[] {
+  if (!raw) return [];
+  const out: Position[] = [];
+  for (const part of raw.split(",").map((s) => s.trim()).filter(Boolean)) {
+    const [t, w] = part.split(/[:=]/).map((s) => s.trim());
+    if (!t) continue;
+    const weight = w ? Number(w) : 1;
+    out.push({
+      ticker: t.toUpperCase(),
+      weight: Number.isFinite(weight) && weight > 0 ? weight : 1,
+    });
+  }
+  return out;
+}
+
+/** POST the parsed positions to the real portfolio risk-snapshot endpoint. */
+export async function fetchPortfolioSnapshot(
+  positions: Position[],
+  key: string,
+): Promise<{ status: number; body: unknown }> {
+  const res = await fetch(`${upstreamBase()}/portfolio/risk-snapshot`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${key}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ positions, include_hedge_ratios: true }),
+    cache: "no-store",
+  });
+  let body: unknown = null;
+  try {
+    body = await res.json();
+  } catch {
+    body = { error: "upstream returned non-JSON", status: res.status };
+  }
+  return { status: res.status, body };
+}

--- a/app/openbb/widgets.json/route.ts
+++ b/app/openbb/widgets.json/route.ts
@@ -264,6 +264,68 @@ const WIDGETS = {
       },
     },
   },
+  rm_portfolio_risk: {
+    name: "RiskModels — Portfolio Risk & Hedge",
+    description:
+      "Portfolio-level L3 explained-risk decomposition, volatility, and the L1/L2/L3 hedge-layering ladder for a list of positions.",
+    category: "Risk",
+    type: "table",
+    source: ["RiskModels API"],
+    endpoint: "widgets/portfolio",
+    gridData: { w: 24, h: 16 },
+    params: [
+      {
+        paramName: "positions",
+        value: "AAPL:0.4, MSFT:0.35, NVDA:0.25",
+        label: "Positions",
+        type: "text",
+        description:
+          "Comma-separated ticker:weight (e.g. AAPL:0.4, MSFT:0.35, NVDA:0.25). Weights auto-normalise; bare tickers = equal weight.",
+      },
+    ],
+    data: {
+      table: {
+        showAll: true,
+        columnsDefs: [
+          { field: "metric", headerName: "Metric", cellDataType: "text" },
+          { field: "value", headerName: "Value", cellDataType: "text" },
+        ],
+      },
+    },
+  },
+  rm_portfolio_positions: {
+    name: "RiskModels — Portfolio Positions",
+    description:
+      "Per-position breakdown for the same portfolio: weight, L3 explained-risk split, and L3 hedge ratios.",
+    category: "Risk",
+    type: "table",
+    source: ["RiskModels API"],
+    endpoint: "widgets/portfolio-positions",
+    gridData: { w: 24, h: 14 },
+    params: [
+      {
+        paramName: "positions",
+        value: "AAPL:0.4, MSFT:0.35, NVDA:0.25",
+        label: "Positions",
+        type: "text",
+        description: "Comma-separated ticker:weight.",
+      },
+    ],
+    data: {
+      table: {
+        showAll: true,
+        columnsDefs: [
+          { field: "ticker", headerName: "Ticker" },
+          { field: "weight", headerName: "Weight" },
+          { field: "market_er", headerName: "Market ER" },
+          { field: "residual_er", headerName: "Residual ER" },
+          { field: "mkt_hr", headerName: "Mkt HR" },
+          { field: "sec_hr", headerName: "Sec HR" },
+          { field: "sub_hr", headerName: "Sub HR" },
+        ],
+      },
+    },
+  },
 } as const;
 
 export async function GET(req: NextRequest) {

--- a/app/openbb/widgets/portfolio-positions/route.ts
+++ b/app/openbb/widgets/portfolio-positions/route.ts
@@ -1,0 +1,69 @@
+/**
+ * Live widget: per-position portfolio breakdown → OpenBB table.
+ *
+ * GET /openbb/widgets/portfolio-positions?positions=AAPL:0.4,MSFT:0.35,NVDA:0.25
+ * Same positions string as the portfolio widget; one row per name with its
+ * weight, L3 explained-risk split, and L3 hedge ratios.
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { noKeyRows } from "../../_lib/connect-probe";
+import { openbbCors } from "../../_lib/cors";
+import { bearerFromRequest } from "../../_lib/upstream";
+import { parsePositions, fetchPortfolioSnapshot } from "../../_lib/portfolio";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+const pct = (x: unknown): string =>
+  x == null || Number.isNaN(Number(x)) ? "—" : `${(Number(x) * 100).toFixed(1)}%`;
+const num = (x: unknown): string =>
+  x == null || Number.isNaN(Number(x)) ? "—" : Number(x).toFixed(3);
+
+export async function GET(req: NextRequest) {
+  const cors = openbbCors(req);
+  const positions = parsePositions(
+    req.nextUrl.searchParams.get("positions") || "AAPL:0.4, MSFT:0.35, NVDA:0.25",
+  );
+
+  const key = bearerFromRequest(req);
+  if (!key) return NextResponse.json(noKeyRows(), { headers: cors });
+  if (!positions.length) {
+    return NextResponse.json(
+      [{ status: "Enter positions, e.g. AAPL:0.4, MSFT:0.35, NVDA:0.25" }],
+      { headers: cors },
+    );
+  }
+
+  const { status, body } = await fetchPortfolioSnapshot(positions, key);
+  if (status < 200 || status >= 300) {
+    const message =
+      (body as { error?: string; message?: string })?.error ||
+      (body as { message?: string })?.message ||
+      `Upstream returned ${status}`;
+    return NextResponse.json({ error: message }, { status, headers: cors });
+  }
+
+  const perTicker =
+    (body as { per_ticker?: Record<string, Record<string, unknown>> }).per_ticker ?? {};
+
+  const rows = Object.keys(perTicker)
+    .sort()
+    .map((t) => {
+      const r = perTicker[t];
+      return {
+        ticker: t,
+        weight: pct(r.weight),
+        market_er: pct(r.l3_mkt_er),
+        residual_er: pct(r.l3_res_er),
+        mkt_hr: num(r.l3_mkt_hr),
+        sec_hr: num(r.l3_sec_hr),
+        sub_hr: num(r.l3_sub_hr),
+      };
+    });
+
+  return NextResponse.json(rows, { headers: cors });
+}
+
+export async function OPTIONS(req: NextRequest) {
+  return new NextResponse(null, { status: 204, headers: openbbCors(req) });
+}

--- a/app/openbb/widgets/portfolio/route.ts
+++ b/app/openbb/widgets/portfolio/route.ts
@@ -1,0 +1,89 @@
+/**
+ * Live widget: portfolio risk + L1/L2/L3 hedge layering → OpenBB table.
+ *
+ * GET /openbb/widgets/portfolio?positions=AAPL:0.4,MSFT:0.35,NVDA:0.25
+ * Parses the positions string, POSTs to /portfolio/risk-snapshot, and maps the
+ * portfolio-level L3 decomposition + the hedge-layering ladder (L1 SPY-only →
+ * L2 +sector → L3 +subsector, with residual left at each layer). Nulls → "—".
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { noKeyRows } from "../../_lib/connect-probe";
+import { openbbCors } from "../../_lib/cors";
+import { bearerFromRequest } from "../../_lib/upstream";
+import { parsePositions, fetchPortfolioSnapshot } from "../../_lib/portfolio";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+type Row = { metric: string; value: string };
+const pct = (x: unknown): string =>
+  x == null || Number.isNaN(Number(x)) ? "—" : `${(Number(x) * 100).toFixed(1)}%`;
+const num = (x: unknown): string =>
+  x == null || Number.isNaN(Number(x)) ? "—" : Number(x).toFixed(3);
+
+export async function GET(req: NextRequest) {
+  const cors = openbbCors(req);
+  const positions = parsePositions(
+    req.nextUrl.searchParams.get("positions") || "AAPL:0.4, MSFT:0.35, NVDA:0.25",
+  );
+
+  const key = bearerFromRequest(req);
+  if (!key) return NextResponse.json(noKeyRows(), { headers: cors });
+  if (!positions.length) {
+    return NextResponse.json(
+      [{ status: "Enter positions, e.g. AAPL:0.4, MSFT:0.35, NVDA:0.25" }],
+      { headers: cors },
+    );
+  }
+
+  const { status, body } = await fetchPortfolioSnapshot(positions, key);
+  if (status < 200 || status >= 300) {
+    const message =
+      (body as { error?: string; message?: string })?.error ||
+      (body as { message?: string })?.message ||
+      `Upstream returned ${status}`;
+    return NextResponse.json({ error: message }, { status, headers: cors });
+  }
+
+  const d = body as {
+    as_of?: string;
+    portfolio_risk_index?: {
+      variance_decomposition?: Record<string, unknown>;
+      portfolio_volatility_23d?: number | null;
+      position_count?: number | null;
+    };
+    portfolio_hedge_levels?: Record<string, Record<string, unknown>>;
+    summary?: { resolved?: number };
+  };
+  const pri = d.portfolio_risk_index ?? {};
+  const vd = pri.variance_decomposition ?? {};
+  const hl = d.portfolio_hedge_levels ?? {};
+  const L = (lvl: string) => hl[lvl] ?? {};
+
+  const rows: Row[] = [
+    { metric: "Positions", value: String(pri.position_count ?? d.summary?.resolved ?? positions.length) },
+    { metric: "As of", value: d.as_of ?? "—" },
+    { metric: "L3 explained risk — Market (%)", value: pct(vd.market) },
+    { metric: "L3 explained risk — Sector (%)", value: pct(vd.sector) },
+    { metric: "L3 explained risk — Subsector (%)", value: pct(vd.subsector) },
+    { metric: "L3 explained risk — Residual (%)", value: pct(vd.residual) },
+    { metric: "Systematic — mkt+sec+sub (%)", value: pct(vd.systematic) },
+    { metric: "Portfolio volatility — 23d annualised (%)", value: pct(pri.portfolio_volatility_23d) },
+    // Hedge layering ladder — each layer adds a leg and shrinks the residual.
+    { metric: "L1 hedge (SPY) — Market HR", value: num(L("L1").market_hr) },
+    { metric: "L1 — residual left (%)", value: pct(L("L1").residual_er) },
+    { metric: "L2 hedge (+ sector) — Market HR", value: num(L("L2").market_hr) },
+    { metric: "L2 — Sector HR", value: num(L("L2").sector_hr) },
+    { metric: "L2 — residual left (%)", value: pct(L("L2").residual_er) },
+    { metric: "L3 hedge (+ subsector) — Market HR", value: num(L("L3").market_hr) },
+    { metric: "L3 — Sector HR", value: num(L("L3").sector_hr) },
+    { metric: "L3 — Subsector HR", value: num(L("L3").subsector_hr) },
+    { metric: "L3 — residual left (%)", value: pct(L("L3").residual_er) },
+  ];
+
+  return NextResponse.json(rows, { headers: cors });
+}
+
+export async function OPTIONS(req: NextRequest) {
+  return new NextResponse(null, { status: 204, headers: openbbCors(req) });
+}


### PR DESCRIPTION
Two new widgets + the planned 3rd app. `/api/portfolio/risk-snapshot` is POST, so the widgets take a `positions` text param (`AAPL:0.4, MSFT:0.35, NVDA:0.25`) → parse → POST upstream.

- **widgets/portfolio** — portfolio L3 decomposition + volatility + **L1/L2/L3 hedge-layering ladder** (residual left at each layer — the differentiator).
- **widgets/portfolio-positions** — per-position weight / ER / HR.
- New **Portfolio Risk & Hedge** app wires both to one positions box.

Shape probed against prod. Typecheck clean. Suite now 8 widgets + 3 apps + 1 agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)