### PR TITLE
feat(analytics): wire GA4 measurement tag on riskmodels.app

### DIFF
--- a/components/GoogleAdsTag.tsx
+++ b/components/GoogleAdsTag.tsx
@@ -1,12 +1,12 @@
-/** Google Ads tag (gtag.js) for riskmodels.app — paste before closing </head> */
-const GOOGLE_ADS_GTAG_ID = 'AW-18161098219';
+import { GA4_MEASUREMENT_ID, GOOGLE_ADS_GTAG_ID } from '@/lib/google-tags';
 
+/** Google tag (gtag.js): GA4 + Ads on riskmodels.app — last in <head> before </head>. */
 export function GoogleAdsTag() {
   return (
     <>
       <script
         async
-        src={`https://www.googletagmanager.com/gtag/js?id=${GOOGLE_ADS_GTAG_ID}`}
+        src={`https://www.googletagmanager.com/gtag/js?id=${GA4_MEASUREMENT_ID}`}
       />
       <script
         dangerouslySetInnerHTML={{
@@ -14,6 +14,7 @@ export function GoogleAdsTag() {
           window.dataLayer = window.dataLayer || [];
           function gtag(){dataLayer.push(arguments);}
           gtag('js', new Date());
+          gtag('config', '${GA4_MEASUREMENT_ID}');
           gtag('config', '${GOOGLE_ADS_GTAG_ID}');
         `,
         }}

--- a/components/posthog-provider.tsx
+++ b/components/posthog-provider.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, Suspense } from 'react';
 import { usePathname, useSearchParams } from 'next/navigation';
+import { trackGaPageView } from '@/lib/google-ads-conversion';
 import { initPostHog, trackPageView, resetUser } from '@/lib/posthog-client';
 
 function PostHogProviderInner({ children }: { children: React.ReactNode }) {
@@ -15,6 +16,7 @@ function PostHogProviderInner({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     if (pathname) {
       trackPageView(pathname);
+      trackGaPageView(pathname);
     }
   }, [pathname, searchParams]);
 

--- a/docs/GOOGLE_ADS_CONVERSIONS.md
+++ b/docs/GOOGLE_ADS_CONVERSIONS.md
@@ -1,7 +1,11 @@
 # Google Ads conversion tracking
 
 Account: **RiskModels.app** (Google Ads `849-116-0672`) · Google tag **`AW-18161098219`**
-(loaded site-wide by [`components/GoogleAdsTag.tsx`](../components/GoogleAdsTag.tsx)).
+· GA4 **`G-3Q4LR1QFWP`** (stream `RiskModels.app`) — both loaded site-wide by
+[`components/GoogleAdsTag.tsx`](../components/GoogleAdsTag.tsx) (IDs in
+[`lib/google-tags.ts`](../lib/google-tags.ts)). Client-side route changes send GA4
+`page_view` via [`trackGaPageView()`](../lib/google-ads-conversion.ts) in
+[`components/posthog-provider.tsx`](../components/posthog-provider.tsx).
 
 ## Phase 1 — Sign-up conversion (live)
 

--- a/lib/google-ads-conversion.ts
+++ b/lib/google-ads-conversion.ts
@@ -15,6 +15,7 @@
  */
 
 import type { User } from '@supabase/supabase-js';
+import { GA4_MEASUREMENT_ID } from '@/lib/google-tags';
 
 /** Sign-up conversion action — Google Ads → Goals → "Sign-up" (count: One, value: $1). */
 const SIGNUP_SEND_TO = 'AW-18161098219/Qn__CI297LocEOu78dND';
@@ -146,4 +147,11 @@ export function reportSignupConversion(user: User | null | undefined): void {
   // Mark only after we've actually handed the event to gtag, so a missing-gtag
   // early-return can still fire on a later call within the window.
   markSignupFired(user.id);
+}
+
+/** SPA route changes — GA4 enhanced measurement only covers the first load. */
+export function trackGaPageView(pagePath: string): void {
+  const gtag = getGtag();
+  if (!gtag) return;
+  gtag('config', GA4_MEASUREMENT_ID, { page_path: pagePath });
 }

--- a/lib/google-tags.ts
+++ b/lib/google-tags.ts
@@ -1,0 +1,3 @@
+/** Google tag IDs for riskmodels.app (public — embedded in client HTML). */
+export const GOOGLE_ADS_GTAG_ID = 'AW-18161098219';
+export const GA4_MEASUREMENT_ID = 'G-3Q4LR1QFWP';


### PR DESCRIPTION
## Summary
- Add GA4 measurement ID `G-3Q4LR1QFWP` to the existing Google tag (`AW-18161098219`) on riskmodels.app
- Centralize tag IDs in `lib/google-tags.ts`
- Send GA4 `page_path` updates on Next.js client-side route changes so click-flow / path explorations capture the full funnel (not just the first full page load)

## Test plan
- [ ] Deploy to Vercel preview or production
- [ ] Open GA4 → Admin → DebugView and browse riskmodels.app — confirm `page_view` events arrive
- [ ] Use Google Tag Assistant — confirm both `G-3Q4LR1QFWP` and `AW-18161098219` fire
- [ ] Navigate `/` → `/pricing` → `/get-key` without full reload — confirm page_path updates in DebugView
- [ ] Verify existing sign-up conversion still fires on new account creation (`reportSignupConversion`)


Made with [Cursor](https://cursor.com)