### PR TITLE
fix(test): add readFundPortfolioDailySeries to funds-zarr-reader mock (green main)

### DIFF
--- a/tests/funds-snapshot-routes.test.ts
+++ b/tests/funds-snapshot-routes.test.ts
@@ -18,6 +18,7 @@ vi.mock("@/lib/dal/funds-zarr-reader", () => ({
   readFundHoldingsTopN: vi.fn(),
   readFundHedgeLatest: vi.fn(),
   readFundPortfolioSeries: vi.fn(),
+  readFundPortfolioDailySeries: vi.fn(),
   readFundNavSeries: vi.fn(),
   readStyleCohortHoldingsTopN: vi.fn(),
   readStyleCohortPortfolioSeries: vi.fn(),


### PR DESCRIPTION
`main` went red after the portfolio_daily merge (`455c254`): `loadFundSnapshot` calls `readFundPortfolioDailySeries`, but `tests/funds-snapshot-routes.test.ts` mocked `@/lib/dal/funds-zarr-reader` without that export → vitest `No … export is defined on the mock`.

One-line fix: add the missing `vi.fn()` to the mock. Full suite **383 pass**, `tsc` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)