### PR TITLE
fix(analytics): load gtag.js via Ads ID so GA4 collects before stream provisions

### DIFF
--- a/components/GoogleAdsTag.tsx
+++ b/components/GoogleAdsTag.tsx
@@ -1,12 +1,16 @@
 import { GA4_MEASUREMENT_ID, GOOGLE_ADS_GTAG_ID } from '@/lib/google-tags';
 
-/** Google tag (gtag.js): GA4 + Ads on riskmodels.app — last in <head> before </head>. */
+/** Google tag (gtag.js): GA4 + Ads on riskmodels.app — last in <head> before </head>.
+ *  Load the (universal) gtag.js runtime via the Ads ID, which is guaranteed to be
+ *  provisioned; a brand-new GA4 measurement ID can 404 on the loader for a while
+ *  after stream creation, which would block the whole runtime. Both destinations
+ *  are then activated via config() below. */
 export function GoogleAdsTag() {
   return (
     <>
       <script
         async
-        src={`https://www.googletagmanager.com/gtag/js?id=${GA4_MEASUREMENT_ID}`}
+        src={`https://www.googletagmanager.com/gtag/js?id=${GOOGLE_ADS_GTAG_ID}`}
       />
       <script
         dangerouslySetInnerHTML={{


### PR DESCRIPTION
## Problem
After #219 the gtag.js loader was pointed at the new GA4 measurement ID:
`https://www.googletagmanager.com/gtag/js?id=G-3Q4LR1QFWP`.

That URL currently **404s** (verified repeatedly) because the GA4 stream is brand new and Google has not finished provisioning its tag config. When the loader `<script>` 404s, the gtag runtime never initializes — so **neither GA4 nor the existing Ads tag sends data**. This is why GA4 Realtime/Reports showed nothing.

Verification:
```
gtag/js?id=G-3Q4LR1QFWP   -> 404   (new GA4 stream, not yet provisioned)
gtag/js?id=AW-18161098219 -> 200   (Ads tag, always live)
```

## Fix
Load the universal gtag.js runtime via the always-provisioned Ads ID, then activate **both** destinations via `config()`. The gtag.js library is the same regardless of which ID loads it, so `gtag('config','G-3Q4LR1QFWP')` still sends GA4 hits to `/g/collect`.

## Test plan
- [ ] Deploy to production
- [ ] `curl -sL https://riskmodels.app | grep gtag/js` shows loader uses `AW-18161098219`
- [ ] GA4 → Reports → Realtime shows an active user when browsing the site
- [ ] DevTools → Network → `collect` shows a request with `tid=G-3Q4LR1QFWP`
- [ ] Ads tag still fires (Tag Assistant shows both destinations)

Made with [Cursor](https://cursor.com)