### PR TITLE
feat(openbb): sharpen RiskModels Analyst description for orchestrator routing

### DIFF
--- a/app/openbb/agents.json/route.ts
+++ b/app/openbb/agents.json/route.ts
@@ -21,8 +21,13 @@ export async function GET(req: NextRequest) {
   const agents = {
     "riskmodels-analyst": {
       name: "RiskModels Analyst",
+      // NOTE: in OpenBB multi-orchestrator mode the main Copilot uses this
+      // description to decide when to route a query here, and it renders as the
+      // welcome message in empty chats — so it leads with capabilities + use
+      // cases (not "free demo"), which is what makes non-MAG7 questions route to
+      // this agent instead of falling through to the default OpenBB Copilot.
       description:
-        "Free demo of the RiskModels institutional analyst — L1/L2/L3 factor decomposition, hedge layering, and residual signal for the Magnificent 7 (AAPL, MSFT, GOOGL, AMZN, NVDA, META, TSLA), with real RiskModels data. Get a key at riskmodels.app for the full US universe + portfolio hedging.",
+        "RiskModels institutional equity risk analyst. Decomposes any US stock or portfolio into market, sector, subsector, and stock-specific (residual/idiosyncratic) risk — position-up L1/L2/L3 factor decomposition with tradeable hedge ratios, residual (Lstar) signal, and cross-sectional rankings. Use it to answer what is driving a name's or portfolio's risk, how to hedge a specific exposure, how idiosyncratic a position is, or how a stock ranks on factor and residual risk. Free for the Magnificent 7 (AAPL, MSFT, GOOGL, AMZN, NVDA, META, TSLA); add your riskmodels.app API key as X-API-KEY for the full US universe and multi-position portfolio hedging.",
       image: `${u.protocol}//${u.host}/logo.png`,
       endpoints: { query: queryUrl },
       features: { streaming: true },


### PR DESCRIPTION
## What
Rewrites the `RiskModels Analyst` description in `app/openbb/agents.json/route.ts`.

## Why (this fixes a real routing bug seen in the live demo)
In OpenBB multi-orchestrator mode, the main Copilot uses an agent's **description** to decide whether to route a query to it (per [OpenBB agents.json docs](https://docs.openbb.co/workspace/developers/json-specs/agents-json-reference)), and it also renders as the empty-chat welcome message.

The old description led with *"Free demo ... Magnificent 7 only"* — so non-MAG7 questions (e.g. "risk of IBM", "risk of GOOG") were **not** routed to RiskModels Analyst and fell through to the default OpenBB Copilot, which only sees dashboard widgets and returned degraded answers ("I could only check the top-10 ranking...").

## Change
Lead with capabilities + use cases across the **full US universe** (single-name L1/L2/L3 decomposition, tradeable hedge ratios, residual/Lstar signal, cross-sectional rankings, multi-position portfolio hedging). Keep the MAG7-free / key-for-full-universe note at the end.

## Risk
Minimal — one documented text field, no behavior change. Keyless callers still get the MAG7 subset + upgrade CTA; the difference is the orchestrator now routes full-universe questions here (with a key) or to the upgrade CTA (keyless) instead of to a degraded generic answer.

## Note
Confirmed against OpenBB docs that there is **no** suggested-prompts / `prompts.json` prompt-library feature for copilot agents, so the description is the only routing lever available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)