### PR TITLE
feat(13f): D.8.39 bi-temporal body stamps + as_of knowledge-mode on filer holdings/portfolio

### DIFF
--- a/OPENAPI_SPEC.yaml
+++ b/OPENAPI_SPEC.yaml
@@ -9153,11 +9153,18 @@ paths:
     get:
       summary: 13F filer top holdings
       description: >
-        Top-N current holdings at the filer's latest teo. Reads per-filer
-        ds_ph.zarr from GCS. Each holding carries `security_id` (post-
-        D.8.1 = bw_sym_id; pre-migration = a raw 9-char security
-        identifier), `adj_mv`, and `weight` (fraction of total
-        in-portfolio AUM).
+        Top-N holdings at the filer's latest teo — or, with `as_of`, at the
+        latest quarter *known* by that date (knowledge mode: selection on
+        `filing_date <= as_of`; falls back to `report_date <= as_of` on
+        panels without per-quarter filing dates, with the basis echoed as
+        `as_of_basis`). Reads per-filer ds_ph.zarr from GCS. Each holding
+        carries `security_id` (post-D.8.1 = bw_sym_id; pre-migration = a
+        raw 9-char security identifier), `adj_mv`, and `weight` (fraction
+        of total in-portfolio AUM). Bi-temporal stamps are body fields —
+        `report_date` (valid time, = teo) and `filing_date` (knowledge
+        time, EDGAR date_filed of the surviving submission; null until the
+        per-quarter data fill lands) — mirrored on the X-Data-As-Of /
+        X-Data-Filing-Date headers.
       operationId: getFilerHoldings
       tags:
         - 13F Filers
@@ -9179,9 +9186,20 @@ paths:
             type: integer
             default: 25
             maximum: 1000
+        - name: as_of
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date
+          description: >
+            Knowledge-mode date: serve the latest quarter whose filing was
+            public on or before this date. 404 when nothing was known yet.
       responses:
         "200":
-          description: Top-N holdings at the latest teo.
+          description: >
+            Top-N holdings at the selected teo, with `report_date`,
+            `filing_date`, and (under `as_of`) `as_of_basis`.
           content:
             application/json:
               schema:
@@ -9209,6 +9227,11 @@ paths:
         One row per teo (quarter-end) with diagnostics, AUM, ERM3 coverage,
         and portfolio style attribution. Return components are NULL until
         D.8 Phase 2 (the security-master ↔ ERM3 attribution bridge).
+        Each row carries its `filing_date` (knowledge-time stamp; null
+        until the per-quarter data fill lands). `as_of` filters to rows
+        known by that date (`filing_date <= as_of`, falling back to
+        `teo <= as_of` on panels without filing dates; basis echoed as
+        `as_of_basis`).
       operationId: getFilerPortfolioHistory
       tags:
         - 13F Filers
@@ -9235,9 +9258,18 @@ paths:
           schema:
             type: string
             format: date
+        - name: as_of
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date
+          description: >
+            Knowledge-mode date: keep only quarters whose filings were
+            public on or before this date. 404 when nothing was known yet.
       responses:
         "200":
-          description: Portfolio history rows.
+          description: Portfolio history rows (each with `filing_date`).
           content:
             application/json:
               schema:

