### PR TITLE
feat(d8.39): surface net_expense_ratio on the fund snapshot

### DIFF
--- a/lib/dal/funds-engine.ts
+++ b/lib/dal/funds-engine.ts
@@ -25,6 +25,13 @@ export interface FundRow {
   morningstar_category: string | null;
   equity_style_9box: string | null;
   style_link_method: string | null;
+  /** Net expense ratio of the representative (ticker_primary) share class, as a
+   *  PERCENT per year (0.59 = 0.59%/yr, NOT 0.0059). Source: EODHD via Funds_DAG.
+   *  Feeds the fee-justification analytic (active_fee = fund_ER − index_ER). */
+  net_expense_ratio: number | null;
+  /** As-of date of net_expense_ratio (EODHD expense_ratio_date); can trail by
+   *  years — a staleness signal, not a current-fee guarantee. */
+  net_expense_ratio_asof: string | null;
   primary_bw_fund_id: string | null;
   latest_report_date: string | null;
   latest_filing_date: string | null;
@@ -100,7 +107,7 @@ export interface SearchFundsOptions {
 }
 
 const FUND_COLUMNS =
-  "bw_fund_id, series_id, ticker, cik, fund_name, morningstar_category, equity_style_9box, style_link_method, primary_bw_fund_id, latest_report_date, latest_filing_date, latest_extracted_at, latest_total_adj_mv, latest_n_holdings, latest_effective_n, last_in_eligible_universe_at, metadata";
+  "bw_fund_id, series_id, ticker, cik, fund_name, morningstar_category, equity_style_9box, style_link_method, net_expense_ratio, net_expense_ratio_asof, primary_bw_fund_id, latest_report_date, latest_filing_date, latest_extracted_at, latest_total_adj_mv, latest_n_holdings, latest_effective_n, last_in_eligible_universe_at, metadata";
 
 const FUND_LATEST_COLUMNS =
   "bw_fund_id, report_date, filing_date, extracted_at, portfolio_gross_return, portfolio_market_return, portfolio_sector_return, portfolio_subsector_return, portfolio_style_return, portfolio_idiosyncratic_return, identity_residual, weight_sum, n_holdings_active, effective_n, top10_weight_sum, total_adj_mv, equity_style_9box, n_funds_in_cell_at_report_date, model_version, factor_set_id, last_synced_at, metadata, aum_erm3, coverage_in_erm3, variance_shares_full, variance_shares_recent, fit_beta_to_spy, fit_capm_r2, fit_nav_correlation, fit_residual_vol, fit_nav_vol_ann, fit_alpha_ann, fit_erm3_multifactor_r2, fit_n_months";

--- a/tests/funds-data-routes.test.ts
+++ b/tests/funds-data-routes.test.ts
@@ -32,6 +32,8 @@ const FUND = {
   morningstar_category: null,
   equity_style_9box: "Large Blend",
   style_link_method: null,
+  net_expense_ratio: null,
+  net_expense_ratio_asof: null,
   primary_bw_fund_id: null,
   latest_report_date: "2026-04-30",
   latest_filing_date: "2026-07-14",

--- a/tests/funds-engine.test.ts
+++ b/tests/funds-engine.test.ts
@@ -70,6 +70,8 @@ const FUND_VFINX = {
   morningstar_category: "Large Blend",
   equity_style_9box: "Large Blend",
   style_link_method: "ticker_match",
+  net_expense_ratio: null,
+  net_expense_ratio_asof: null,
   primary_bw_fund_id: null,
   latest_report_date: "2026-04-30",
   latest_filing_date: "2026-07-14",

--- a/tests/funds-format.test.ts
+++ b/tests/funds-format.test.ts
@@ -11,6 +11,8 @@ const FUND: FundRow = {
   morningstar_category: "Large Blend",
   equity_style_9box: "Large Blend",
   style_link_method: "ticker_match",
+  net_expense_ratio: null,
+  net_expense_ratio_asof: null,
   primary_bw_fund_id: null,
   latest_report_date: "2026-04-30",
   latest_filing_date: "2026-07-14",

--- a/tests/funds-hedge-route.test.ts
+++ b/tests/funds-hedge-route.test.ts
@@ -32,6 +32,8 @@ const FUND = {
   morningstar_category: null,
   equity_style_9box: "Large Blend",
   style_link_method: null,
+  net_expense_ratio: null,
+  net_expense_ratio_asof: null,
   primary_bw_fund_id: null,
   latest_report_date: "2026-04-30",
   latest_filing_date: "2026-07-14",

--- a/tests/funds-holdings-route.test.ts
+++ b/tests/funds-holdings-route.test.ts
@@ -32,6 +32,8 @@ const FUND = {
   morningstar_category: null,
   equity_style_9box: "Large Blend",
   style_link_method: null,
+  net_expense_ratio: null,
+  net_expense_ratio_asof: null,
   primary_bw_fund_id: null,
   latest_report_date: "2026-04-30",
   latest_filing_date: "2026-07-14",

--- a/tests/funds-metrics-route.test.ts
+++ b/tests/funds-metrics-route.test.ts
@@ -33,6 +33,8 @@ const FUND = {
   morningstar_category: "Large Blend",
   equity_style_9box: "Large Blend",
   style_link_method: "ticker_match",
+  net_expense_ratio: null,
+  net_expense_ratio_asof: null,
   primary_bw_fund_id: null,
   latest_report_date: "2026-04-30",
   latest_filing_date: "2026-07-14",

--- a/tests/funds-nav-route.test.ts
+++ b/tests/funds-nav-route.test.ts
@@ -32,6 +32,8 @@ const FUND = {
   morningstar_category: null,
   equity_style_9box: "Large Blend",
   style_link_method: null,
+  net_expense_ratio: null,
+  net_expense_ratio_asof: null,
   primary_bw_fund_id: null,
   latest_report_date: "2026-04-30",
   latest_filing_date: "2026-07-14",

--- a/tests/funds-portfolio-route.test.ts
+++ b/tests/funds-portfolio-route.test.ts
@@ -32,6 +32,8 @@ const FUND = {
   morningstar_category: null,
   equity_style_9box: "Large Blend",
   style_link_method: null,
+  net_expense_ratio: null,
+  net_expense_ratio_asof: null,
   primary_bw_fund_id: null,
   latest_report_date: "2026-04-30",
   latest_filing_date: "2026-07-14",


### PR DESCRIPTION
Surfaces the fund **net expense ratio** on the funds DAL so the OCIO fee-justification analytic reads it from `public.funds` via the snapshot.

- `FundRow` += `net_expense_ratio` / `net_expense_ratio_asof` (unit = **PERCENT/yr**, 0.59 = 0.59%; asof is a staleness signal)
- `FUND_COLUMNS` += the two columns; composer spreads `{...fund}` so they flow unchanged
- 8 test fixtures updated for the new required fields

Pairs with BWMACRO migration `20260703000000_funds_net_expense_ratio.sql` (applied) + Funds_DAG `fund_expense_ratio.py` (PR #50, merged). `public.funds` already populated for **4,983 funds** (roster verified: AGTHX 0.59, FXAIX 0.015…). `tsc` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)