### PR TITLE
feat(d8.39): emit net_expense_ratio in the composed FundSnapshot

### DIFF
--- a/lib/funds/snapshot-composer.ts
+++ b/lib/funds/snapshot-composer.ts
@@ -71,6 +71,13 @@ export interface FundSnapshot {
   ticker: string | null;
   fund_name: string | null;
   equity_style_9box: string | null;
+  /** Net expense ratio of the representative (ticker_primary) share class, as a
+   *  PERCENT per year (0.59 = 0.59%/yr, NOT 0.0059). Powers the fee-justification
+   *  analytic (active_fee = fund_ER − index_ER). Null when unavailable. */
+  net_expense_ratio: number | null;
+  /** As-of date of net_expense_ratio (EODHD expense_ratio_date); can trail by
+   *  years — a staleness signal, not a current-fee guarantee. */
+  net_expense_ratio_asof: string | null;
   report_date: string;
   filing_date: string;
   metrics: FundMetricsResponse;
@@ -163,6 +170,8 @@ export function composeFundSnapshot(p: FundSnapshotPrimitives): FundSnapshot {
     ticker: fund.ticker,
     fund_name: fund.fund_name,
     equity_style_9box: fund.equity_style_9box ?? latest.equity_style_9box,
+    net_expense_ratio: fund.net_expense_ratio,
+    net_expense_ratio_asof: fund.net_expense_ratio_asof,
     report_date: latest.report_date,
     filing_date: latest.filing_date,
     metrics: formatFundMetrics(fund, latest),

--- a/tests/fixtures/funds/fund.json
+++ b/tests/fixtures/funds/fund.json
@@ -14,6 +14,8 @@
     "filing_date_source": "placeholder_lag_75d"
   },
   "morningstar_category": "Large Blend",
+  "net_expense_ratio": 0.45,
+  "net_expense_ratio_asof": "2025-10-31",
   "primary_bw_fund_id": null,
   "series_id": "S000001243",
   "style_link_method": "ticker_match",

--- a/tests/funds-snapshot-composer.test.ts
+++ b/tests/funds-snapshot-composer.test.ts
@@ -48,6 +48,9 @@ describe("composeFundSnapshot (real fixtures: NOLCX / Northern Large Cap Core)",
     expect(snap.bw_fund_id).toBe("BW-FUND-S000001243");
     expect(snap.ticker).toBe("NOLCX");
     expect(snap.equity_style_9box).toBe("Large Blend");
+    // Fee-justification: net expense ratio flows through as PERCENT/yr + asof.
+    expect(snap.net_expense_ratio).toBe(0.45);
+    expect(snap.net_expense_ratio_asof).toBe("2025-10-31");
     expect(snap.report_date).toBe(LATEST.report_date);
     expect(snap.filing_date).toBe(LATEST.filing_date);
   });


### PR DESCRIPTION
Follow-up to #208. Adding `net_expense_ratio` to `FundRow`/`FUND_COLUMNS` **fetched** the column but didn't **surface** it — `composeFundSnapshot` emits a curated shape, so `GET /api/funds/snapshot/{id}` never returned the fee.

- `FundSnapshot` += `net_expense_ratio` / `net_expense_ratio_asof` (**PERCENT/yr**, documented)
- `composeFundSnapshot` maps them from the fund registry row
- Composer test asserts passthrough; `fund.json` fixture carries the fields

Completes the through-line: `public.funds` (4,983 funds) → snapshot → RiskModels_net fee agent. `tsc` + **383 tests** green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)