### PR TITLE
fix(ci): sha allowlist for the commit-message licensed-id scan

### DIFF
--- a/scripts/check-licensed-identifiers-git.sh
+++ b/scripts/check-licensed-identifiers-git.sh
@@ -18,10 +18,18 @@
 #                                  on a line near the offending token.
 # Use AUDIT-PENDING in the reason to surface the commit as a warning
 # (does not fail the check).
+#
+# Sha allowlist (scripts/licensed-id-commit-allowlist.txt):
+#   For messages ALREADY on a shared branch, where the in-message marker
+#   would require a history rewrite. One entry per line: <full-sha> <reason>.
+#   Reserve it for prose mentions of an identifier scheme — never for an
+#   actual leaked identifier value (those require the history rewrite).
 
 set -uo pipefail
 
 PATTERN='cusip|fsym_id|factset_fund_id|factset_entity_id|isin'
+
+SHA_ALLOWLIST_FILE="$(dirname "$0")/licensed-id-commit-allowlist.txt"
 
 # Resolve the git log range.
 if [[ -n "${GIT_LOG_RANGE:-}" ]]; then
@@ -50,6 +58,12 @@ audit_pending=""
 
 while IFS= read -r sha; do
     [[ -z "$sha" ]] && continue
+
+    # Sha allowlist: already-merged commits vetted as prose-only mentions.
+    if [[ -f "$SHA_ALLOWLIST_FILE" ]] && grep -q "^$sha" "$SHA_ALLOWLIST_FILE"; then
+        continue
+    fi
+
     # Full message: subject + body. %B includes both with a blank line.
     msg=$(git show --no-patch --format=%B "$sha" 2>/dev/null || true)
     [[ -z "$msg" ]] && continue

--- a/scripts/licensed-id-commit-allowlist.txt
+++ b/scripts/licensed-id-commit-allowlist.txt
@@ -1,0 +1,6 @@
+# Sha allowlist for check-licensed-identifiers-git.sh (commit-message scan).
+# One entry per line: <full-sha> <reason>. Only for commits already merged to
+# a shared branch, where adding the in-message `licensed-id-ok:` marker would
+# require a history rewrite. Reserve for prose mentions of an identifier
+# scheme — never for an actual leaked identifier value.
+d71a600659e96fa304dd17a9d48b16c1d8987fa3 identifier-scheme acronym used in prose describing the holdings scrub; no identifier value present (squash merge of PR #211 reused the pre-amend branch commit message)


### PR DESCRIPTION
## Summary

The squash merge of #211 reused the branch commit's pre-amend message, landing a prose mention of an identifier-scheme acronym in main's history. The main-push scan window is `HEAD~20..HEAD`, so every push to main for the next ~20 commits would re-flag it, and the documented remediation (in-message `licensed-id-ok:` marker) would require rewriting shared history.

## Changes

- `scripts/check-licensed-identifiers-git.sh`: consult `scripts/licensed-id-commit-allowlist.txt` and skip listed shas before scanning. Reserved for prose-only mentions on already-shared history — never for actual identifier values (those still require the history rewrite).
- `scripts/licensed-id-commit-allowlist.txt`: new, with `d71a600` (the #211 squash commit) and its rationale.

## Testing

- `GIT_LOG_RANGE=HEAD~20..HEAD bash scripts/check-licensed-identifiers-git.sh` → passes with the entry
- Same range with the allowlist neutralized → still fails on `d71a600` (scanner logic intact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)