--- a/app/api/13f/filers/[bw_filer_id]/holdings/route.ts
+++ b/app/api/13f/filers/[bw_filer_id]/holdings/route.ts
@@ -8,16 +8,25 @@ export const dynamic = "force-dynamic";
 
 const DEFAULT_TOP_N = 25;
 const MAX_TOP_N = 1000;
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
 
 /**
- * GET /api/13f/filers/{bw_filer_id}/holdings?limit=25
+ * GET /api/13f/filers/{bw_filer_id}/holdings?limit=25&as_of=YYYY-MM-DD
  *
- * Top-N current holdings at the filer's latest teo. Reads per-filer
- * ds_ph.zarr from GCS. Each holding carries `security_id` (post-D.8.1 =
- * bw_sym_id; pre-migration = a raw 9-char security identifier), `adj_mv`,
- * `weight` (fraction of total in-portfolio AUM), and — when resolvable
- * from the registry — display labels (`ticker`, `name`) plus latest L3
- * explained-risk shares (same enrichment as the snapshot endpoint).
+ * Top-N holdings at the filer's latest teo — or, with `as_of`, at the
+ * latest quarter *known* by that date (D.8.39 knowledge mode: selection on
+ * `filing_date <= as_of`; falls back to `report_date <= as_of` on zarrs
+ * without per-teo filing dates, with the basis echoed as `as_of_basis`).
+ * Reads per-filer ds_ph.zarr from GCS. Each holding carries `security_id`
+ * (post-D.8.1 = bw_sym_id; pre-migration = a raw 9-char security
+ * identifier), `adj_mv`, `weight` (fraction of total in-portfolio AUM),
+ * and — when resolvable from the registry — display labels (`ticker`,
+ * `name`) plus latest L3 explained-risk shares (same enrichment as the
+ * snapshot endpoint).
+ *
+ * Bi-temporal stamps are body fields (`report_date`, `filing_date`) so
+ * SDK/MCP consumers see them, mirrored on the X-Data-As-Of /
+ * X-Data-Filing-Date headers.
  *
  * Default `limit = 25`; caller can request up to 1000.
  */
@@ -45,26 +54,39 @@ export const GET = withBilling(
       limit = Math.min(Math.floor(parsed), MAX_TOP_N);
     }
 
+    const asOf = request.nextUrl.searchParams.get("as_of") ?? undefined;
+    if (asOf && !ISO_DATE.test(asOf)) {
+      return NextResponse.json(
+        { error: "as_of must be YYYY-MM-DD" },
+        { status: 400 },
+      );
+    }
+
     const filer = await fetchFiler(bwFilerId);
     if (!filer) {
       return NextResponse.json({ error: "Filer not found" }, { status: 404 });
     }
 
     const snapshot = await enrichFilerHoldingsWithL3(
-      await readFilerHoldingsTopN(bwFilerId, limit),
+      await readFilerHoldingsTopN(bwFilerId, limit, asOf),
     );
     if (!snapshot) {
       return NextResponse.json(
         {
-          error: "No holdings panel available for this filer",
+          error: asOf
+            ? "No holdings were known for this filer as of the requested date"
+            : "No holdings panel available for this filer",
           bw_filer_id: bwFilerId,
+          ...(asOf ? { as_of: asOf } : {}),
         },
         { status: 404 },
       );
     }
 
     const headers = new Headers({ "X-Data-As-Of": snapshot.teo });
-    if (filer.latest_filing_date) {
+    if (snapshot.filing_date) {
+      headers.set("X-Data-Filing-Date", snapshot.filing_date);
+    } else if (filer.latest_filing_date) {
       headers.set("X-Data-Filing-Date", filer.latest_filing_date);
     }
 
@@ -75,6 +97,7 @@ export const GET = withBilling(
         name: filer.name,
         filer_type: filer.filer_type,
         aum_tier: filer.aum_tier,
+        ...(asOf ? { as_of: asOf } : {}),
         ...snapshot,
       },
       { headers },

--- a/app/api/13f/filers/[bw_filer_id]/portfolio/route.ts
+++ b/app/api/13f/filers/[bw_filer_id]/portfolio/route.ts
@@ -8,13 +8,18 @@ export const dynamic = "force-dynamic";
 const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
 
 /**
- * GET /api/13f/filers/{bw_filer_id}/portfolio?start_date=YYYY-MM-DD&end_date=YYYY-MM-DD
+ * GET /api/13f/filers/{bw_filer_id}/portfolio?start_date=YYYY-MM-DD&end_date=YYYY-MM-DD&as_of=YYYY-MM-DD
  *
  * Per-filer portfolio time series from per-filer ds_portfolio.zarr on GCS.
  * Returns one row per teo (quarter-end) with diagnostics (weight_sum,
  * n_holdings_active, effective_n, top10_weight_sum), AUM (total_aum_usd,
  * aum_in_erm3), ERM3 coverage diagnostics, and portfolio style attribution
  * fields. Return components are NULL until D.8 Phase 2.
+ *
+ * D.8.39: each row carries its `filing_date` (knowledge-time stamp; null on
+ * pre-1.4-schema zarrs). `as_of` filters to rows *known* by that date —
+ * `filing_date <= as_of` when per-teo filing dates exist, else
+ * `teo <= as_of` (basis echoed as `as_of_basis`).
  *
  * Date params are inclusive and optional.
  */
@@ -51,26 +56,51 @@ export const GET = withBilling(
       );
     }
 
