### PR TITLE
chore(chat): stop advertising gpt-4o-mini as the default model

### DIFF
--- a/lib/agent/capabilities.ts
+++ b/lib/agent/capabilities.ts
@@ -282,7 +282,7 @@ export const CAPABILITIES: Capability[] = [
         type: "string",
         required: false,
         description: "AI model to use",
-        default: "gpt-4o-mini",
+        default: "kimi-k2.5",
       },
       response_mode: {
         type: "string",

--- a/lib/api-reference-data.ts
+++ b/lib/api-reference-data.ts
@@ -310,7 +310,7 @@ export const ENDPOINT_GROUPS: EndpointGroup[] = [
         requestBody: {
           contentType: 'application/json',
           example: JSON.stringify(
-            { messages: [{ role: 'user', content: 'What is NVDA exposure to tech sector?' }], model: 'gpt-4o-mini' },
+            { messages: [{ role: 'user', content: 'What is NVDA exposure to tech sector?' }], model: 'kimi-k2.5' },
             null,
             2
           ),


### PR DESCRIPTION
## What
Changes the advertised default chat model from `gpt-4o-mini` to `kimi-k2.5` in two docs/discovery spots:
- `lib/agent/capabilities.ts` — chat capability schema `model.default`
- `lib/api-reference-data.ts` — the API-reference example request body

## Why
The runtime resolver (`lib/chat/llm-backend.ts:resolveAgentBackend`) already defaults to **Moonshot/Kimi** when `MOONSHOT_API_KEY` is set (it is, in prod), then Claude, with OpenAI only as the last resort. The two advertised `gpt-4o-mini` defaults were stale and misleading (and pointed at the out-of-quota OpenAI key). This makes docs/discovery match actual behavior.

## Deliberately NOT changed
The `llm-backend.ts` final fallback that returns `gpt-4o-mini` stays. That branch is only reached when **neither** Moonshot nor Anthropic keys are configured — i.e. OpenAI is the *only* backend — so `gpt-4o-mini` is correct there. OpenAI is already ranked last (Moonshot → Claude → OpenAI); there is no silent OpenAI default to remove, and an explicitly-requested OpenAI model still routes correctly.

## Risk
Cosmetic — no runtime behavior change. Just honest defaults in the schema + example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)