### PR TITLE
feat(funds): admin cache-purge endpoint for the funds_zarr namespace

### DIFF
--- a/app/api/admin/cache/funds/route.ts
+++ b/app/api/admin/cache/funds/route.ts
@@ -1,0 +1,51 @@
+/**
+ * POST /api/admin/cache/funds
+ *
+ * Purge the funds-zarr Redis cache namespace (`riskmodels:funds_zarr:*`).
+ * Called by the Funds_DAG supabase sync after its upsert burst so a snapshot
+ * cached mid-sync (torn read, pre-refresh data) is evicted immediately
+ * instead of aging out over the readers' TTL. Safe to call any time — the
+ * next request per key just recomputes from GCS/Supabase.
+ *
+ * Auth: Authorization: Bearer CRON_SECRET (same machine-to-machine secret
+ * the Vercel cron routes use).
+ *
+ * Manual: curl -sS -X POST -H "Authorization: Bearer $CRON_SECRET" "https://riskmodels.app/api/admin/cache/funds"
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { deleteCachePattern } from "@/lib/cache/redis";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+const FUNDS_ZARR_CACHE_PATTERN = "riskmodels:funds_zarr:*";
+
+function authorize(request: NextRequest): boolean {
+  const secret = process.env.CRON_SECRET?.trim();
+  if (!secret) return false;
+  const auth = request.headers.get("authorization");
+  return auth === `Bearer ${secret}`;
+}
+
+export async function POST(request: NextRequest) {
+  if (!authorize(request)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const deleted = await deleteCachePattern(FUNDS_ZARR_CACHE_PATTERN);
+    console.log(
+      `[admin/cache/funds] purged ${deleted} keys (${FUNDS_ZARR_CACHE_PATTERN})`,
+    );
+    return NextResponse.json({
+      ok: true,
+      pattern: FUNDS_ZARR_CACHE_PATTERN,
+      deleted,
+    });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    console.error("[admin/cache/funds]", msg);
+    return NextResponse.json({ ok: false, error: msg }, { status: 500 });
+  }
+}

--- a/lib/cache/redis.ts
+++ b/lib/cache/redis.ts
@@ -153,9 +153,12 @@ export async function deleteCache(key: string): Promise<void> {
 }
 
 /**
- * Delete multiple keys by pattern (Redis only)
+ * Delete multiple keys by pattern. Returns the number of keys deleted
+ * (Redis + memory fallback combined) for observability.
  */
-export async function deleteCachePattern(pattern: string): Promise<void> {
+export async function deleteCachePattern(pattern: string): Promise<number> {
+  let deleted = 0;
+
   if (redis) {
     try {
       // Upstash Redis doesn't support KEYS, use scan instead
@@ -173,6 +176,7 @@ export async function deleteCachePattern(pattern: string): Promise<void> {
 
       if (keysToDelete.length > 0) {
         await redis.del(...keysToDelete);
+        deleted += keysToDelete.length;
       }
     } catch (error) {
       console.error("[Cache] Redis pattern delete error:", error);
@@ -184,8 +188,11 @@ export async function deleteCachePattern(pattern: string): Promise<void> {
   for (const key of memoryCache.keys()) {
     if (regex.test(key)) {
       memoryCache.delete(key);
+      deleted++;
     }
   }
+
+  return deleted;
 }
 
 /**

--- a/tests/admin-cache-purge-route.test.ts
+++ b/tests/admin-cache-purge-route.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/cache/redis", () => ({
+  deleteCachePattern: vi.fn(),
+}));
+
+import { deleteCachePattern } from "@/lib/cache/redis";
+import { POST } from "@/app/api/admin/cache/funds/route";
+
+const URL = "http://localhost/api/admin/cache/funds";
+
+function request(auth?: string): NextRequest {
+  return new NextRequest(URL, {
+    method: "POST",
+    headers: auth ? { authorization: auth } : {},
+  });
+}
+
+describe("POST /api/admin/cache/funds", () => {
+  beforeEach(() => {
+    vi.mocked(deleteCachePattern).mockReset();
+    process.env.CRON_SECRET = "test-secret";
+  });
+
+  afterEach(() => {
+    delete process.env.CRON_SECRET;
+  });
+
+  it("rejects missing or wrong bearer token", async () => {
+    expect((await POST(request())).status).toBe(401);
+    expect((await POST(request("Bearer wrong"))).status).toBe(401);
+    expect(vi.mocked(deleteCachePattern)).not.toHaveBeenCalled();
+  });
+
+  it("rejects everything when CRON_SECRET is unset", async () => {
+    delete process.env.CRON_SECRET;
+    expect((await POST(request("Bearer test-secret"))).status).toBe(401);
+  });
+
+  it("purges the funds_zarr namespace and reports the count", async () => {
+    vi.mocked(deleteCachePattern).mockResolvedValue(42);
+    const res = await POST(request("Bearer test-secret"));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      ok: true,
+      pattern: "riskmodels:funds_zarr:*",
+      deleted: 42,
+    });
+    expect(vi.mocked(deleteCachePattern)).toHaveBeenCalledWith(
+      "riskmodels:funds_zarr:*",
+    );
+  });
+
+  it("returns 500 when the purge throws", async () => {
+    vi.mocked(deleteCachePattern).mockRejectedValue(new Error("scan failed"));
+    const res = await POST(request("Bearer test-secret"));
+    expect(res.status).toBe(500);
+    expect((await res.json()).ok).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Closes the P2 follow-up from the 2026-07-03 funds-zarr cache-hardening review (#211): `POST /api/admin/cache/funds` evicts the `riskmodels:funds_zarr:*` Redis namespace so the Funds_DAG supabase sync can purge right after its upsert burst. A snapshot cached mid-sync (torn read, pre-refresh data) is dropped immediately instead of aging out over the readers' TTL — the only mitigation that also covers zarr-level torn reads, where no per-row date exists to detect the tear.

## Changes

- `app/api/admin/cache/funds/route.ts` (new): POST, `Authorization: Bearer CRON_SECRET` (same machine-to-machine pattern as the cron routes), calls `deleteCachePattern("riskmodels:funds_zarr:*")`, returns `{ok, pattern, deleted}`.
- `lib/cache/redis.ts`: `deleteCachePattern` now returns the number of keys deleted (Redis + memory fallback) for observability; previously `void`.
- `tests/admin-cache-purge-route.test.ts` (new): 401 without/with wrong token, 401 when `CRON_SECRET` unset, happy path with count, 500 on purge failure.

## Companion change

Funds_DAG PR wires `funds_supabase_sync` (mode=`supabase_upsert`) to call this endpoint after the sync-state stamp — best-effort, never fails the asset. Requires `RISKMODELS_API_CRON_SECRET` in the DAG runtime env (same value as the API's `CRON_SECRET`).

## Testing

- `tsc --noEmit` clean; full vitest suite 390/390 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)