+    const asOf = searchParams.get("as_of") ?? undefined;
+    if (asOf && !ISO_DATE.test(asOf)) {
+      return NextResponse.json(
+        { error: "as_of must be YYYY-MM-DD" },
+        { status: 400 },
+      );
+    }
+
     const filer = await fetchFiler(bwFilerId);
     if (!filer) {
       return NextResponse.json({ error: "Filer not found" }, { status: 404 });
     }
 
-    const rows = await readFilerPortfolioSeries(bwFilerId, { startDate, endDate });
+    let rows = await readFilerPortfolioSeries(bwFilerId, { startDate, endDate });
+
+    // D.8.39 knowledge mode: keep rows known by as_of. Basis is per-panel —
+    // filing_date when the zarr carries it, report_date (teo) otherwise.
+    let asOfBasis: "filing_date" | "report_date" | undefined;
+    if (asOf && rows.length > 0) {
+      const hasFilingDates = rows.some((r) => r.filing_date != null);
+      asOfBasis = hasFilingDates ? "filing_date" : "report_date";
+      rows = hasFilingDates
+        ? rows.filter((r) => r.filing_date != null && r.filing_date <= asOf)
+        : rows.filter((r) => r.teo <= asOf);
+    }
     if (rows.length === 0) {
       return NextResponse.json(
         {
-          error: "No portfolio history available for this filer",
+          error: asOf
+            ? "No portfolio history was known for this filer as of the requested date"
+            : "No portfolio history available for this filer",
           bw_filer_id: bwFilerId,
+          ...(asOf ? { as_of: asOf } : {}),
         },
         { status: 404 },
       );
     }
 
+    const lastRow = rows[rows.length - 1]!;
     const headers = new Headers({
-      "X-Data-As-Of": rows[rows.length - 1]!.teo,
+      "X-Data-As-Of": lastRow.teo,
     });
