### PR TITLE
chore(chat): drop the OpenAI backend — Moonshot (Kimi) is the only OpenAI-protocol backend

### DIFF
--- a/OPENAPI_SPEC.yaml
+++ b/OPENAPI_SPEC.yaml
@@ -7476,7 +7476,7 @@ paths:
         "502":
           description: Upstream AI provider error.
         "503":
-          description: Chat not configured (e.g. missing OPENAI_API_KEY).
+          description: Chat not configured (e.g. missing MOONSHOT_API_KEY).
 
   /pricing:
     get:

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -94,14 +94,14 @@ export const POST = withBilling(
     const origin = request.headers.get("origin");
 
     // At least one backend must be configured. The runner picks per-request
-    // based on the resolved model (claude-* → Anthropic, else OpenAI), so we
+    // based on the resolved model (claude-* → Anthropic, else Moonshot), so we
     // only hard-fail here if neither key is present.
     if (!hasChatBackend()) {
       return NextResponse.json(
         {
           error: "Service unavailable",
           message:
-            "AI chat is not configured (need MOONSHOT_API_KEY, ANTHROPIC_API_KEY, or OPENAI_API_KEY)",
+            "AI chat is not configured (need MOONSHOT_API_KEY or ANTHROPIC_API_KEY)",
         },
         { status: 503, headers: getCorsHeaders(origin) },
       );

--- a/app/api/landing/chat/route.ts
+++ b/app/api/landing/chat/route.ts
@@ -115,7 +115,7 @@ export async function POST(request: NextRequest) {
       {
         error: "Service unavailable",
         message:
-          "AI chat demo is not configured (need MOONSHOT_API_KEY, ANTHROPIC_API_KEY, or OPENAI_API_KEY).",
+          "AI chat demo is not configured (need MOONSHOT_API_KEY or ANTHROPIC_API_KEY).",
       },
       { status: 503, headers: corsHeaders },
     );

--- a/docs/CHAT_MANUAL_QA.md
+++ b/docs/CHAT_MANUAL_QA.md
@@ -6,7 +6,7 @@ For authentication patterns, see [AUTHENTICATION_GUIDE.md](../AUTHENTICATION_GUI
 
 ## Prerequisites
 
-1. **Server-side:** `OPENAI_API_KEY` must be set wherever the Next app runs (local `.env.local`, Vercel, etc.). If missing, chat returns **503** with a configuration message.
+1. **Server-side:** `MOONSHOT_API_KEY` (or `ANTHROPIC_API_KEY`) must be set wherever the Next app runs (local `.env.local`, Vercel, etc.). If missing, chat returns **503** with a configuration message.
 2. **Client-side:** A valid RiskModels **API key** or session JWT (`Authorization: Bearer …`). Keys are created after login at [riskmodels.app](https://riskmodels.app) (Account → Usage / API).
 3. **Balance:** Enough credits for at least one chat turn (LLM estimate + 1–2 tools). Typical NVDA smoke test: roughly a few thousandths of a dollar LLM + **metrics-snapshot** + **ticker-returns** (see preflight below).
 4. **Tier:** Chat uses capability `chat-risk-analyst` (premium per-token). Free-tier-only accounts may get **402** or tier limits from `withBilling`; that is expected until upgraded.
@@ -103,14 +103,14 @@ Run the same `curl` pattern; swap the user `content`:
 | **401** | Missing/invalid Bearer token. |
 | **402** | Insufficient balance (or payment required) on the **chat** pre-charge. |
 | **429** | Rate limit / free-tier limit (if applicable). |
-| **502** | OpenAI upstream error (bad key, outage, or bad model name). |
-| **503** | `OPENAI_API_KEY` not configured on the server. |
+| **502** | Upstream LLM error — Moonshot/Anthropic (bad key, outage, or bad model name). |
+| **503** | `MOONSHOT_API_KEY` (or `ANTHROPIC_API_KEY`) not configured on the server. |
 
 ## 6. Local dev quick check
 
 ```bash
 cd /path/to/RiskModels_API
-# Ensure OPENAI_API_KEY and Supabase/env match a working deployment
+# Ensure MOONSHOT_API_KEY and Supabase/env match a working deployment
 npm run dev
 ```
 

--- a/lib/chat/agent-runner.ts
+++ b/lib/chat/agent-runner.ts
@@ -90,10 +90,18 @@ export async function runChatAgent(
     preFlightGuard,
   } = opts;
 
-  if (!opts.openai && !process.env.OPENAI_API_KEY) {
-    throw new AgentUpstreamError("OPENAI_API_KEY is not configured");
+  // Moonshot (Kimi) is the only OpenAI-compatible backend; callers normally
+  // pass the client from resolveAgentBackend(), this is the direct-call fallback.
+  const moonshotKey = process.env.MOONSHOT_API_KEY?.trim();
+  if (!opts.openai && !moonshotKey) {
+    throw new AgentUpstreamError("MOONSHOT_API_KEY is not configured");
   }
-  const openai = opts.openai ?? new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+  const openai =
+    opts.openai ??
+    new OpenAI({
+      apiKey: moonshotKey,
+      baseURL: process.env.MOONSHOT_BASE_URL?.trim() || "https://api.moonshot.ai/v1",
+    });
 
   const tools: ChatCompletionTool[] = allowedToolNames
     ? CHAT_TOOLS.filter(

--- a/lib/chat/llm-backend.ts
+++ b/lib/chat/llm-backend.ts
@@ -3,19 +3,20 @@ import OpenAI from "openai";
 /**
  * Resolves which LLM backend the tool-calling chat agent should use.
  *
- * Moonshot (Kimi) is OpenAI-compatible and cheaper, so when MOONSHOT_API_KEY is
- * present it becomes the default backend for both the full analyst (/api/chat)
- * and the keyless MAG7 demo (/api/landing/chat). Billing to the end user is
- * unchanged — that's priced per RiskModels capability, not per upstream model —
- * so this only lowers our own inference cost.
+ * Moonshot (Kimi) replaced OpenAI entirely (2026-07-07, after the OpenAI quota
+ * exhaustion): it is OpenAI-compatible and cheaper, so it serves as the only
+ * OpenAI-protocol backend for both the full analyst (/api/chat) and the keyless
+ * MAG7 demo (/api/landing/chat). Billing to the end user is unchanged — that's
+ * priced per RiskModels capability, not per upstream model — so this only
+ * lowers our own inference cost.
  *
  * Precedence:
  *   1. An explicit `claude-*` requested model → Anthropic (runner dispatches on
  *      the `claude-` prefix; lets a specific caller force Claude).
  *   2. MOONSHOT_API_KEY set → Moonshot (Kimi), via an OpenAI client pointed at
- *      the Moonshot base URL.
- *   3. AGENT_BACKEND=claude → Claude default.
- *   4. else → OpenAI (requested model or gpt-4o-mini).
+ *      the Moonshot base URL. Non-Claude requested ids that aren't kimi/moonshot
+ *      models resolve to the default Kimi model (there is no OpenAI backend).
+ *   3. else → Claude default.
  *
  * Env (Doppler):
  *   MOONSHOT_API_KEY   — the Moonshot key (enables this backend when set)
@@ -40,51 +41,30 @@ export function resolveAgentBackend(requestedModel?: string): AgentBackend {
   }
 
   const moonshotKey = process.env.MOONSHOT_API_KEY?.trim();
-  const moonshotClient = moonshotKey
-    ? new OpenAI({
-        apiKey: moonshotKey,
-        baseURL: process.env.MOONSHOT_BASE_URL?.trim() || "https://api.moonshot.ai/v1",
-      })
-    : undefined;
-
-  // An explicit non-Claude model is honored: kimi/moonshot ids route through the
-  // Moonshot client (when configured); anything else through the default OpenAI.
-  if (req) {
-    const isKimi = /^(kimi|moonshot)/i.test(req);
+  if (moonshotKey) {
+    const moonshotClient = new OpenAI({
+      apiKey: moonshotKey,
+      baseURL: process.env.MOONSHOT_BASE_URL?.trim() || "https://api.moonshot.ai/v1",
+    });
+    const defaultModel = process.env.MOONSHOT_MODEL?.trim() || "kimi-k2.5";
+    // Honor explicit kimi/moonshot ids; anything else (legacy gpt-* callers)
+    // resolves to the default Kimi model — there is no OpenAI backend anymore.
+    const isKimi = req ? /^(kimi|moonshot)/i.test(req) : false;
     return {
-      model: req,
-      openai: isKimi ? moonshotClient : undefined,
-      allowParallel: !isKimi,
-      omitParallelToolCalls: isKimi,
-    };
-  }
-
-  // Default backend (no model requested):
-  //   Moonshot when configured → cheapest;
-  //   else Claude when its key is present (configured + working today);
-  //   else OpenAI.
-  if (moonshotClient) {
-    return {
-      model: process.env.MOONSHOT_MODEL?.trim() || "kimi-k2.5",
+      model: isKimi && req ? req : defaultModel,
       openai: moonshotClient,
       allowParallel: false,
       omitParallelToolCalls: true,
     };
   }
-  if (
-    process.env.AGENT_BACKEND?.toLowerCase() === "claude" ||
-    process.env.ANTHROPIC_API_KEY?.trim()
-  ) {
-    return { model: "claude-sonnet-4-6", allowParallel: true, omitParallelToolCalls: false };
-  }
-  return { model: "gpt-4o-mini", allowParallel: true, omitParallelToolCalls: false };
+
+  // No Moonshot key → Claude is the only remaining backend.
+  return { model: "claude-sonnet-4-6", allowParallel: true, omitParallelToolCalls: false };
 }
 
 /** True when any usable chat backend is configured. */
 export function hasChatBackend(): boolean {
   return Boolean(
-    process.env.MOONSHOT_API_KEY?.trim() ||
-      process.env.ANTHROPIC_API_KEY?.trim() ||
-      process.env.OPENAI_API_KEY?.trim(),
+    process.env.MOONSHOT_API_KEY?.trim() || process.env.ANTHROPIC_API_KEY?.trim(),
   );
 }


### PR DESCRIPTION
OPENAI_API_KEY is out of quota and no longer configured (flagged in E.21 2026-07-02). This removes every path that could still silently route to it.

- **llm-backend**: precedence is now `claude-*` → Anthropic; `MOONSHOT_API_KEY` set → Moonshot via the OpenAI-compatible client (legacy `gpt-*` requests resolve to the default Kimi model instead of erroring); else Claude. `hasChatBackend()` no longer counts `OPENAI_API_KEY`.
- **agent-runner**: the direct-call fallback builds a Moonshot client (`MOONSHOT_API_KEY` + base URL) instead of `new OpenAI({ apiKey: OPENAI_API_KEY })`, and the error message names the right variable.
- `/api/chat` + `/api/landing/chat` 503 messages, the OpenAPI spec's 503 description, and `docs/CHAT_MANUAL_QA.md` updated to name `MOONSHOT_API_KEY`.

No behavior change in the running deployment — `MOONSHOT_API_KEY` is set in Doppler, so both routes already resolve to kimi-k2.5; this removes the dead fallbacks. `OPENAI_API_KEY` can now be deleted from Doppler.

Built from `origin/main` in an isolated worktree — deliberately does not touch the in-flight fundamentals work (`app/api/fundamentals/`, `capabilities.ts`, `mcp/`) in the local checkout.

Verified: `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)