-    if (filer.latest_filing_date) {
+    if (lastRow.filing_date) {
+      headers.set("X-Data-Filing-Date", lastRow.filing_date);
+    } else if (!asOf && filer.latest_filing_date) {
       headers.set("X-Data-Filing-Date", filer.latest_filing_date);
     }
 
@@ -81,9 +111,10 @@ export const GET = withBilling(
         name: filer.name,
         filer_type: filer.filer_type,
         aum_tier: filer.aum_tier,
+        ...(asOf ? { as_of: asOf, as_of_basis: asOfBasis } : {}),
         n_periods: rows.length,
         start_teo: rows[0]!.teo,
-        end_teo: rows[rows.length - 1]!.teo,
+        end_teo: lastRow.teo,
         rows,
       },
       { headers },

--- a/lib/dal/funds-zarr-reader.ts
+++ b/lib/dal/funds-zarr-reader.ts
@@ -1187,6 +1187,21 @@ export interface FilerHolding {
 
 export interface FilerHoldingsSnapshot {
   teo: string;
+  /** Valid-time stamp (D.8.39): the 13F reporting period end. Equal to `teo`. */
+  report_date: string;
+  /**
+   * Knowledge-time stamp (D.8.39): EDGAR date_filed of the surviving
+   * (latest-filed) submission for this report_date. Null on pre-1.4-schema
+   * zarrs that don't carry the `filing_date` var yet.
+   */
+  filing_date: string | null;
+  /**
+   * Which time axis resolved an `as_of` selection: `filing_date` (knowledge
+   * mode — what was public by that date) or `report_date` (fallback when the
+   * zarr has no filing_date var; overstates what was knowable by up to the
+   * statutory 13F lag).
+   */
+  as_of_basis: "filing_date" | "report_date";
   total_aum_usd: number | null;
   /** Sum of `adj_mv` over the in-ERM3 mapped subset; null pre-D.8.1. */
   aum_in_erm3: number | null;
@@ -1196,8 +1211,11 @@ export interface FilerHoldingsSnapshot {
 }
 
 /**
- * Top-N current holdings at the latest teo for a 13F filer. Default n=25.
- * Returns null when the filer has no zarr or no positive holdings.
+ * Top-N holdings for a 13F filer. Default n=25 at the latest teo. With
+ * `asOf`, selects the latest quarter *known* by that date — filing_date <=
+ * asOf when the zarr carries per-teo filing dates, else report_date <= asOf
+ * (the basis used is surfaced on the snapshot). Returns null when the filer
+ * has no zarr, no positive holdings, or nothing was known by `asOf`.
  *
  * Symmetric to `readFundHoldingsTopN` but reads `bw_filer_id/...` and
  * surfaces the security id under `security_id` (since pre-D.8.1 it may be
@@ -1206,15 +1224,18 @@ export interface FilerHoldingsSnapshot {
 export async function readFilerHoldingsTopN(
   bwFilerId: string,
   n = 25,
+  asOf?: string,
 ): Promise<FilerHoldingsSnapshot | null> {
   const safeN = Math.min(Math.max(n, 1), 1000);
   const ck = generateCacheKey("funds_zarr", "filer_holdings_top", {
     filer: bwFilerId,
     n: safeN,
+    as_of: asOf ?? "",
+    v: 2, // D.8.39 snapshot shape (report_date/filing_date/as_of_basis)
   });
   const snapshot = await withZarrCache(
     ck,
-    () => computeFilerHoldingsTopN(bwFilerId, safeN),
+    () => computeFilerHoldingsTopN(bwFilerId, safeN, asOf),
     { emptyValue: null },
   );
   if (!snapshot) return null;
@@ -1228,6 +1249,7 @@ export async function readFilerHoldingsTopN(
 async function computeFilerHoldingsTopN(
   bwFilerId: string,
   safeN: number,
+  asOf?: string,
 ): Promise<FilerHoldingsSnapshot | null> {
   const grp = await openFilerZarrGroup(bwFilerId, "ds_ph.zarr");
   if (!grp) return null;
@@ -1238,7 +1260,27 @@ async function computeFilerHoldingsTopN(
   const symbols = await readSymbolStrings(grp);
   if (!symbols || symbols.length === 0) return null;
 
-  const teoIdx = teos.length - 1;
+  // D.8.39: per-teo knowledge-time stamps. Absent on pre-1.4-schema zarrs.
+  const filingDates = await readDatetimeVarStrings(grp, "filing_date");
+  const asOfBasis: FilerHoldingsSnapshot["as_of_basis"] = filingDates
+    ? "filing_date"
+    : "report_date";
+
+  let teoIdx = teos.length - 1;
+  if (asOf) {
+    // Latest quarter known by `asOf`: walk back from the newest teo so an
+    // out-of-order amendment date on an older quarter can't shadow a
+    // regularly-filed newer one.
+    teoIdx = -1;
+    for (let i = teos.length - 1; i >= 0; i--) {
+      const known = filingDates ? filingDates[i] : teos[i];
+      if (known != null && known <= asOf) {
+        teoIdx = i;
+        break;
+      }
+    }
+    if (teoIdx < 0) return null;
+  }
   const teo = teos[teoIdx]!;
 
   // total_aum_usd may not exist on filer ds_ph — readScalarAtTeo returns null on missing var.
@@ -1275,6 +1317,9 @@ async function computeFilerHoldingsTopN(
 
   return {
     teo,
+    report_date: teo,
+    filing_date: filingDates?.[teoIdx] ?? null,
+    as_of_basis: asOfBasis,
     total_aum_usd: totalAumUsd,
     aum_in_erm3: aumInErm3,
     n_holdings_returned: Math.min(safeN, holdings.length),
@@ -1290,6 +1335,11 @@ async function computeFilerHoldingsTopN(
  */
 export interface FilerPortfolioRow {
   teo: string;
+  /**
+   * Knowledge-time stamp (D.8.39): EDGAR date_filed of the surviving
+   * submission for this quarter. Null on pre-1.4-schema zarrs.
+   */
+  filing_date: string | null;
   // Diagnostics (parallel to fund-side)
   weight_sum: number | null;
   n_holdings_active: number | null;
@@ -1352,6 +1402,7 @@ export async function readFilerPortfolioSeries(
     filer: bwFilerId,
     start: options.startDate ?? "",
     end: options.endDate ?? "",
+    v: 2, // D.8.39 row shape (filing_date)
   });
   return withZarrCache(ck, () => computeFilerPortfolioSeries(bwFilerId, options), {
     emptyValue: [],
@@ -1378,16 +1429,23 @@ async function computeFilerPortfolioSeries(
   }
   if (t0 >= t1) return [];
 
-  const series = await Promise.all(
-    FILER_PORTFOLIO_VARS.map(async (varName) => ({
-      name: varName,
-      data: await readFloatSlice1d(grp, varName, t0, t1),
-    })),
-  );
+  const [series, filingDates] = await Promise.all([
+    Promise.all(
+      FILER_PORTFOLIO_VARS.map(async (varName) => ({
+        name: varName,
+        data: await readFloatSlice1d(grp, varName, t0, t1),
+      })),
+    ),
+    // D.8.39: per-teo knowledge-time stamps. Absent on pre-1.4-schema zarrs.
+    readDatetimeVarStrings(grp, "filing_date"),
+  ]);
 
   const rows: FilerPortfolioRow[] = [];
   for (let i = 0; i < t1 - t0; i++) {
-    const row: Record<string, unknown> = { teo: teos[t0 + i]! };
+    const row: Record<string, unknown> = {
+      teo: teos[t0 + i]!,
+      filing_date: filingDates?.[t0 + i] ?? null,
+    };
     for (const s of series) {
       row[s.name] = s.data?.[i] ?? null;
     }

--- a/mcp/data/openapi.json
+++ b/mcp/data/openapi.json
@@ -13900,7 +13900,7 @@
     "/13f/filers/{bw_filer_id}/holdings": {
       "get": {
         "summary": "13F filer top holdings",
-        "description": "Top-N current holdings at the filer's latest teo. Reads per-filer ds_ph.zarr from GCS. Each holding carries `security_id` (post- D.8.1 = bw_sym_id; pre-migration = a raw 9-char security identifier), `adj_mv`, and `weight` (fraction of total in-portfolio AUM).\n",
+        "description": "Top-N holdings at the filer's latest teo — or, with `as_of`, at the latest quarter *known* by that date (knowledge mode: selection on `filing_date <= as_of`; falls back to `report_date <= as_of` on panels without per-quarter filing dates, with the basis echoed as `as_of_basis`). Reads per-filer ds_ph.zarr from GCS. Each holding carries `security_id` (post-D.8.1 = bw_sym_id; pre-migration = a raw 9-char security identifier), `adj_mv`, and `weight` (fraction of total in-portfolio AUM). Bi-temporal stamps are body fields — `report_date` (valid time, = teo) and `filing_date` (knowledge time, EDGAR date_filed of the surviving submission; null until the per-quarter data fill lands) — mirrored on the X-Data-As-Of / X-Data-Filing-Date headers.\n",
         "operationId": "getFilerHoldings",
         "tags": [
           "13F Filers"
@@ -13929,11 +13929,21 @@
               "default": 25,
               "maximum": 1000
             }
+          },
+          {
+            "name": "as_of",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date"
+            },
+            "description": "Knowledge-mode date: serve the latest quarter whose filing was public on or before this date. 404 when nothing was known yet.\n"
           }
         ],
         "responses": {
           "200": {
-            "description": "Top-N holdings at the latest teo.",
+            "description": "Top-N holdings at the selected teo, with `report_date`, `filing_date`, and (under `as_of`) `as_of_basis`.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -13971,7 +13981,7 @@
     "/13f/filers/{bw_filer_id}/portfolio": {
       "get": {
         "summary": "13F filer portfolio history",
-        "description": "Per-filer portfolio time series from per-filer ds_portfolio.zarr. One row per teo (quarter-end) with diagnostics, AUM, ERM3 coverage, and portfolio style attribution. Return components are NULL until D.8 Phase 2 (the security-master ↔ ERM3 attribution bridge).\n",
+        "description": "Per-filer portfolio time series from per-filer ds_portfolio.zarr. One row per teo (quarter-end) with diagnostics, AUM, ERM3 coverage, and portfolio style attribution. Return components are NULL until D.8 Phase 2 (the security-master ↔ ERM3 attribution bridge). Each row carries its `filing_date` (knowledge-time stamp; null until the per-quarter data fill lands). `as_of` filters to rows known by that date (`filing_date <= as_of`, falling back to `teo <= as_of` on panels without filing dates; basis echoed as `as_of_basis`).\n",
         "operationId": "getFilerPortfolioHistory",
         "tags": [
           "13F Filers"
@@ -14008,11 +14018,21 @@
               "type": "string",
               "format": "date"
             }
+          },
+          {
+            "name": "as_of",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date"
+            },
+            "description": "Knowledge-mode date: keep only quarters whose filings were public on or before this date. 404 when nothing was known yet.\n"
           }
         ],
         "responses": {
           "200": {
-            "description": "Portfolio history rows.",
+            "description": "Portfolio history rows (each with `filing_date`).",
             "content": {
               "application/json": {
                 "schema": {

--- a/tests/filer-bitemporal-routes.test.ts
+++ b/tests/filer-bitemporal-routes.test.ts
@@ -1,0 +1,265 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest, type NextResponse } from "next/server";
+
+vi.mock("@/lib/agent/billing-middleware", () => ({
+  withBilling: <T extends (...args: unknown[]) => unknown>(handler: T) => handler,
+}));
+
+vi.mock("@/lib/dal/filers-engine", () => ({
+  fetchFiler: vi.fn(),
+}));
+
+vi.mock("@/lib/dal/funds-zarr-reader", () => ({
+  readFilerHoldingsTopN: vi.fn(),
+  readFilerPortfolioSeries: vi.fn(),
+}));
+
+vi.mock("@/lib/13f/enrich-filer-holdings", () => ({
+  // Pass-through: enrichment must preserve the D.8.39 bitemporal fields.
+  enrichFilerHoldingsWithL3: vi.fn(async (snap: unknown) => snap),
+}));
+
+import { fetchFiler } from "@/lib/dal/filers-engine";
+import {
+  readFilerHoldingsTopN,
+  readFilerPortfolioSeries,
+  type FilerPortfolioRow,
+} from "@/lib/dal/funds-zarr-reader";
+import type { BillingContext } from "@/lib/agent/billing-middleware";
+import { GET as holdingsGETWrapped } from "@/app/api/13f/filers/[bw_filer_id]/holdings/route";
+import { GET as portfolioGETWrapped } from "@/app/api/13f/filers/[bw_filer_id]/portfolio/route";
+
+type RouteGET = (
+  req: NextRequest,
+  ctx: BillingContext,
+) => Promise<NextResponse>;
+const holdingsGET = holdingsGETWrapped as unknown as RouteGET;
+const portfolioGET = portfolioGETWrapped as unknown as RouteGET;
+
+const FILER = {
+  bw_filer_id: "BW-FILER-X",
+  cik: "0000123456",
+  name: "Test Capital LP",
+  filer_type: "hedge_fund",
+  filer_subtype: null,
+  aum_tier: "large",
+  style_label: null,
+  country: "US",
+  status: "active",
+  n_funds_managed: null,
+  latest_report_date: "2026-03-31",
+  latest_filing_date: "2026-05-14",
+  latest_extracted_at: null,
+  latest_aum_usd: 1_000_000_000,
+};
+
+const HOLDINGS_SNAPSHOT = {
+  teo: "2026-03-31",
+  report_date: "2026-03-31",
+  filing_date: "2026-05-14",
+  as_of_basis: "filing_date" as const,
+  total_aum_usd: 1_000_000_000,
+  aum_in_erm3: 900_000_000,
+  n_holdings_returned: 2,
+  n_total_holdings: 42,
+  holdings: [
+    { security_id: "BW-A", adj_mv: 600_000_000, weight: 0.6 },
+    { security_id: "BW-B", adj_mv: 400_000_000, weight: 0.4 },
+  ],
+};
+
+function portfolioRow(
+  teo: string,
+  filing_date: string | null,
+): FilerPortfolioRow {
+  return {
+    teo,
+    filing_date,
+    weight_sum: 1,
+    n_holdings_active: 42,
+    effective_n: 10,
+    top5_weight_sum: 0.5,
+    top10_weight_sum: 0.7,
+    weight_hhi: 0.1,
+    total_aum_usd: 1_000_000_000,
+    aum_in_erm3: 900_000_000,
+    n_holdings_in_erm3: 40,
+    effective_n_in_erm3: 9,
+    coverage_in_erm3: 0.9,
+    portfolio_style_hhi: null,
+    effective_n_styles: null,
+    portfolio_gross_return: null,
+    portfolio_market_return: null,
+    portfolio_sector_return: null,
+    portfolio_subsector_return: null,
+    portfolio_idiosyncratic_return: null,
+    identity_residual: null,
+  };
+}
+
+const fakeContext: BillingContext = {
+  userId: "test-user",
+  requestId: "test-req",
+  capabilityId: "filer-holdings",
+  costUsd: 0.005,
+  startTime: Date.now(),
+} as BillingContext;
+
+function req(path: string): NextRequest {
+  return new NextRequest(new Request(`http://localhost${path}`));
+}
+
+beforeEach(() => {
+  vi.mocked(fetchFiler).mockReset();
+  vi.mocked(readFilerHoldingsTopN).mockReset();
+  vi.mocked(readFilerPortfolioSeries).mockReset();
+});
+
+describe("GET /api/13f/filers/[bw_filer_id]/holdings (D.8.39)", () => {
+  it("serves bitemporal stamps as body fields + headers", async () => {
+    vi.mocked(fetchFiler).mockResolvedValue(FILER as never);
+    vi.mocked(readFilerHoldingsTopN).mockResolvedValue(HOLDINGS_SNAPSHOT);
+
+    const res = await holdingsGET(
+      req("/api/13f/filers/BW-FILER-X/holdings"),
+      fakeContext,
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.report_date).toBe("2026-03-31");
+    expect(body.filing_date).toBe("2026-05-14");
+    expect(body.as_of).toBeUndefined();
+    expect(res.headers.get("X-Data-As-Of")).toBe("2026-03-31");
+    // Per-snapshot filing_date wins over the filer's latest_filing_date.
+    expect(res.headers.get("X-Data-Filing-Date")).toBe("2026-05-14");
+    expect(vi.mocked(readFilerHoldingsTopN)).toHaveBeenCalledWith(
+      "BW-FILER-X",
+      25,
+      undefined,
+    );
+  });
+
+  it("passes as_of through to the reader and echoes it", async () => {
+    vi.mocked(fetchFiler).mockResolvedValue(FILER as never);
+    vi.mocked(readFilerHoldingsTopN).mockResolvedValue({
+      ...HOLDINGS_SNAPSHOT,
+      teo: "2025-12-31",
+      report_date: "2025-12-31",
+      filing_date: "2026-02-13",
+    });
+
+    const res = await holdingsGET(
+      req("/api/13f/filers/BW-FILER-X/holdings?as_of=2026-03-01"),
+      fakeContext,
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.as_of).toBe("2026-03-01");
+    expect(body.as_of_basis).toBe("filing_date");
+    expect(body.report_date).toBe("2025-12-31");
+    expect(body.filing_date).toBe("2026-02-13");
+    expect(vi.mocked(readFilerHoldingsTopN)).toHaveBeenCalledWith(
+      "BW-FILER-X",
+      25,
+      "2026-03-01",
+    );
+  });
+
+  it("rejects malformed as_of with 400", async () => {
+    const res = await holdingsGET(
+      req("/api/13f/filers/BW-FILER-X/holdings?as_of=Q1-2026"),
+      fakeContext,
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("404s with an as_of-specific message when nothing was known", async () => {
+    vi.mocked(fetchFiler).mockResolvedValue(FILER as never);
+    vi.mocked(readFilerHoldingsTopN).mockResolvedValue(null);
+
+    const res = await holdingsGET(
+      req("/api/13f/filers/BW-FILER-X/holdings?as_of=2006-01-01"),
+      fakeContext,
+    );
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toMatch(/as of the requested date/);
+    expect(body.as_of).toBe("2006-01-01");
+  });
+});
+
+describe("GET /api/13f/filers/[bw_filer_id]/portfolio (D.8.39)", () => {
+  const ROWS = [
+    portfolioRow("2025-09-30", "2025-11-14"),
+    portfolioRow("2025-12-31", "2026-02-13"),
+    portfolioRow("2026-03-31", "2026-05-14"),
+  ];
+
+  it("rows carry filing_date; latest row drives X-Data-Filing-Date", async () => {
+    vi.mocked(fetchFiler).mockResolvedValue(FILER as never);
+    vi.mocked(readFilerPortfolioSeries).mockResolvedValue(ROWS);
+
+    const res = await portfolioGET(
+      req("/api/13f/filers/BW-FILER-X/portfolio"),
+      fakeContext,
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.rows).toHaveLength(3);
+    expect(body.rows[0].filing_date).toBe("2025-11-14");
+    expect(res.headers.get("X-Data-Filing-Date")).toBe("2026-05-14");
+  });
+
+  it("as_of filters knowledge-mode on filing_date", async () => {
+    vi.mocked(fetchFiler).mockResolvedValue(FILER as never);
+    vi.mocked(readFilerPortfolioSeries).mockResolvedValue(ROWS);
+
+    const res = await portfolioGET(
+      req("/api/13f/filers/BW-FILER-X/portfolio?as_of=2026-03-01"),
+      fakeContext,
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    // 2026-03-31 quarter was filed 2026-05-14 — not yet known on 2026-03-01.
+    expect(body.n_periods).toBe(2);
+    expect(body.end_teo).toBe("2025-12-31");
+    expect(body.as_of).toBe("2026-03-01");
+    expect(body.as_of_basis).toBe("filing_date");
+    expect(res.headers.get("X-Data-As-Of")).toBe("2025-12-31");
+    expect(res.headers.get("X-Data-Filing-Date")).toBe("2026-02-13");
+  });
+
+  it("falls back to report_date basis on pre-1.4 zarrs without filing dates", async () => {
+    vi.mocked(fetchFiler).mockResolvedValue(FILER as never);
+    vi.mocked(readFilerPortfolioSeries).mockResolvedValue(
+      ROWS.map((r) => ({ ...r, filing_date: null })),
+    );
+
+    const res = await portfolioGET(
+      req("/api/13f/filers/BW-FILER-X/portfolio?as_of=2026-01-15"),
+      fakeContext,
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.as_of_basis).toBe("report_date");
+    // teo <= as_of keeps 2025-09-30 and 2025-12-31.
+    expect(body.n_periods).toBe(2);
+    expect(body.end_teo).toBe("2025-12-31");
+    // No real knowledge-time stamp available for the served window: the
+    // filer-level latest_filing_date must NOT be substituted under as_of.
+    expect(res.headers.get("X-Data-Filing-Date")).toBeNull();
+  });
+
+  it("404s with an as_of-specific message when no rows were known", async () => {
+    vi.mocked(fetchFiler).mockResolvedValue(FILER as never);
+    vi.mocked(readFilerPortfolioSeries).mockResolvedValue(ROWS);
+
+    const res = await portfolioGET(
+      req("/api/13f/filers/BW-FILER-X/portfolio?as_of=2005-01-01"),
+      fakeContext,
+    );
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toMatch(/as of the requested date/);
+  });
+});


### PR DESCRIPTION
## Summary
- 13F filer `/holdings` + `/portfolio` now serve bi-temporal stamps as **body fields** (`report_date`, per-teo `filing_date`, `as_of_basis`) so SDK/MCP consumers see them — previously headers-only, latest-only
- `?as_of=` knowledge-mode on both: holdings returns the latest quarter **filed** by that date; portfolio filters history to what was public. Falls back to report_date basis on pre-1.4 zarrs, explicitly labeled — never a silent proxy
- 8 new route tests (`tests/filer-bitemporal-routes.test.ts`); suite 398/398; OpenAPI + mcp/data/openapi.json regenerated

## Data dependency
Paired producer PR in Funds_DAG (`feat/d839-filer-filing-date`) adds the `filing_date (teo,)` var (zarr schema 1.4). Until the filer zarrs re-materialize, `filing_date` reads null and `as_of` degrades to the labeled report_date basis — no schema change when data lands.

Backlog: D.8.39. Motivated by API-only consumers unable to build PIT 13F panels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)