### PR TITLE
feat(h89.6): fundamentals SDK — client methods, AOM .with_fundamentals(), MCP tool, notebooks

### DIFF
--- a/OPENAPI_SPEC.yaml
+++ b/OPENAPI_SPEC.yaml
@@ -960,6 +960,12 @@ components:
               example: current_snapshot
             note:
               type: string
+        sensitivity_grid:
+          $ref: "#/components/schemas/FundamentalsSensitivityGrid"
+          nullable: true
+          description: >
+            Present only when the request set `grid=true`. Null (with a
+            `note`) when no PIT-visible period exists at `as_of`.
         disclosures:
           type: object
           additionalProperties: true
@@ -970,6 +976,51 @@ components:
         _metadata:
           type: object
           additionalProperties: true
+
+    FundamentalsSensitivityGrid:
+      type: object
+      description: >
+        Cost-of-capital sensitivity grid for the latest PIT-visible period
+        only — `cost_of_equity` / `wacc` / `economic_profit` recomputed
+        across every combination of `erp_values` x `rf_tenor_values`. Pure
+        derived analytics (same fields as `FundamentalsRow`'s cost-of-capital
+        layer), just parameterized instead of single-valued. `cells` is
+        row-major: `cells[i][j]` pairs `erp_values[i]` with `rf_tenor_values[j]`.
+      required:
+        - period_end_date
+        - erp_values
+        - rf_tenor_values
+        - tax_rate
+        - cells
+      properties:
+        period_end_date:
+          type: string
+          format: date
+        filed_date:
+          type: string
+          format: date
+          nullable: true
+        erp_values:
+          type: array
+          items: { type: number }
+        rf_tenor_values:
+          type: array
+          items:
+            type: string
+            enum: [3m, 1y, 2y, 5y, 10y, 30y]
+        tax_rate:
+          type: number
+        cells:
+          type: array
+          description: Row-major [erp_values.length][rf_tenor_values.length].
+          items:
+            type: array
+            items:
+              type: object
+              properties:
+                cost_of_equity: { type: number, nullable: true }
+                wacc: { type: number, nullable: true }
+                economic_profit: { type: number, nullable: true }
 
     MetricsSnapshotResponse:
       type: object
@@ -4019,6 +4070,38 @@ paths:
             Treasury constant-maturity tenor backing rf_rate. Default 10y (valuation
             convention). Pair a short tenor with a bill-basis ERP or cost of capital
             is understated.
+        - name: grid
+          in: query
+          required: false
+          schema:
+            type: boolean
+            default: false
+          description: >-
+            When true, the response also carries `sensitivity_grid` —
+            `cost_of_equity` / `wacc` / `economic_profit` across `erp_grid` x
+            `rf_tenor_grid` for the latest PIT-visible period only (not a time
+            series — a "what if my assumptions were different today" table).
+            Same billing as the base call; no extra cost.
+        - name: erp_grid
+          in: query
+          required: false
+          schema:
+            type: string
+          description: >-
+            Comma-separated ERP values for the sensitivity grid (1-10 values,
+            each in [0, 0.5]), e.g. `0.03,0.04,0.05,0.06,0.07`. Ignored unless
+            `grid=true`. Default: `0.03,0.04,0.05,0.06,0.07`.
+          example: "0.03,0.04,0.05,0.06,0.07"
+        - name: rf_tenor_grid
+          in: query
+          required: false
+          schema:
+            type: string
+          description: >-
+            Comma-separated subset of `3m,1y,2y,5y,10y,30y` for the
+            sensitivity grid. Ignored unless `grid=true`. Default: all six
+            tenors.
+          example: "1y,10y,30y"
       responses:
         "200":
           description: PIT quarterly fundamentals rows (derived analytics only).

--- a/app/api/fundamentals/[ticker]/route.ts
+++ b/app/api/fundamentals/[ticker]/route.ts
@@ -1,7 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getCorsHeaders } from "@/lib/cors";
 import { withBilling, BillingContext } from "@/lib/agent/billing-middleware";
-import { getFundamentalsForTicker } from "@/lib/dal/fundamentals-zarr-reader";
+import {
+  getFundamentalsForTicker,
+  getFundamentalsSensitivityGrid,
+  DEFAULT_ERP_GRID,
+  RF_TENORS,
+} from "@/lib/dal/fundamentals-zarr-reader";
 import {
   buildFundamentalsDisclosures,
   sanitizeFundamentalsRow,
@@ -61,6 +66,9 @@ export const GET = withBilling(
       erp: sp.get("erp") ?? undefined,
       tax_rate: sp.get("tax_rate") ?? undefined,
       rf_tenor: sp.get("rf_tenor") ?? undefined,
+      grid: sp.get("grid") ?? undefined,
+      erp_grid: sp.get("erp_grid") ?? undefined,
+      rf_tenor_grid: sp.get("rf_tenor_grid") ?? undefined,
     });
     if (!validation.success) {
       return NextResponse.json(
@@ -72,18 +80,29 @@ export const GET = withBilling(
       );
     }
 
-    const { ticker, periods, erp, tax_rate, rf_tenor } = validation.data;
+    const { ticker, periods, erp, tax_rate, rf_tenor, grid, erp_grid, rf_tenor_grid } =
+      validation.data;
     const asOf = validation.data.as_of ?? new Date().toISOString().slice(0, 10);
 
     try {
       const fetchStart = performance.now();
-      const result = await getFundamentalsForTicker(ticker, {
-        asOf,
-        periods,
-        erp,
-        taxRate: tax_rate,
-        rfTenor: rf_tenor,
-      });
+      const [result, sensitivityGrid] = await Promise.all([
+        getFundamentalsForTicker(ticker, {
+          asOf,
+          periods,
+          erp,
+          taxRate: tax_rate,
+          rfTenor: rf_tenor,
+        }),
+        grid
+          ? getFundamentalsSensitivityGrid(ticker, {
+              asOf,
+              erpGrid: erp_grid ?? DEFAULT_ERP_GRID,
+              rfTenorGrid: rf_tenor_grid ?? RF_TENORS,
+              taxRate: tax_rate,
+            })
+          : Promise.resolve(null),
+      ]);
 
       if (!result) {
         const metadata = await getRiskMetadata();
@@ -115,6 +134,7 @@ export const GET = withBilling(
           basis: "current_snapshot",
           note: "Current market cap, not point-in-time per quarter.",
         },
+        ...(grid ? { sensitivity_grid: sensitivityGrid } : {}),
         disclosures: buildFundamentalsDisclosures({ erp, tax_rate, as_of: asOf, rf_tenor }),
         _metadata: buildMetadataBody(metadata),
       };

--- a/lib/api/schemas.ts
+++ b/lib/api/schemas.ts
@@ -74,6 +74,25 @@ export const FundamentalsRequestSchema = z.object({
   // rf_3m..rf_30y). Default 10y = the valuation convention; a caller selecting
   // a short tenor should pair a bill-basis ERP or cost of capital is understated.
   rf_tenor: z.enum(["3m", "1y", "2y", "5y", "10y", "30y"]).default("10y"),
+  // Sensitivity-grid variant (H.89.6): when true, the response also carries
+  // `sensitivity_grid` — cost_of_equity/wacc/economic_profit across
+  // erp_grid x rf_tenor_grid for the latest PIT-visible period only. Cheap:
+  // the six-tenor rf strip is already read into the pack for the single-row
+  // `rf_tenor` lookup, so the grid is pure computation, no extra I/O.
+  grid: z.coerce.boolean().default(false),
+  erp_grid: z
+    .string()
+    .transform((s) => s.split(",").map((v) => Number(v.trim())))
+    .refine(
+      (arr) => arr.length >= 1 && arr.length <= 10 && arr.every((v) => Number.isFinite(v) && v >= 0 && v <= 0.5),
+      "erp_grid must be 1-10 comma-separated numbers in [0, 0.5]",
+    )
+    .optional(),
+  rf_tenor_grid: z
+    .string()
+    .transform((s) => s.split(",").map((v) => v.trim()))
+    .pipe(z.array(z.enum(["3m", "1y", "2y", "5y", "10y", "30y"])).min(1).max(6))
+    .optional(),
 });
 
 /**

--- a/lib/dal/fundamentals-zarr-reader.ts
+++ b/lib/dal/fundamentals-zarr-reader.ts
@@ -323,6 +323,82 @@ export function buildFundamentalsRows(
   return out;
 }
 
+// ── Sensitivity grid (H.89.6) — erp × rf_tenor cost-of-capital grid ─────────
+
+/** Canonical erp grid: brackets the 0.05 suggested default without editorializing. */
+export const DEFAULT_ERP_GRID: readonly number[] = [0.03, 0.04, 0.05, 0.06, 0.07];
+
+export interface SensitivityGridCell {
+  cost_of_equity: number | null;
+  wacc: number | null;
+  economic_profit: number | null;
+}
+
+export interface SensitivityGrid {
+  period_end_date: string;
+  filed_date: string | null;
+  erp_values: number[];
+  rf_tenor_values: RfTenor[];
+  tax_rate: number;
+  /** [erp_idx][tenor_idx], row-major over erp_values × rf_tenor_values. */
+  cells: SensitivityGridCell[][];
+}
+
+/**
+ * Cost-of-capital sensitivity grid for the latest PIT-visible period only
+ * (grid across all historical periods would be unbounded cost for no
+ * incremental use case — sensitivity is a "what if my assumptions were
+ * different today" tool, not a time series). Reuses the same TTM window
+ * inputs as `buildFundamentalsRows`'s last row and the already-loaded
+ * `rfCurve` strip (all six tenors are read into the pack regardless of the
+ * caller's single-row `rf_tenor`, so this is pure computation — no extra I/O).
+ * Returns null when no PIT-visible period exists.
+ */
+export function buildSensitivityGrid(
+  pack: FundamentalsRowPack,
+  opts: {
+    asOf: string;
+    erpGrid: readonly number[];
+    rfTenorGrid: readonly RfTenor[];
+    taxRate: number;
+  },
+): SensitivityGrid | null {
+  const visible = selectPitIndices(pack, opts.asOf);
+  if (visible.length === 0) return null;
+  const p = visible.length - 1;
+  const i = visible[p]!;
+  const windowPos = visible.slice(Math.max(0, p - (TTM_WINDOW_QUARTERS - 1)), p + 1);
+  const windowVals = (name: PackVar, positions: number[]): (number | null)[] =>
+    positions.map((pos) => pack.vars[name][pos] ?? null);
+
+  const niTtm = ttmSum(windowVals("net_income", windowPos));
+  const ieTtm = ttmSum(windowVals("interest_expense", windowPos));
+  const eqAvg = ttmAvg(windowVals("total_equity", windowPos));
+  const eqLast = latestFinite(windowVals("total_equity", windowPos));
+  const debtLast = latestFinite(windowVals("total_debt", windowPos));
+  const bm = pack.vars.beta_market[i] ?? NaN;
+
+  const cells: SensitivityGridCell[][] = opts.erpGrid.map((erp) =>
+    opts.rfTenorGrid.map((tenor) => {
+      const rf = pack.rfCurve[tenor]?.[i] ?? NaN;
+      return {
+        cost_of_equity: toNull(costOfEquity(rf, bm, erp)),
+        wacc: toNull(waccBookWeights(rf, bm, ieTtm, eqLast, debtLast, opts.taxRate, erp)),
+        economic_profit: toNull(economicProfit(niTtm, eqAvg, eqLast, rf, bm, erp)),
+      };
+    }),
+  );
+
+  return {
+    period_end_date: pack.periodEndDates[i]!,
+    filed_date: pack.filedDates[i] ?? null,
+    erp_values: [...opts.erpGrid],
+    rf_tenor_values: [...opts.rfTenorGrid],
+    tax_rate: opts.taxRate,
+    cells,
+  };
+}
+
 // ── GCS plumbing (per-store, mirroring lib/dal/funds-zarr-reader.ts) ────────
 
 let _storage: Storage | null = null;
@@ -627,4 +703,17 @@ export async function getFundamentalsForTicker(
   const pack = await readRowPackCached(ticker);
   if (!pack) return null;
   return { ticker: pack.ticker, rows: buildFundamentalsRows(pack, opts) };
+}
+
+/**
+ * Sensitivity-grid entry point — same cached row pack as `getFundamentalsForTicker`
+ * (Redis-cached, so calling both for one request costs a single cold read).
+ */
+export async function getFundamentalsSensitivityGrid(
+  ticker: string,
+  opts: { asOf: string; erpGrid: readonly number[]; rfTenorGrid: readonly RfTenor[]; taxRate: number },
+): Promise<SensitivityGrid | null> {
+  const pack = await readRowPackCached(ticker);
+  if (!pack) return null;
+  return buildSensitivityGrid(pack, opts);
 }

--- a/lib/mcp/tools/riskmodels-tools.ts
+++ b/lib/mcp/tools/riskmodels-tools.ts
@@ -644,6 +644,51 @@ export function registerRiskModelsTools(
   );
 
   server.registerTool(
+    "riskmodels_get_fundamentals",
+    {
+      title: "RiskModels PIT Quarterly Fundamentals",
+      annotations: { readOnlyHint: true },
+      description:
+        "PIT quarterly fundamentals, derived analytics only (GET /fundamentals/{ticker}): TTM profitability ratios (roe_ttm, roa_ttm, fcf_margin), leverage_ratio, ERM3 cascade betas, and the cost-of-capital layer (cost_of_equity, wacc, economic_profit). Rows are visible iff filed_date <= as_of — never \"latest\". Raw vendor line items (revenue, net income, EPS, balance-sheet levels) are never included (derived-only licensing). Set grid=true for a cost-of-capital sensitivity table across erp_grid x rf_tenor_grid instead of a scalar wacc/cost_of_equity.",
+      inputSchema: {
+        ticker: z.string().min(1).describe("Ticker symbol, e.g. AAPL"),
+        as_of: z.string().optional().describe("Point-in-time date YYYY-MM-DD (default: today)"),
+        periods: z.number().int().min(1).max(40).optional().describe("Quarterly rows returned, most recent last (default 8, max 40)"),
+        erp: z.number().min(0).max(0.5).optional().describe("Equity risk premium for cost-of-capital (default 0.05)"),
+        tax_rate: z.number().min(0).max(1).optional().describe("Tax rate applied to the WACC debt shield (default 0.21)"),
+        rf_tenor: z
+          .enum(["3m", "1y", "2y", "5y", "10y", "30y"])
+          .optional()
+          .describe("Treasury CMT tenor backing rf_rate (default 10y — pair a short tenor with a bill-basis ERP)"),
+        grid: z
+          .boolean()
+          .optional()
+          .describe("If true, response also carries sensitivity_grid: cost_of_equity/wacc/economic_profit across erp_grid x rf_tenor_grid for the latest PIT-visible period only"),
+        erp_grid: z.string().optional().describe('Comma-separated ERP values for the grid, e.g. "0.03,0.04,0.05,0.06,0.07". Only used when grid=true'),
+        rf_tenor_grid: z.string().optional().describe('Comma-separated tenor subset for the grid, e.g. "1y,10y,30y". Only used when grid=true'),
+      },
+    },
+    async ({ ticker, as_of, periods, erp, tax_rate, rf_tenor, grid, erp_grid, rf_tenor_grid }) => {
+      try {
+        const query: Record<string, string | number | boolean> = {};
+        if (as_of !== undefined) query.as_of = as_of;
+        if (periods !== undefined) query.periods = periods;
+        if (erp !== undefined) query.erp = erp;
+        if (tax_rate !== undefined) query.tax_rate = tax_rate;
+        if (rf_tenor !== undefined) query.rf_tenor = rf_tenor;
+        if (grid !== undefined) query.grid = grid;
+        if (erp_grid !== undefined) query.erp_grid = erp_grid;
+        if (rf_tenor_grid !== undefined) query.rf_tenor_grid = rf_tenor_grid;
+        return textResult(
+          await sdk.call("GET", `/fundamentals/${encodeURIComponent(ticker.trim().toUpperCase())}`, { query }),
+        );
+      } catch (error) {
+        return errorResult(error);
+      }
+    },
+  );
+
+  server.registerTool(
     "riskmodels_screen_rankings",
     {
       title: "RiskModels Rankings Screen",

--- a/mcp/data/openapi.json
+++ b/mcp/data/openapi.json
@@ -1030,6 +1030,11 @@
               }
             }
           },
+          "sensitivity_grid": {
+            "$ref": "#/components/schemas/FundamentalsSensitivityGrid",
+            "nullable": true,
+            "description": "Present only when the request set `grid=true`. Null (with a `note`) when no PIT-visible period exists at `as_of`.\n"
+          },
           "disclosures": {
             "type": "object",
             "additionalProperties": true,
@@ -1038,6 +1043,75 @@
           "_metadata": {
             "type": "object",
             "additionalProperties": true
+          }
+        }
+      },
+      "FundamentalsSensitivityGrid": {
+        "type": "object",
+        "description": "Cost-of-capital sensitivity grid for the latest PIT-visible period only — `cost_of_equity` / `wacc` / `economic_profit` recomputed across every combination of `erp_values` x `rf_tenor_values`. Pure derived analytics (same fields as `FundamentalsRow`'s cost-of-capital layer), just parameterized instead of single-valued. `cells` is row-major: `cells[i][j]` pairs `erp_values[i]` with `rf_tenor_values[j]`.\n",
+        "required": [
+          "period_end_date",
+          "erp_values",
+          "rf_tenor_values",
+          "tax_rate",
+          "cells"
+        ],
+        "properties": {
+          "period_end_date": {
+            "type": "string",
+            "format": "date"
+          },
+          "filed_date": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "erp_values": {
+            "type": "array",
+            "items": {
+              "type": "number"
+            }
+          },
+          "rf_tenor_values": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "3m",
+                "1y",
+                "2y",
+                "5y",
+                "10y",
+                "30y"
+              ]
+            }
+          },
+          "tax_rate": {
+            "type": "number"
+          },
+          "cells": {
+            "type": "array",
+            "description": "Row-major [erp_values.length][rf_tenor_values.length].",
+            "items": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "cost_of_equity": {
+                    "type": "number",
+                    "nullable": true
+                  },
+                  "wacc": {
+                    "type": "number",
+                    "nullable": true
+                  },
+                  "economic_profit": {
+                    "type": "number",
+                    "nullable": true
+                  }
+                }
+              }
+            }
           }
         }
       },
@@ -5480,7 +5554,7 @@
     "/fundamentals/{ticker}": {
       "get": {
         "summary": "Point-in-time quarterly fundamentals (derived analytics only)",
-        "description": "Quarterly fundamentals for a single ticker, point-in-time filtered: a row is visible if and only if its `filed_date` is on or before `as_of` (never \"latest\"). `filed_date_source` is `exact` (vendor filing date) or `approx` (period_end + 45 days, the 10-Q deadline, when the vendor date is missing).\n\n**Derived analytics only.** Raw vendor line items (revenue, net income, EPS, balance-sheet levels) are not redistributable and are never included. Rows carry TTM profitability ratios (`roe_ttm`, `roa_ttm`, `fcf_margin`), `leverage_ratio`, ERM3 cascade betas with provenance (`beta_market` / `beta_sector` / `beta_subsector` / `beta_source`), and the cost-of-capital layer (`cost_of_equity`, `cost_of_debt`, `wacc`, `economic_profit`). `gross_margin` and `operating_margin` are currently always null (inputs not yet in the store). `market_cap` is a current snapshot, not point-in-time per quarter.\n\n**Disclosures (also returned in every response body):**\n- Realized historical data only. No forecasts, no analyst targets, no buy/sell\n  signals.\n\n- Coverage starts ~2009 for most filers; pre-2009 and small-cap or\n  recently-IPO'd names are thin. Missing fields are null.\n\n- `beta_market` is a short-half-life conditional market beta, not a textbook\n  long-run CAPM beta; for defensive names `cost_of_equity` can fall below the\n  risk-free rate. That is a property of the conditional beta, not an error.\n\n- WACC uses BOOK-value weights. Market-value weights are the textbook\n  convention; compute them yourself if you have market-cap access.\n\n- TTM sums flows over the trailing 4 reported quarters; stock quantities are\n  point-in-time (ROE denominator uses trailing-4-quarter average equity).\n  Ratios need 4 finite quarters or they are null.\n\n- `erp` (default 0.05) and `tax_rate` (default 0.21) are always\n  caller-supplied parameters, echoed in the response; no equity-risk-premium\n  opinion is stored.\n\n\n**Authentication:** Required (API Key or OAuth2)\n**Billing:** $0.005 per request (deducted from account balance)\n**Rate Limit:** 60 requests/minute (default)\n\nPer-symbol, per-call only: no batch variant, no CSV/bulk export (JSON only).\n",
+        "description": "Quarterly fundamentals for a single ticker, point-in-time filtered: a row is visible if and only if its `filed_date` is on or before `as_of` (never \"latest\"). `filed_date_source` is `exact` (vendor filing date) or `approx` (period_end + 45 days, the 10-Q deadline, when the vendor date is missing).\n\n**Derived analytics only.** Raw vendor line items (revenue, net income, EPS, balance-sheet levels) are not redistributable and are never included. Rows carry TTM profitability ratios (`roe_ttm`, `roa_ttm`, `fcf_margin`), `leverage_ratio`, ERM3 cascade betas with provenance (`beta_market` / `beta_sector` / `beta_subsector` / `beta_source`), and the cost-of-capital layer (`cost_of_equity`, `cost_of_debt`, `wacc`, `economic_profit`). `gross_margin` and `operating_margin` are currently always null (inputs not yet in the store). `market_cap` is a current snapshot, not point-in-time per quarter.\n\n**Disclosures (also returned in every response body):**\n- Realized historical data only. No forecasts, no analyst targets, no buy/sell\n  signals.\n\n- Coverage starts ~2009 for most filers; pre-2009 and small-cap or\n  recently-IPO'd names are thin. Missing fields are null.\n\n- `beta_market` is a short-half-life conditional market beta, not a textbook\n  long-run CAPM beta; for defensive names `cost_of_equity` can fall below the\n  risk-free rate. That is a property of the conditional beta, not an error.\n\n- WACC uses BOOK-value weights. Market-value weights are the textbook\n  convention; compute them yourself if you have market-cap access.\n\n- TTM sums flows over the trailing 4 reported quarters; stock quantities are\n  point-in-time (ROE denominator uses trailing-4-quarter average equity).\n  Ratios need 4 finite quarters or they are null.\n\n- `erp` (default 0.05) and `tax_rate` (default 0.21) are always\n  caller-supplied parameters, echoed in the response; no equity-risk-premium\n  opinion is stored.\n\n- `rf_rate` is the Treasury constant-maturity yield at the selected\n  `rf_tenor` (3m|1y|2y|5y|10y|30y, default 10y — the valuation convention),\n  sampled at the last observation on or before each quarter's period end.\n  A short tenor should be paired with a bill-basis ERP or cost of capital\n  is understated.\n\n\n**Authentication:** Required (API Key or OAuth2)\n**Billing:** $0.005 per request (deducted from account balance)\n**Rate Limit:** 60 requests/minute (default)\n\nPer-symbol, per-call only: no batch variant, no CSV/bulk export (JSON only).\n",
         "operationId": "getFundamentals",
         "tags": [
           "Fundamentals"
@@ -5567,10 +5641,47 @@
             "required": false,
             "schema": {
               "type": "string",
-              "enum": ["3m", "1y", "2y", "5y", "10y", "30y"],
+              "enum": [
+                "3m",
+                "1y",
+                "2y",
+                "5y",
+                "10y",
+                "30y"
+              ],
               "default": "10y"
             },
             "description": "Treasury constant-maturity tenor backing rf_rate. Default 10y (valuation convention). Pair a short tenor with a bill-basis ERP or cost of capital is understated."
+          },
+          {
+            "name": "grid",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false
+            },
+            "description": "When true, the response also carries `sensitivity_grid` — `cost_of_equity` / `wacc` / `economic_profit` across `erp_grid` x `rf_tenor_grid` for the latest PIT-visible period only (not a time series — a \"what if my assumptions were different today\" table). Same billing as the base call; no extra cost."
+          },
+          {
+            "name": "erp_grid",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Comma-separated ERP values for the sensitivity grid (1-10 values, each in [0, 0.5]), e.g. `0.03,0.04,0.05,0.06,0.07`. Ignored unless `grid=true`. Default: `0.03,0.04,0.05,0.06,0.07`.",
+            "example": "0.03,0.04,0.05,0.06,0.07"
+          },
+          {
+            "name": "rf_tenor_grid",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Comma-separated subset of `3m,1y,2y,5y,10y,30y` for the sensitivity grid. Ignored unless `grid=true`. Default: all six tenors.",
+            "example": "1y,10y,30y"
           }
         ],
         "responses": {
@@ -11434,7 +11545,7 @@
             "description": "Upstream AI provider error."
           },
           "503": {
-            "description": "Chat not configured (e.g. missing OPENAI_API_KEY)."
+            "description": "Chat not configured (e.g. missing MOONSHOT_API_KEY)."
           }
         }
       }

--- a/sdk/notebooks/pit_fundamentals_event_study.ipynb
+++ b/sdk/notebooks/pit_fundamentals_event_study.ipynb
@@ -1,0 +1,539 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "645997df",
+   "metadata": {},
+   "source": [
+    "# PIT fundamentals event study — the anti-look-ahead differentiator (H.89.6)\n",
+    "\n",
+    "**[Open in Colab](https://colab.research.google.com/github/BlueWaterCorp/RiskModels_API/blob/main/sdk/notebooks/pit_fundamentals_event_study.ipynb)** · **[Get API key](https://riskmodels.app/get-key)**\n",
+    "\n",
+    "Most fundamentals APIs key on `period_end_date` (\"give me the Q2 numbers\") and silently return whatever the **current, restated** value is — including data that was not actually knowable on any date near the quarter end. `GET /fundamentals/{ticker}`'s `as_of` parameter is the differentiator: a row is visible **iff `filed_date <= as_of`**, never \"latest\". This notebook proves the mechanism by walking `as_of` across a real filing boundary and watching a quarter's data appear exactly once knowable — not before.\n",
+    "\n",
+    "**Scope note:** the store's `eps_actual` / `eps_estimate` (and therefore a true EPS-surprise event study) are held back pending SEC-promotion or counsel clearance (`FUNDAMENTALS_HELD_BACK_FIELDS`, H.69) — this SDK never reconstructs a held-back field client-side (see `CLAUDE.md`). So this walks the **same PIT mechanism** using the fields that *are* shipped (`roe_ttm`, `cost_of_equity`, `wacc`) — the identical `as_of`/`filed_date` gate a real surprise event study will use once those fields clear review.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6a9ecaba",
+   "metadata": {},
+   "source": [
+    "### Colab only (skip locally)\n",
+    "\n",
+    "Run once to install the SDK; local users should `pip install riskmodels-py` in their venv.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "aa9bce02",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-08T02:45:27.001841Z",
+     "iopub.status.busy": "2026-07-08T02:45:27.001758Z",
+     "iopub.status.idle": "2026-07-08T02:45:27.005711Z",
+     "shell.execute_reply": "2026-07-08T02:45:27.005319Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Local: use your environment (pip install riskmodels-py python-dotenv).\n"
+     ]
+    }
+   ],
+   "source": [
+    "import sys\n",
+    "\n",
+    "try:\n",
+    "    import google.colab  # noqa: F401\n",
+    "    _COLAB = True\n",
+    "except ImportError:\n",
+    "    _COLAB = False\n",
+    "\n",
+    "if _COLAB:\n",
+    "    import subprocess\n",
+    "\n",
+    "    _deps = [\"python-dotenv\"]\n",
+    "    _pypi = \"riskmodels-py>=0.3.4\"\n",
+    "    _git = (\n",
+    "        \"riskmodels-py @ git+https://github.com/BlueWaterCorp/RiskModels_API.git\"\n",
+    "        \"@main#subdirectory=sdk\"\n",
+    "    )\n",
+    "    try:\n",
+    "        subprocess.check_call(\n",
+    "            [sys.executable, \"-m\", \"pip\", \"install\", \"-q\", _pypi, *_deps],\n",
+    "            stdout=subprocess.DEVNULL,\n",
+    "        )\n",
+    "        print(\"Colab: installed riskmodels-py from PyPI (+ python-dotenv).\")\n",
+    "    except subprocess.CalledProcessError:\n",
+    "        subprocess.check_call(\n",
+    "            [sys.executable, \"-m\", \"pip\", \"install\", \"-q\", _git, *_deps],\n",
+    "            stdout=subprocess.DEVNULL,\n",
+    "        )\n",
+    "        print(\n",
+    "            \"Colab: installed riskmodels-py from GitHub main \"\n",
+    "            \"(PyPI may not list this version yet).\"\n",
+    "        )\n",
+    "else:\n",
+    "    print(\"Local: use your environment (pip install riskmodels-py python-dotenv).\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d61586d5",
+   "metadata": {},
+   "source": [
+    "## 1. Connect — `RiskModelsClient.from_env()`\n",
+    "\n",
+    "Loads **`RISKMODELS_API_KEY`** from shell env, `.env` / `.env.local` (when `python-dotenv` is installed), or Colab Secrets.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "dbf5c55e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-08T02:45:27.007073Z",
+     "iopub.status.busy": "2026-07-08T02:45:27.006920Z",
+     "iopub.status.idle": "2026-07-08T02:45:27.198515Z",
+     "shell.execute_reply": "2026-07-08T02:45:27.198110Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "RISKMODELS_BASE_URL = https://riskmodels.app/api\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "\n",
+    "from IPython.display import display\n",
+    "\n",
+    "from riskmodels import RiskModelsClient\n",
+    "from riskmodels.client import DEFAULT_BASE_URL\n",
+    "from riskmodels.notebook import load_notebook_dotenv\n",
+    "\n",
+    "load_notebook_dotenv()\n",
+    "print(\"RISKMODELS_BASE_URL =\", os.environ.get(\"RISKMODELS_BASE_URL\", DEFAULT_BASE_URL))\n",
+    "client = RiskModelsClient.from_env()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4d056fa1",
+   "metadata": {},
+   "source": [
+    "## 2. Find a recent filing boundary\n",
+    "\n",
+    "Pull enough history to see `period_end_date` / `filed_date` pairs, then pick the most recent one as the event boundary.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "944bf781",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-08T02:45:27.199500Z",
+     "iopub.status.busy": "2026-07-08T02:45:27.199447Z",
+     "iopub.status.idle": "2026-07-08T02:45:29.986821Z",
+     "shell.execute_reply": "2026-07-08T02:45:29.986269Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>period_end_date</th>\n",
+       "      <th>filed_date</th>\n",
+       "      <th>filed_date_source</th>\n",
+       "      <th>roe_ttm</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>2024-06-30</td>\n",
+       "      <td>2024-08-02</td>\n",
+       "      <td>exact</td>\n",
+       "      <td>1.471503</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2024-09-30</td>\n",
+       "      <td>2024-11-01</td>\n",
+       "      <td>exact</td>\n",
+       "      <td>1.378714</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2024-12-31</td>\n",
+       "      <td>2025-01-31</td>\n",
+       "      <td>exact</td>\n",
+       "      <td>1.453460</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>2025-03-31</td>\n",
+       "      <td>2025-05-02</td>\n",
+       "      <td>exact</td>\n",
+       "      <td>1.513055</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>2025-06-30</td>\n",
+       "      <td>2025-08-01</td>\n",
+       "      <td>exact</td>\n",
+       "      <td>1.549229</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>2025-09-30</td>\n",
+       "      <td>2025-10-31</td>\n",
+       "      <td>exact</td>\n",
+       "      <td>1.640469</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>2025-12-31</td>\n",
+       "      <td>2026-01-30</td>\n",
+       "      <td>exact</td>\n",
+       "      <td>1.599422</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>2026-03-31</td>\n",
+       "      <td>2026-05-01</td>\n",
+       "      <td>exact</td>\n",
+       "      <td>1.466892</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  period_end_date  filed_date filed_date_source   roe_ttm\n",
+       "0      2024-06-30  2024-08-02             exact  1.471503\n",
+       "1      2024-09-30  2024-11-01             exact  1.378714\n",
+       "2      2024-12-31  2025-01-31             exact  1.453460\n",
+       "3      2025-03-31  2025-05-02             exact  1.513055\n",
+       "4      2025-06-30  2025-08-01             exact  1.549229\n",
+       "5      2025-09-30  2025-10-31             exact  1.640469\n",
+       "6      2025-12-31  2026-01-30             exact  1.599422\n",
+       "7      2026-03-31  2026-05-01             exact  1.466892"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Event quarter: period_end=2026-03-31, filed_date=2026-05-01\n"
+     ]
+    }
+   ],
+   "source": [
+    "TICKER = \"AAPL\"\n",
+    "\n",
+    "history = client.get_fundamentals(TICKER, periods=8, as_dataframe=True)\n",
+    "display(history[[\"period_end_date\", \"filed_date\", \"filed_date_source\", \"roe_ttm\"]])\n",
+    "\n",
+    "event = history.iloc[-1]\n",
+    "event_period_end = event[\"period_end_date\"]\n",
+    "event_filed = event[\"filed_date\"]\n",
+    "print(f\"Event quarter: period_end={event_period_end}, filed_date={event_filed}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fb7feba1",
+   "metadata": {},
+   "source": [
+    "## 3. Naive `period_end` cutoff vs. true PIT `filed_date` cutoff\n",
+    "\n",
+    "A backtest that (incorrectly) uses the quarter's `period_end_date` as its knowledge cutoff would already \"see\" a quarter's data — but nobody actually knew those numbers until the filing landed, ~1-2 months later. Querying `as_of=period_end_date` should **not** surface the event quarter; only `as_of=filed_date` should.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "fe3aeca7",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-08T02:45:29.988158Z",
+     "iopub.status.busy": "2026-07-08T02:45:29.988072Z",
+     "iopub.status.idle": "2026-07-08T02:45:34.975503Z",
+     "shell.execute_reply": "2026-07-08T02:45:34.975017Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "as_of=period_end_date (2026-03-31): event quarter visible = False\n",
+      "as_of=filed_date      (2026-05-01):      event quarter visible = True\n"
+     ]
+    }
+   ],
+   "source": [
+    "naive = client.get_fundamentals(TICKER, as_of=event_period_end, periods=8)\n",
+    "pit = client.get_fundamentals(TICKER, as_of=event_filed, periods=8)\n",
+    "\n",
+    "naive_has_event = any(r[\"period_end_date\"] == event_period_end for r in naive[\"rows\"])\n",
+    "pit_has_event = any(r[\"period_end_date\"] == event_period_end for r in pit[\"rows\"])\n",
+    "\n",
+    "print(f\"as_of=period_end_date ({event_period_end}): event quarter visible = {naive_has_event}\")\n",
+    "print(f\"as_of=filed_date      ({event_filed}):      event quarter visible = {pit_has_event}\")\n",
+    "assert not naive_has_event and pit_has_event, (\n",
+    "    \"Expected the event quarter to be invisible at as_of=period_end and visible \"\n",
+    "    \"at as_of=filed_date — if this fails, filed_date_source may be 'approx' \"\n",
+    "    \"(period_end + 45d), which can coincide with the as_of used above.\"\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "deef1374",
+   "metadata": {},
+   "source": [
+    "## 4. Step function across the filing date\n",
+    "\n",
+    "Walk `as_of` day-by-day around `filed_date` and show `roe_ttm` for the event quarter appearing at exactly one point — never gradually, never early.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "e68499b8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-08T02:45:34.976572Z",
+     "iopub.status.busy": "2026-07-08T02:45:34.976506Z",
+     "iopub.status.idle": "2026-07-08T02:46:01.886595Z",
+     "shell.execute_reply": "2026-07-08T02:46:01.886098Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>as_of</th>\n",
+       "      <th>days_from_filing</th>\n",
+       "      <th>event_quarter_visible</th>\n",
+       "      <th>roe_ttm</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>2026-04-26</td>\n",
+       "      <td>-5</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2026-04-27</td>\n",
+       "      <td>-4</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2026-04-28</td>\n",
+       "      <td>-3</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>2026-04-29</td>\n",
+       "      <td>-2</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>2026-04-30</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>2026-05-01</td>\n",
+       "      <td>0</td>\n",
+       "      <td>True</td>\n",
+       "      <td>1.466892</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>2026-05-02</td>\n",
+       "      <td>1</td>\n",
+       "      <td>True</td>\n",
+       "      <td>1.466892</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>2026-05-03</td>\n",
+       "      <td>2</td>\n",
+       "      <td>True</td>\n",
+       "      <td>1.466892</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>2026-05-04</td>\n",
+       "      <td>3</td>\n",
+       "      <td>True</td>\n",
+       "      <td>1.466892</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>2026-05-05</td>\n",
+       "      <td>4</td>\n",
+       "      <td>True</td>\n",
+       "      <td>1.466892</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>10</th>\n",
+       "      <td>2026-05-06</td>\n",
+       "      <td>5</td>\n",
+       "      <td>True</td>\n",
+       "      <td>1.466892</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "         as_of  days_from_filing  event_quarter_visible   roe_ttm\n",
+       "0   2026-04-26                -5                  False       NaN\n",
+       "1   2026-04-27                -4                  False       NaN\n",
+       "2   2026-04-28                -3                  False       NaN\n",
+       "3   2026-04-29                -2                  False       NaN\n",
+       "4   2026-04-30                -1                  False       NaN\n",
+       "5   2026-05-01                 0                   True  1.466892\n",
+       "6   2026-05-02                 1                   True  1.466892\n",
+       "7   2026-05-03                 2                   True  1.466892\n",
+       "8   2026-05-04                 3                   True  1.466892\n",
+       "9   2026-05-05                 4                   True  1.466892\n",
+       "10  2026-05-06                 5                   True  1.466892"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from datetime import date, timedelta\n",
+    "\n",
+    "filed = date.fromisoformat(event_filed)\n",
+    "rows = []\n",
+    "for offset in range(-5, 6):\n",
+    "    as_of = (filed + timedelta(days=offset)).isoformat()\n",
+    "    body = client.get_fundamentals(TICKER, as_of=as_of, periods=8)\n",
+    "    visible_row = next(\n",
+    "        (r for r in body[\"rows\"] if r[\"period_end_date\"] == event_period_end), None\n",
+    "    )\n",
+    "    rows.append(\n",
+    "        {\n",
+    "            \"as_of\": as_of,\n",
+    "            \"days_from_filing\": offset,\n",
+    "            \"event_quarter_visible\": visible_row is not None,\n",
+    "            \"roe_ttm\": visible_row[\"roe_ttm\"] if visible_row else None,\n",
+    "        }\n",
+    "    )\n",
+    "\n",
+    "import pandas as pd\n",
+    "\n",
+    "step = pd.DataFrame(rows)\n",
+    "display(step)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3a6978a0",
+   "metadata": {},
+   "source": [
+    "## Reading the table\n",
+    "\n",
+    "`event_quarter_visible` should flip from `False` to `True` exactly at `days_from_filing == 0` and stay `True` afterward — a hard step, not a gradual reveal. That step is the whole point: any backtest, screen, or agent that queries this endpoint with a historical `as_of` gets exactly the information that existed on that date, no more.\n",
+    "\n",
+    "## Next steps\n",
+    "\n",
+    "- Once `eps_actual` / `eps_estimate` clear H.69 counsel review, a true surprise event study reuses this identical `as_of` walk — swap `roe_ttm` for the surprise field and the mechanism is unchanged.\n",
+    "- **Quality-overlay screen:** [`quality_overlay_screen.ipynb`](./quality_overlay_screen.ipynb)\n",
+    "- **Pre-earnings hedge timing:** [`pre_earnings_hedge_timing.ipynb`](./pre_earnings_hedge_timing.ipynb)\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/sdk/notebooks/pre_earnings_hedge_timing.ipynb
+++ b/sdk/notebooks/pre_earnings_hedge_timing.ipynb
@@ -1,0 +1,564 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "5ff58e30",
+   "metadata": {},
+   "source": [
+    "# Pre-earnings hedge timing — `next_earnings` + `decompose` (H.89.6)\n",
+    "\n",
+    "**[Open in Colab](https://colab.research.google.com/github/BlueWaterCorp/RiskModels_API/blob/main/sdk/notebooks/pre_earnings_hedge_timing.ipynb)** · **[Get API key](https://riskmodels.app/get-key)**\n",
+    "\n",
+    "Idiosyncratic risk spikes around earnings. If you want exposure to the earnings *event itself* (the residual/stock-specific bet) without the market/sector beta riding along for the same few days, you need two things: **when** the event is likely, and **how much** market/sector exposure to lay off going into it.\n",
+    "\n",
+    "- `client.next_earnings(ticker)` — a **cadence-based estimate**, not a confirmed earnings-calendar date. It projects from the median gap between this ticker's own historical `filed_date` values. There is no analyst-estimate or vendor earnings-calendar feed in the store (`eps_forecast` / `analyst_rating` / `target_price` are permanently held back — see `lib/api/fundamentals-contract.ts` `FUNDAMENTALS_HELD_BACK_FIELDS` in the API repo, and `CLAUDE.md`'s derived-only licensing rule). Treat the date as a planning window, not a forecast.\n",
+    "- `client.decompose(ticker, as_dataframe=True)` — current per-layer hedge ratios and recommended hedge ETFs, to structure the market/sector leg of the hedge.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1368ce2a",
+   "metadata": {},
+   "source": [
+    "### Colab only (skip locally)\n",
+    "\n",
+    "Run once to install the SDK; local users should `pip install riskmodels-py` in their venv.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "5af0ff82",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-08T02:45:15.071295Z",
+     "iopub.status.busy": "2026-07-08T02:45:15.071209Z",
+     "iopub.status.idle": "2026-07-08T02:45:15.075539Z",
+     "shell.execute_reply": "2026-07-08T02:45:15.075037Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Local: use your environment (pip install riskmodels-py python-dotenv).\n"
+     ]
+    }
+   ],
+   "source": [
+    "import sys\n",
+    "\n",
+    "try:\n",
+    "    import google.colab  # noqa: F401\n",
+    "    _COLAB = True\n",
+    "except ImportError:\n",
+    "    _COLAB = False\n",
+    "\n",
+    "if _COLAB:\n",
+    "    import subprocess\n",
+    "\n",
+    "    _deps = [\"python-dotenv\"]\n",
+    "    _pypi = \"riskmodels-py>=0.3.4\"\n",
+    "    _git = (\n",
+    "        \"riskmodels-py @ git+https://github.com/BlueWaterCorp/RiskModels_API.git\"\n",
+    "        \"@main#subdirectory=sdk\"\n",
+    "    )\n",
+    "    try:\n",
+    "        subprocess.check_call(\n",
+    "            [sys.executable, \"-m\", \"pip\", \"install\", \"-q\", _pypi, *_deps],\n",
+    "            stdout=subprocess.DEVNULL,\n",
+    "        )\n",
+    "        print(\"Colab: installed riskmodels-py from PyPI (+ python-dotenv).\")\n",
+    "    except subprocess.CalledProcessError:\n",
+    "        subprocess.check_call(\n",
+    "            [sys.executable, \"-m\", \"pip\", \"install\", \"-q\", _git, *_deps],\n",
+    "            stdout=subprocess.DEVNULL,\n",
+    "        )\n",
+    "        print(\n",
+    "            \"Colab: installed riskmodels-py from GitHub main \"\n",
+    "            \"(PyPI may not list this version yet).\"\n",
+    "        )\n",
+    "else:\n",
+    "    print(\"Local: use your environment (pip install riskmodels-py python-dotenv).\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e4ca4bb1",
+   "metadata": {},
+   "source": [
+    "## 1. Connect — `RiskModelsClient.from_env()`\n",
+    "\n",
+    "Loads **`RISKMODELS_API_KEY`** from shell env, `.env` / `.env.local` (when `python-dotenv` is installed), or Colab Secrets.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "4a0e3057",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-08T02:45:15.076987Z",
+     "iopub.status.busy": "2026-07-08T02:45:15.076910Z",
+     "iopub.status.idle": "2026-07-08T02:45:15.268372Z",
+     "shell.execute_reply": "2026-07-08T02:45:15.267969Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "RISKMODELS_BASE_URL = https://riskmodels.app/api\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "\n",
+    "from IPython.display import display\n",
+    "\n",
+    "from riskmodels import RiskModelsClient\n",
+    "from riskmodels.client import DEFAULT_BASE_URL\n",
+    "from riskmodels.notebook import load_notebook_dotenv\n",
+    "\n",
+    "load_notebook_dotenv()\n",
+    "print(\"RISKMODELS_BASE_URL =\", os.environ.get(\"RISKMODELS_BASE_URL\", DEFAULT_BASE_URL))\n",
+    "client = RiskModelsClient.from_env()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bcac8bc1",
+   "metadata": {},
+   "source": [
+    "## 2. When's the next print?\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "925c4708",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-08T02:45:15.269346Z",
+     "iopub.status.busy": "2026-07-08T02:45:15.269286Z",
+     "iopub.status.idle": "2026-07-08T02:45:18.659876Z",
+     "shell.execute_reply": "2026-07-08T02:45:18.659269Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'ticker': 'NVDA',\n",
+       " 'last_filed_date': '2026-05-27',\n",
+       " 'estimated_next_filed_date': '2026-08-26',\n",
+       " 'median_cadence_days': 91,\n",
+       " 'n_periods_observed': 8,\n",
+       " 'basis': 'filed_date_cadence',\n",
+       " 'note': 'Statistical projection from historical filing cadence, not a confirmed earnings-calendar date. No analyst estimates or vendor earnings-calendar feed are stored (derived-only licensing posture).'}"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "TICKER = \"NVDA\"\n",
+    "\n",
+    "next_earn = client.next_earnings(TICKER)\n",
+    "next_earn\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "be9ee32b",
+   "metadata": {},
+   "source": [
+    "## 3. Days until the estimated window\n",
+    "\n",
+    "A simple planning threshold: inside ~21 trading days of the estimate, start thinking about hedging the beta legs; the exact cutoff is a judgment call, not something the API prescribes.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "91e2cc85",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-08T02:45:18.667318Z",
+     "iopub.status.busy": "2026-07-08T02:45:18.667219Z",
+     "iopub.status.idle": "2026-07-08T02:45:18.670006Z",
+     "shell.execute_reply": "2026-07-08T02:45:18.669289Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "NVDA: ~50 calendar days to the estimated next filing (2026-08-26).\n",
+      "Basis: filed_date_cadence over 8 observed quarters.\n"
+     ]
+    }
+   ],
+   "source": [
+    "from datetime import date\n",
+    "\n",
+    "next_date_str = next_earn.get(\"estimated_next_filed_date\")\n",
+    "if next_date_str is None:\n",
+    "    print(\n",
+    "        f\"Not enough filing history to project a cadence for {TICKER} \"\n",
+    "        \"(need >= 2 filed quarters).\"\n",
+    "    )\n",
+    "    days_until = None\n",
+    "else:\n",
+    "    days_until = (date.fromisoformat(next_date_str) - date.today()).days\n",
+    "    print(f\"{TICKER}: ~{days_until} calendar days to the estimated next filing ({next_date_str}).\")\n",
+    "    print(f\"Basis: {next_earn['basis']} over {next_earn['n_periods_observed']} observed quarters.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "306b1624",
+   "metadata": {},
+   "source": [
+    "## 4. Structure the beta hedge\n",
+    "\n",
+    "`decompose` gives the market/sector/subsector hedge ratios and which ETF trades each one. The `residual` layer is deliberately **not hedgeable** here — that's the earnings-event exposure you're choosing to keep.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "60a31cf6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-08T02:45:18.671149Z",
+     "iopub.status.busy": "2026-07-08T02:45:18.671067Z",
+     "iopub.status.idle": "2026-07-08T02:45:24.549742Z",
+     "shell.execute_reply": "2026-07-08T02:45:24.549343Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>ticker</th>\n",
+       "      <th>layer</th>\n",
+       "      <th>er</th>\n",
+       "      <th>hr</th>\n",
+       "      <th>hedge_etf</th>\n",
+       "      <th>hedgeable</th>\n",
+       "      <th>data_as_of</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>NVDA</td>\n",
+       "      <td>market</td>\n",
+       "      <td>0.419527</td>\n",
+       "      <td>-0.961814</td>\n",
+       "      <td>SPY</td>\n",
+       "      <td>True</td>\n",
+       "      <td>2026-07-06</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>NVDA</td>\n",
+       "      <td>sector</td>\n",
+       "      <td>0.130094</td>\n",
+       "      <td>-0.086165</td>\n",
+       "      <td>XLK</td>\n",
+       "      <td>True</td>\n",
+       "      <td>2026-07-06</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>NVDA</td>\n",
+       "      <td>subsector</td>\n",
+       "      <td>-0.012480</td>\n",
+       "      <td>-0.359021</td>\n",
+       "      <td>SMH</td>\n",
+       "      <td>True</td>\n",
+       "      <td>2026-07-06</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>NVDA</td>\n",
+       "      <td>residual</td>\n",
+       "      <td>0.462859</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>None</td>\n",
+       "      <td>False</td>\n",
+       "      <td>2026-07-06</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>NVDA</td>\n",
+       "      <td>style</td>\n",
+       "      <td>0.132342</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>None</td>\n",
+       "      <td>False</td>\n",
+       "      <td>2026-07-06</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>NVDA</td>\n",
+       "      <td>stock_specific</td>\n",
+       "      <td>0.449242</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>None</td>\n",
+       "      <td>False</td>\n",
+       "      <td>2026-07-06</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  ticker           layer        er        hr hedge_etf  hedgeable  data_as_of\n",
+       "0   NVDA          market  0.419527 -0.961814       SPY       True  2026-07-06\n",
+       "1   NVDA          sector  0.130094 -0.086165       XLK       True  2026-07-06\n",
+       "2   NVDA       subsector -0.012480 -0.359021       SMH       True  2026-07-06\n",
+       "3   NVDA        residual  0.462859       NaN      None      False  2026-07-06\n",
+       "4   NVDA           style  0.132342       NaN      None      False  2026-07-06\n",
+       "5   NVDA  stock_specific  0.449242       NaN      None      False  2026-07-06"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Layers to hedge going into the print (market/sector/subsector):\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>layer</th>\n",
+       "      <th>hr</th>\n",
+       "      <th>hedge_etf</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>market</td>\n",
+       "      <td>-0.961814</td>\n",
+       "      <td>SPY</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>sector</td>\n",
+       "      <td>-0.086165</td>\n",
+       "      <td>XLK</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>subsector</td>\n",
+       "      <td>-0.359021</td>\n",
+       "      <td>SMH</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "       layer        hr hedge_etf\n",
+       "0     market -0.961814       SPY\n",
+       "1     sector -0.086165       XLK\n",
+       "2  subsector -0.359021       SMH"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Kept as the earnings bet (not hedged):\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>layer</th>\n",
+       "      <th>er</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>residual</td>\n",
+       "      <td>0.462859</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "      layer        er\n",
+       "3  residual  0.462859"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "hedge_df = client.decompose(TICKER, as_dataframe=True)\n",
+    "display(hedge_df)\n",
+    "\n",
+    "hedgeable = hedge_df[hedge_df[\"hedgeable\"]]\n",
+    "print(\"Layers to hedge going into the print (market/sector/subsector):\")\n",
+    "display(hedgeable[[\"layer\", \"hr\", \"hedge_etf\"]])\n",
+    "print(\"\\nKept as the earnings bet (not hedged):\")\n",
+    "display(hedge_df[hedge_df[\"layer\"] == \"residual\"][[\"layer\", \"er\"]])\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2a53788a",
+   "metadata": {},
+   "source": [
+    "## 5. Put it together\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "c3a976f9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-08T02:45:24.551213Z",
+     "iopub.status.busy": "2026-07-08T02:45:24.551131Z",
+     "iopub.status.idle": "2026-07-08T02:45:24.553125Z",
+     "shell.execute_reply": "2026-07-08T02:45:24.552738Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "NVDA is not yet inside a ~21-day pre-earnings window; re-check closer to\n",
+      "2026-08-26.\n"
+     ]
+    }
+   ],
+   "source": [
+    "if days_until is not None:\n",
+    "    if days_until <= 21:\n",
+    "        print(f\"Inside the pre-earnings window for {TICKER} — consider laying off the\")\n",
+    "        print(\"hedgeable layers above via their listed hedge_etf before the print, sized\")\n",
+    "        print(\"to each layer's hr, to isolate the residual/stock-specific earnings bet.\")\n",
+    "    else:\n",
+    "        print(f\"{TICKER} is not yet inside a ~21-day pre-earnings window; re-check closer to\")\n",
+    "        print(f\"{next_date_str}.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a53cbc53",
+   "metadata": {},
+   "source": [
+    "## Caveats\n",
+    "\n",
+    "- `next_earnings` is a **statistical projection from cadence**, not a confirmed date — companies change reporting schedules, and the median-gap estimate has no confidence interval attached. Always cross-check against a real calendar before sizing a trade on it.\n",
+    "- Hedge ratios from `decompose` are point-in-time (`data_as_of`) and drift as the regression windows roll forward — re-fetch close to execution, not once days in advance.\n",
+    "- Sign convention: `hedge[etf] == -exposure[layer].hr` — a positive stock `hr` means **short** the ETF to hedge a long position.\n",
+    "\n",
+    "## Next steps\n",
+    "\n",
+    "- **Quality-overlay screen:** [`quality_overlay_screen.ipynb`](./quality_overlay_screen.ipynb)\n",
+    "- **PIT fundamentals event study:** [`pit_fundamentals_event_study.ipynb`](./pit_fundamentals_event_study.ipynb)\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/sdk/notebooks/quality_overlay_screen.ipynb
+++ b/sdk/notebooks/quality_overlay_screen.ipynb
@@ -1,0 +1,488 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "e3b4d322",
+   "metadata": {},
+   "source": [
+    "# The compounder screen — residual Sharpe x ROE spread (H.89.6)\n",
+    "\n",
+    "**[Open in Colab](https://colab.research.google.com/github/BlueWaterCorp/RiskModels_API/blob/main/sdk/notebooks/quality_overlay_screen.ipynb)** · **[Get API key](https://riskmodels.app/get-key)**\n",
+    "\n",
+    "A **quality overlay**: rank a watchlist on two independent axes and keep only names strong on both —\n",
+    "\n",
+    "1. **Residual Sharpe** (`residual_return` from `get_lstar`) — risk-adjusted *skill-based* alpha, net of market/sector/subsector beta. High residual Sharpe means the stock's excess return isn't just a levered market/sector bet.\n",
+    "2. **ROE spread** (`roe_ttm - cost_of_equity` from `get_fundamentals`) — the equity-charge form of economic profit, normalized to a percentage so it's comparable across market caps (the dollar `economic_profit` field scales with `total_equity`, which isn't in the derived-only response — see `CLAUDE.md` \"Derived-only licensing\").\n",
+    "\n",
+    "A stock high on **both** axes is generating genuine idiosyncratic return *and* earning more than its cost of capital — the two ingredients of a durable compounder, as opposed to a name that's merely riding a factor tailwind or growing revenue below its cost of capital.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "da365cef",
+   "metadata": {},
+   "source": [
+    "### Colab only (skip locally)\n",
+    "\n",
+    "Run once to install the SDK; local users should `pip install riskmodels-py` in their venv.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "b37afa3d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-08T02:44:09.320605Z",
+     "iopub.status.busy": "2026-07-08T02:44:09.320530Z",
+     "iopub.status.idle": "2026-07-08T02:44:09.324310Z",
+     "shell.execute_reply": "2026-07-08T02:44:09.323936Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Local: use your environment (pip install riskmodels-py python-dotenv).\n"
+     ]
+    }
+   ],
+   "source": [
+    "import sys\n",
+    "\n",
+    "try:\n",
+    "    import google.colab  # noqa: F401\n",
+    "    _COLAB = True\n",
+    "except ImportError:\n",
+    "    _COLAB = False\n",
+    "\n",
+    "if _COLAB:\n",
+    "    import subprocess\n",
+    "\n",
+    "    _deps = [\"python-dotenv\"]\n",
+    "    _pypi = \"riskmodels-py>=0.3.4\"\n",
+    "    _git = (\n",
+    "        \"riskmodels-py @ git+https://github.com/BlueWaterCorp/RiskModels_API.git\"\n",
+    "        \"@main#subdirectory=sdk\"\n",
+    "    )\n",
+    "    try:\n",
+    "        subprocess.check_call(\n",
+    "            [sys.executable, \"-m\", \"pip\", \"install\", \"-q\", _pypi, *_deps],\n",
+    "            stdout=subprocess.DEVNULL,\n",
+    "        )\n",
+    "        print(\"Colab: installed riskmodels-py from PyPI (+ python-dotenv).\")\n",
+    "    except subprocess.CalledProcessError:\n",
+    "        subprocess.check_call(\n",
+    "            [sys.executable, \"-m\", \"pip\", \"install\", \"-q\", _git, *_deps],\n",
+    "            stdout=subprocess.DEVNULL,\n",
+    "        )\n",
+    "        print(\n",
+    "            \"Colab: installed riskmodels-py from GitHub main \"\n",
+    "            \"(PyPI may not list this version yet).\"\n",
+    "        )\n",
+    "else:\n",
+    "    print(\"Local: use your environment (pip install riskmodels-py python-dotenv).\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4efb98b6",
+   "metadata": {},
+   "source": [
+    "## 1. Connect — `RiskModelsClient.from_env()`\n",
+    "\n",
+    "Loads **`RISKMODELS_API_KEY`** from shell env, `.env` / `.env.local` (when `python-dotenv` is installed), or Colab Secrets.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "96544b8b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-08T02:44:09.325400Z",
+     "iopub.status.busy": "2026-07-08T02:44:09.325335Z",
+     "iopub.status.idle": "2026-07-08T02:44:09.537781Z",
+     "shell.execute_reply": "2026-07-08T02:44:09.537343Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "RISKMODELS_BASE_URL = https://riskmodels.app/api\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "\n",
+    "from IPython.display import display\n",
+    "\n",
+    "from riskmodels import RiskModelsClient\n",
+    "from riskmodels.client import DEFAULT_BASE_URL\n",
+    "from riskmodels.notebook import load_notebook_dotenv\n",
+    "\n",
+    "load_notebook_dotenv()\n",
+    "print(\"RISKMODELS_BASE_URL =\", os.environ.get(\"RISKMODELS_BASE_URL\", DEFAULT_BASE_URL))\n",
+    "client = RiskModelsClient.from_env()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1c46fa24",
+   "metadata": {},
+   "source": [
+    "## 2. Watchlist\n",
+    "\n",
+    "A deliberately mixed set — mega-cap tech, staples, industrials — so the screen has to discriminate, not just sort by sector momentum.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "50e79a4d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-08T02:44:09.538917Z",
+     "iopub.status.busy": "2026-07-08T02:44:09.538861Z",
+     "iopub.status.idle": "2026-07-08T02:44:09.540350Z",
+     "shell.execute_reply": "2026-07-08T02:44:09.540029Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "WATCHLIST = [\"AAPL\", \"MSFT\", \"NVDA\", \"COST\", \"WMT\", \"XOM\", \"JNJ\", \"CAT\"]\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c6caaa67",
+   "metadata": {},
+   "source": [
+    "## 3. Residual Sharpe per ticker\n",
+    "\n",
+    "`get_ticker_returns` carries `l3_residual_er` (an explained-variance *fraction*, 0-1) but no residual *return* series. `get_lstar(years=2)` is the SDK method that does: for each date it dispatches to the simplest hedge level (L1/L2/L3) whose marginal explained-return clears a threshold, then returns that level's daily `residual_return`. Annualized Sharpe over the full window — deliberately simple (no rolling window) since this is a screen, not a timing signal.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "51d11630",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-08T02:44:09.541214Z",
+     "iopub.status.busy": "2026-07-08T02:44:09.541161Z",
+     "iopub.status.idle": "2026-07-08T02:44:53.258921Z",
+     "shell.execute_reply": "2026-07-08T02:44:53.258593Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'AAPL': 0.10196404620243678,\n",
+       " 'MSFT': -1.1589712909271774,\n",
+       " 'NVDA': 0.1561551326870415,\n",
+       " 'COST': 0.007010124192302697,\n",
+       " 'WMT': 0.9117525670385396,\n",
+       " 'XOM': 0.57178486708075,\n",
+       " 'JNJ': 2.373279020751213,\n",
+       " 'CAT': 1.4626542729392005}"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "\n",
+    "\n",
+    "def residual_sharpe(ticker: str, years: int = 2) -> float | None:\n",
+    "    df = client.get_lstar(ticker, years=years)\n",
+    "    r = df.get(\"residual_return\")\n",
+    "    if r is None or r.dropna().empty:\n",
+    "        return None\n",
+    "    r = r.dropna()\n",
+    "    if r.std() == 0:\n",
+    "        return None\n",
+    "    return float(r.mean() / r.std() * np.sqrt(252))\n",
+    "\n",
+    "\n",
+    "sharpe_by_ticker = {t: residual_sharpe(t) for t in WATCHLIST}\n",
+    "sharpe_by_ticker\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6373a6cd",
+   "metadata": {},
+   "source": [
+    "## 4. ROE spread per ticker\n",
+    "\n",
+    "Latest PIT-visible quarter's `roe_ttm - cost_of_equity` from `get_fundamentals`. `cost_of_equity` uses the caller-supplied `erp` (default 0.05) and defaults to the `10y` risk-free tenor — see the endpoint's `disclosures.conditional_beta_cost_of_equity` caveat: `beta_market` is a short-half-life conditional beta, not a textbook CAPM beta, so `cost_of_equity` can occasionally sit below `rf_rate` for defensive names. That's a property of the beta, not a data error.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "20fba562",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-08T02:44:53.260086Z",
+     "iopub.status.busy": "2026-07-08T02:44:53.260005Z",
+     "iopub.status.idle": "2026-07-08T02:45:12.583753Z",
+     "shell.execute_reply": "2026-07-08T02:45:12.583160Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'AAPL': (1.3738337461419186, 146300933417.04025),\n",
+       " 'MSFT': (0.24706169187654234, 102374209690.20303),\n",
+       " 'NVDA': (0.9866400423699141, 192862473495.28784),\n",
+       " 'COST': (0.24036301881520047, 8054324197.496521),\n",
+       " 'WMT': (0.18865179213845393, 17795524204.40095),\n",
+       " 'XOM': (0.04214026095877305, 10719681666.317137),\n",
+       " 'JNJ': (0.21656175888664214, 17581782263.9733),\n",
+       " 'CAT': (0.3408983117807388, 6361503112.512972)}"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "def roe_spread(ticker: str) -> tuple[float | None, float | None]:\n",
+    "    df = client.get_fundamentals(ticker, as_dataframe=True)\n",
+    "    if df.empty:\n",
+    "        return None, None\n",
+    "    last = df.iloc[-1]\n",
+    "    roe, coe = last[\"roe_ttm\"], last[\"cost_of_equity\"]\n",
+    "    if roe is None or coe is None:\n",
+    "        return None, None\n",
+    "    return float(roe - coe), float(last.get(\"economic_profit\") or float(\"nan\"))\n",
+    "\n",
+    "\n",
+    "spread_by_ticker = {t: roe_spread(t) for t in WATCHLIST}\n",
+    "spread_by_ticker\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3428290b",
+   "metadata": {},
+   "source": [
+    "## 5. Combine + rank\n",
+    "\n",
+    "Cross-sectional rank on each axis (percentile), then average — no arbitrary weighting scheme, just \"strong on both\" vs. \"strong on one, weak on the other\" vs. \"weak on both\". This is a screen to generate a short list for further diligence, not a standalone signal.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "b6b1fef1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-08T02:45:12.585286Z",
+     "iopub.status.busy": "2026-07-08T02:45:12.585156Z",
+     "iopub.status.idle": "2026-07-08T02:45:12.596184Z",
+     "shell.execute_reply": "2026-07-08T02:45:12.595755Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>ticker</th>\n",
+       "      <th>residual_sharpe</th>\n",
+       "      <th>roe_spread</th>\n",
+       "      <th>economic_profit_latest_quarter_$</th>\n",
+       "      <th>sharpe_pct</th>\n",
+       "      <th>spread_pct</th>\n",
+       "      <th>compounder_score</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>CAT</td>\n",
+       "      <td>1.462654</td>\n",
+       "      <td>0.340898</td>\n",
+       "      <td>6.361503e+09</td>\n",
+       "      <td>0.875</td>\n",
+       "      <td>0.750</td>\n",
+       "      <td>0.8125</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>AAPL</td>\n",
+       "      <td>0.101964</td>\n",
+       "      <td>1.373834</td>\n",
+       "      <td>1.463009e+11</td>\n",
+       "      <td>0.375</td>\n",
+       "      <td>1.000</td>\n",
+       "      <td>0.6875</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>NVDA</td>\n",
+       "      <td>0.156155</td>\n",
+       "      <td>0.986640</td>\n",
+       "      <td>1.928625e+11</td>\n",
+       "      <td>0.500</td>\n",
+       "      <td>0.875</td>\n",
+       "      <td>0.6875</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>JNJ</td>\n",
+       "      <td>2.373279</td>\n",
+       "      <td>0.216562</td>\n",
+       "      <td>1.758178e+10</td>\n",
+       "      <td>1.000</td>\n",
+       "      <td>0.375</td>\n",
+       "      <td>0.6875</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>WMT</td>\n",
+       "      <td>0.911753</td>\n",
+       "      <td>0.188652</td>\n",
+       "      <td>1.779552e+10</td>\n",
+       "      <td>0.750</td>\n",
+       "      <td>0.250</td>\n",
+       "      <td>0.5000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>MSFT</td>\n",
+       "      <td>-1.158971</td>\n",
+       "      <td>0.247062</td>\n",
+       "      <td>1.023742e+11</td>\n",
+       "      <td>0.125</td>\n",
+       "      <td>0.625</td>\n",
+       "      <td>0.3750</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>COST</td>\n",
+       "      <td>0.007010</td>\n",
+       "      <td>0.240363</td>\n",
+       "      <td>8.054324e+09</td>\n",
+       "      <td>0.250</td>\n",
+       "      <td>0.500</td>\n",
+       "      <td>0.3750</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>XOM</td>\n",
+       "      <td>0.571785</td>\n",
+       "      <td>0.042140</td>\n",
+       "      <td>1.071968e+10</td>\n",
+       "      <td>0.625</td>\n",
+       "      <td>0.125</td>\n",
+       "      <td>0.3750</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  ticker  residual_sharpe  roe_spread  economic_profit_latest_quarter_$  sharpe_pct  spread_pct  compounder_score\n",
+       "0    CAT         1.462654    0.340898                      6.361503e+09       0.875       0.750            0.8125\n",
+       "1   AAPL         0.101964    1.373834                      1.463009e+11       0.375       1.000            0.6875\n",
+       "2   NVDA         0.156155    0.986640                      1.928625e+11       0.500       0.875            0.6875\n",
+       "3    JNJ         2.373279    0.216562                      1.758178e+10       1.000       0.375            0.6875\n",
+       "4    WMT         0.911753    0.188652                      1.779552e+10       0.750       0.250            0.5000\n",
+       "5   MSFT        -1.158971    0.247062                      1.023742e+11       0.125       0.625            0.3750\n",
+       "6   COST         0.007010    0.240363                      8.054324e+09       0.250       0.500            0.3750\n",
+       "7    XOM         0.571785    0.042140                      1.071968e+10       0.625       0.125            0.3750"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import pandas as pd\n",
+    "\n",
+    "rows = []\n",
+    "for t in WATCHLIST:\n",
+    "    rs = sharpe_by_ticker.get(t)\n",
+    "    spread, econ_profit_dollar = spread_by_ticker.get(t, (None, None))\n",
+    "    rows.append(\n",
+    "        {\n",
+    "            \"ticker\": t,\n",
+    "            \"residual_sharpe\": rs,\n",
+    "            \"roe_spread\": spread,\n",
+    "            \"economic_profit_latest_quarter_$\": econ_profit_dollar,\n",
+    "        }\n",
+    "    )\n",
+    "screen = pd.DataFrame(rows).dropna(subset=[\"residual_sharpe\", \"roe_spread\"])\n",
+    "screen[\"sharpe_pct\"] = screen[\"residual_sharpe\"].rank(pct=True)\n",
+    "screen[\"spread_pct\"] = screen[\"roe_spread\"].rank(pct=True)\n",
+    "screen[\"compounder_score\"] = (screen[\"sharpe_pct\"] + screen[\"spread_pct\"]) / 2\n",
+    "screen = screen.sort_values(\"compounder_score\", ascending=False).reset_index(drop=True)\n",
+    "display(screen)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "82ece799",
+   "metadata": {},
+   "source": [
+    "## Next steps\n",
+    "\n",
+    "- Widen `WATCHLIST` with `riskmodels_search_tickers` / `client.search_tickers()` for a sector or the full universe (subject to per-call fundamentals billing — no batch/bulk variant exists by design, see `OPENAPI_SPEC.yaml` `/fundamentals/{ticker}`).\n",
+    "- Pair with `client.get_fundamentals_sensitivity_grid(ticker)` to see how sensitive a borderline name's `roe_spread` is to the ERP assumption before acting on the screen.\n",
+    "- **Pre-earnings hedge timing:** [`pre_earnings_hedge_timing.ipynb`](./pre_earnings_hedge_timing.ipynb)\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/sdk/riskmodels/aom/__init__.py
+++ b/sdk/riskmodels/aom/__init__.py
@@ -3,6 +3,7 @@
 from .builder import (
     analyze,
     comparison,
+    fundamentals,
     hedge_action,
     portfolio_id,
     portfolio_inline,
@@ -24,6 +25,7 @@ __all__ = [
     "execute_plan",
     "normalize_execution_plan",
     "serialize_plan",
+    "fundamentals",
     "hedge_action",
     "portfolio_id",
     "portfolio_inline",

--- a/sdk/riskmodels/aom/builder.py
+++ b/sdk/riskmodels/aom/builder.py
@@ -72,6 +72,24 @@ class _ScopedBuilder:
     def chain(self, *stages: ChainStage) -> _ChainBuilder:
         return _ChainBuilder(self._subject, dict(self._scope), list(stages))
 
+    def with_fundamentals(
+        self,
+        *,
+        erp: float | None = None,
+        tax_rate: float | None = None,
+        rf_tenor: str | None = None,
+        periods: int | None = None,
+    ) -> _ChainBuilder:
+        """Start a chain with PIT quarterly fundamentals context (H.89.6).
+
+        Shorthand for ``.chain(fundamentals(...))``. Compiles to
+        ``client.get_fundamentals(..., as_dataframe=True)``; the result rides
+        :func:`riskmodels.llm.to_llm_context` like any other SDK DataFrame.
+        """
+        return self.chain(
+            fundamentals(erp=erp, tax_rate=tax_rate, rf_tenor=rf_tenor, periods=periods)
+        )
+
     def return_attribution(
         self,
         *,
@@ -159,6 +177,24 @@ class _ChainBuilder:
         self._intent_val = value
         return self
 
+    def with_fundamentals(
+        self,
+        *,
+        erp: float | None = None,
+        tax_rate: float | None = None,
+        rf_tenor: str | None = None,
+        periods: int | None = None,
+    ) -> _ChainBuilder:
+        """Append PIT quarterly fundamentals context onto an existing chain (H.89.6).
+
+        E.g. ``.chain(analyze(lens="exposure", ...)).with_fundamentals()`` fetches
+        both the exposure snapshot and fundamentals in one compiled plan.
+        """
+        self._stages.append(
+            fundamentals(erp=erp, tax_rate=tax_rate, rf_tenor=rf_tenor, periods=periods)
+        )
+        return self
+
     def _finalize(self, mode: OutputMode) -> AOMChainRequest:
         req: AOMChainRequest = {
             "subject": self._subject,
@@ -224,4 +260,24 @@ def hedge_action(*, depends_on: str | None = "previous") -> ChainStage:
     out: dict[str, Any] = {"kind": "hedge_action"}
     if depends_on is not None:
         out["depends_on"] = depends_on  # type: ignore[assignment]
+    return out  # type: ignore[return-value]
+
+
+def fundamentals(
+    *,
+    erp: float | None = None,
+    tax_rate: float | None = None,
+    rf_tenor: str | None = None,
+    periods: int | None = None,
+) -> ChainStage:
+    """Chain-stage factory backing ``.with_fundamentals()`` (H.89.6)."""
+    out: dict[str, Any] = {"kind": "fundamentals"}
+    if erp is not None:
+        out["erp"] = erp
+    if tax_rate is not None:
+        out["tax_rate"] = tax_rate
+    if rf_tenor is not None:
+        out["rf_tenor"] = rf_tenor
+    if periods is not None:
+        out["periods"] = periods
     return out  # type: ignore[return-value]

--- a/sdk/riskmodels/aom/compiler.py
+++ b/sdk/riskmodels/aom/compiler.py
@@ -54,10 +54,12 @@ def validate_aom(req: AOMRequest) -> None:
             )
         for i, stage in enumerate(chain):
             k = stage.get("kind")
-            if k not in ("analyze", "hedge_action"):
+            if k not in ("analyze", "hedge_action", "fundamentals"):
                 raise RiskModelsValidationError(
-                    f"Invalid chain stage at index {i}: kind must be 'analyze' or 'hedge_action'.",
-                    fix='Use analyze(lens=...) or hedge_action(depends_on="previous").',
+                    f"Invalid chain stage at index {i}: kind must be "
+                    "'analyze', 'hedge_action', or 'fundamentals'.",
+                    fix='Use analyze(lens=...), hedge_action(depends_on="previous"), '
+                    "or fundamentals().",
                 )
             if k == "analyze":
                 if not stage.get("lens"):
@@ -430,6 +432,19 @@ def _compile_chain(req: AOMChainRequest) -> ExecutionPlanV1:
                     client_method="decompose",
                     kwargs={"ticker": ticker, "as_dataframe": False},
                     chain_stage_index=i,
+                )
+            )
+        elif sk == "fundamentals":
+            kwargs: dict[str, Any] = {"ticker": ticker, "as_dataframe": True}
+            for opt_key in ("erp", "tax_rate", "rf_tenor", "periods"):
+                if stage.get(opt_key) is not None:
+                    kwargs[opt_key] = stage[opt_key]
+            steps_list.append(
+                RestFetchStep(
+                    step_id=nid(),
+                    client_method="get_fundamentals",
+                    kwargs=kwargs,
+                    binding={"ticker": ticker, "kind": "fundamentals", "chain_stage_index": i},
                 )
             )
 

--- a/sdk/riskmodels/aom/types.py
+++ b/sdk/riskmodels/aom/types.py
@@ -94,7 +94,24 @@ class ChainStageHedge(TypedDict, total=False):
     depends_on: Literal["previous"] | str
 
 
-ChainStage = ChainStageAnalyze | ChainStageHedge
+class ChainStageFundamentals(TypedDict, total=False):
+    """``.with_fundamentals()`` — PIT quarterly fundamentals context (H.89.6).
+
+    Compiles to a ``RestFetchStep`` calling ``client.get_fundamentals(...,
+    as_dataframe=True)``; the resulting DataFrame carries SDK lineage/legend
+    attrs and rides ``riskmodels.llm.to_llm_context()`` like any other SDK
+    DataFrame output. Stock subjects only (same restriction as ``analyze`` /
+    ``hedge_action`` chain stages).
+    """
+
+    kind: Literal["fundamentals"]
+    erp: float
+    tax_rate: float
+    rf_tenor: str
+    periods: int
+
+
+ChainStage = ChainStageAnalyze | ChainStageHedge | ChainStageFundamentals
 
 
 class AOMSingleRequest(TypedDict, total=False):

--- a/sdk/riskmodels/client.py
+++ b/sdk/riskmodels/client.py
@@ -54,6 +54,13 @@ import pandas as pd
 
 from .auth import OAuthClientCredentialsAuth, StaticBearerAuth
 from .capabilities import DISCOVER_SPEC, discover_markdown
+from .fundamentals import (
+    RfTenor,
+    attach_fundamentals_metadata,
+    estimate_next_earnings,
+    fundamentals_json_to_dataframe,
+    sensitivity_grid_json_to_dataframe,
+)
 from .legends import COMBINED_ERM3_MACRO_LEGEND, SHORT_MACRO_SERIES_LEGEND, SHORT_RANKINGS_LEGEND
 from .lineage import RiskLineage
 from .mapping import TICKER_RETURNS_COLUMN_RENAME, extract_hedge_levels
@@ -2470,6 +2477,165 @@ class RiskModelsClient:
         if path is not None:
             Path(path).write_bytes(pdf)
         return pdf
+
+    def get_fundamentals(
+        self,
+        ticker: str,
+        *,
+        as_of: str | None = None,
+        periods: int = 8,
+        erp: float = 0.05,
+        tax_rate: float = 0.21,
+        rf_tenor: RfTenor = "10y",
+        as_dataframe: bool = False,
+    ) -> dict[str, Any] | pd.DataFrame:
+        """PIT quarterly fundamentals — derived analytics only (H.89.5, ``$0.005``).
+
+        Calls ``GET /fundamentals/{ticker}``. Rows carry TTM profitability
+        ratios (``roe_ttm``, ``roa_ttm``, ``fcf_margin``), ``leverage_ratio``,
+        ERM3 cascade betas with provenance, and the cost-of-capital layer
+        (``cost_of_equity``, ``cost_of_debt``, ``wacc``, ``economic_profit``).
+        Raw vendor line items (revenue, net income, EPS, balance-sheet
+        levels) are never included — see the API's
+        ``lib/api/fundamentals-contract.ts`` allowlist.
+
+        PIT: a row is visible iff its ``filed_date`` is on or before
+        ``as_of``. Never "latest".
+
+        Args:
+            ticker: Stock ticker symbol.
+            as_of: Point-in-time date, ``YYYY-MM-DD`` (default: today).
+            periods: Number of quarterly rows returned, most recent last
+                (server caps at 40).
+            erp: Equity risk premium for the cost-of-capital layer
+                (caller-supplied; no ERP opinion is stored server-side).
+            tax_rate: Tax rate applied to the WACC debt shield.
+            rf_tenor: Treasury CMT tenor backing ``rf_rate``. Default
+                ``"10y"`` (the valuation convention — pair a shorter tenor
+                with a bill-basis ERP or cost of capital is understated).
+            as_dataframe: If True, return a one-row-per-quarter DataFrame
+                with SDK lineage/legend/cheatsheet attrs (rides
+                :func:`riskmodels.llm.to_llm_context`). If False (default),
+                return the raw response dict.
+
+        Returns:
+            Raw JSON dict, or a DataFrame when ``as_dataframe=True``.
+
+        Example:
+            >>> df = client.get_fundamentals("AAPL", as_dataframe=True)
+            >>> df[["period_end_date", "roe_ttm", "wacc"]].tail(1)
+        """
+        t, _ = resolve_ticker(ticker, self)
+        params: dict[str, Any] = {
+            "periods": periods,
+            "erp": erp,
+            "tax_rate": tax_rate,
+            "rf_tenor": rf_tenor,
+        }
+        if as_of is not None:
+            params["as_of"] = as_of
+        body, _lineage, _r = self._transport.request(
+            "GET", f"/fundamentals/{quote(t, safe='')}", params=params
+        )
+        if not as_dataframe:
+            return body
+        df = fundamentals_json_to_dataframe(body)
+        attach_fundamentals_metadata(df, body)
+        return df
+
+    def get_fundamentals_sensitivity_grid(
+        self,
+        ticker: str,
+        *,
+        as_of: str | None = None,
+        erp_grid: list[float] | None = None,
+        rf_tenor_grid: list[RfTenor] | None = None,
+        tax_rate: float = 0.21,
+        as_dataframe: bool = False,
+    ) -> dict[str, Any] | pd.DataFrame:
+        """Cost-of-capital sensitivity grid — ``erp_grid`` x ``rf_tenor_grid`` (H.89.6, ``$0.005``).
+
+        Calls ``GET /fundamentals/{ticker}?grid=true``. Recomputes
+        ``cost_of_equity`` / ``wacc`` / ``economic_profit`` across every
+        combination of ERP and risk-free tenor for the latest PIT-visible
+        period only — a "what if my assumptions were different today" table,
+        not a time series. Same billing as :meth:`get_fundamentals`.
+
+        Args:
+            ticker: Stock ticker symbol.
+            as_of: Point-in-time date, ``YYYY-MM-DD`` (default: today).
+            erp_grid: ERP values to grid over (server default:
+                ``[0.03, 0.04, 0.05, 0.06, 0.07]``; 1-10 values in [0, 0.5]).
+            rf_tenor_grid: Tenor subset to grid over (server default: all
+                six tenors).
+            tax_rate: Tax rate applied to the WACC debt shield.
+            as_dataframe: If True, return a long-form DataFrame — one row
+                per ``(erp, rf_tenor)`` combination — with SDK attrs. If
+                False (default), return the raw response dict.
+
+        Returns:
+            Raw JSON dict (``sensitivity_grid`` key), or a long-form
+            DataFrame when ``as_dataframe=True``. ``None``-shaped
+            (``sensitivity_grid`` is ``null``) when no PIT-visible period
+            exists at ``as_of``.
+
+        Example:
+            >>> grid = client.get_fundamentals_sensitivity_grid(
+            ...     "AAPL", erp_grid=[0.04, 0.05, 0.06], as_dataframe=True
+            ... )
+            >>> grid.pivot(index="erp", columns="rf_tenor", values="wacc")
+        """
+        t, _ = resolve_ticker(ticker, self)
+        params: dict[str, Any] = {"grid": "true", "tax_rate": tax_rate}
+        if as_of is not None:
+            params["as_of"] = as_of
+        if erp_grid is not None:
+            params["erp_grid"] = ",".join(str(v) for v in erp_grid)
+        if rf_tenor_grid is not None:
+            params["rf_tenor_grid"] = ",".join(rf_tenor_grid)
+        body, _lineage, _r = self._transport.request(
+            "GET", f"/fundamentals/{quote(t, safe='')}", params=params
+        )
+        if not as_dataframe:
+            return body
+        df = sensitivity_grid_json_to_dataframe(body)
+        attach_fundamentals_metadata(df, body)
+        return df
+
+    def next_earnings(self, ticker: str, *, as_of: str | None = None) -> dict[str, Any]:
+        """Estimate the next earnings filing date from historical filing cadence.
+
+        NOT a real earnings calendar — the store carries no analyst
+        estimates or vendor earnings-calendar feed (``eps_forecast`` /
+        ``analyst_rating`` / ``target_price`` are permanently held back per
+        the no-investment-advice house rule). This is the median gap
+        between this ticker's own historical ``filed_date`` values,
+        projected forward from the most recent one. Always echoes
+        ``basis="filed_date_cadence"`` so callers don't mistake it for a
+        confirmed date.
+
+        Calls :meth:`get_fundamentals` under the hood (``periods=8``, enough
+        history for a stable cadence estimate without over-fetching).
+
+        Args:
+            ticker: Stock ticker symbol.
+            as_of: Point-in-time date, ``YYYY-MM-DD`` (default: today) — the
+                cadence is computed only from filings visible by this date.
+
+        Returns:
+            Dict with ``ticker``, ``last_filed_date``,
+            ``estimated_next_filed_date``, ``median_cadence_days``,
+            ``n_periods_observed``, ``basis``, ``note``. Date fields are
+            ``None`` when fewer than 2 filed quarters are visible.
+
+        Example:
+            >>> client.next_earnings("AAPL")
+            {'ticker': 'AAPL', 'estimated_next_filed_date': '2026-05-01', ...}
+        """
+        body = self.get_fundamentals(ticker, as_of=as_of, periods=8)
+        rows = body.get("rows") or [] if isinstance(body, dict) else []
+        t, _ = resolve_ticker(ticker, self)
+        return estimate_next_earnings(t, rows).to_dict()
 
     def _batch_json_for_portfolio(
         self, tickers: list[str], metrics: list[str], years: int

--- a/sdk/riskmodels/fundamentals.py
+++ b/sdk/riskmodels/fundamentals.py
@@ -1,0 +1,241 @@
+"""PIT quarterly fundamentals — parsing, cadence-based next-earnings estimate,
+and cost-of-capital sensitivity-grid helpers for ``GET /fundamentals/{ticker}``.
+
+This module owns the DataFrame shape and derived (client-side, non-reconstructive)
+helpers for the fundamentals endpoint. ``client.get_fundamentals()`` /
+``client.next_earnings()`` (see ``client.py``) call the endpoint and delegate
+parsing here — mirroring how ``parsing.py`` backs ``get_ticker_returns`` /
+``get_rankings``.
+
+LICENSING: every field this module reads comes from the server's already
+derived-only, sanitized response body (``lib/api/fundamentals-contract.ts`` on
+the API side). This module never reconstructs a held-back raw field (revenue,
+net income, EPS, balance-sheet levels, earnings surprise) from derived ones —
+it only reshapes and aggregates what the server already cleared to ship. See
+``CLAUDE.md`` — "Derived-only licensing is enforced server-side — never add
+client-side raw-field reconstruction."
+
+Examples
+--------
+>>> from riskmodels import RiskModelsClient
+>>> client = RiskModelsClient.from_env()
+>>> df = client.get_fundamentals("AAPL", as_dataframe=True)
+>>> df.columns[:3].tolist()
+['period_end_date', 'filed_date', 'filed_date_source']
+>>> client.next_earnings("AAPL")
+{'ticker': 'AAPL', 'last_filed_date': '2026-01-30', 'estimated_next_filed_date': '2026-05-01', ...}
+"""
+
+from __future__ import annotations
+
+import statistics
+from dataclasses import dataclass
+from datetime import date, timedelta
+from typing import Any, Literal
+
+import pandas as pd
+
+from .lineage import RiskLineage
+from .metadata_attach import attach_sdk_metadata
+
+RfTenor = Literal["3m", "1y", "2y", "5y", "10y", "30y"]
+
+FUNDAMENTALS_ROW_COLUMNS = [
+    "period_end_date",
+    "filed_date",
+    "filed_date_source",
+    "gross_margin",
+    "operating_margin",
+    "roe_ttm",
+    "roa_ttm",
+    "leverage_ratio",
+    "fcf_margin",
+    "beta_market",
+    "beta_sector",
+    "beta_subsector",
+    "beta_source",
+    "rf_rate",
+    "cost_of_equity",
+    "cost_of_debt",
+    "wacc",
+    "economic_profit",
+    "market_cap",
+]
+
+FUNDAMENTALS_COLUMN_HINTS: dict[str, str] = {
+    "period_end_date": "Fiscal quarter end (economic truth).",
+    "filed_date": "PIT knowledge-time stamp; null if unfiled at the requested as_of.",
+    "filed_date_source": "'exact' (vendor filing date) or 'approx' (period_end + 45d, the 10-Q deadline).",
+    "roe_ttm": "Trailing-4Q net income / trailing-4Q average total equity.",
+    "roa_ttm": "Trailing-4Q net income / trailing-4Q average total assets.",
+    "leverage_ratio": "Latest total_debt / latest total_equity (point-in-time, not TTM).",
+    "fcf_margin": "(cash_from_operations_ttm - capex_ttm) / revenue_ttm.",
+    "beta_market": "Short-half-life conditional market beta — NOT a textbook long-run CAPM beta.",
+    "beta_source": "Provenance of the beta window: none | in-universe | out-of-universe | post-delisting.",
+    "rf_rate": "Treasury CMT yield at the requested rf_tenor, sampled at/before this quarter's period end.",
+    "cost_of_equity": "CAPM: rf_rate + beta_market * erp (caller-supplied erp).",
+    "wacc": "BOOK-value-weighted WACC (balance-sheet equity/debt, not market-value weights).",
+    "economic_profit": "(roe_ttm - cost_of_equity) * total_equity — equity-charge form.",
+}
+
+
+def attach_fundamentals_semantic_hints(df: pd.DataFrame) -> None:
+    """Merge the fundamentals-specific column hints into df.attrs cheatsheet target."""
+    existing = df.attrs.get("riskmodels_column_hints")
+    merged = {**(existing or {}), **FUNDAMENTALS_COLUMN_HINTS}
+    df.attrs["riskmodels_column_hints"] = merged
+
+
+def fundamentals_json_to_dataframe(body: dict[str, Any]) -> pd.DataFrame:
+    """Rows from ``GET /fundamentals/{ticker}`` -> one-row-per-quarter DataFrame.
+
+    Empty rows list -> empty DataFrame with the full column set (never a
+    zero-column frame, so downstream ``df["roe_ttm"]`` reads are safe).
+    """
+    rows = body.get("rows") or []
+    if not rows:
+        return pd.DataFrame(columns=FUNDAMENTALS_ROW_COLUMNS)
+    df = pd.DataFrame(rows)
+    for col in FUNDAMENTALS_ROW_COLUMNS:
+        if col not in df.columns:
+            df[col] = None
+    mc = body.get("market_cap") or {}
+    df["market_cap"] = mc.get("value")
+    return df[FUNDAMENTALS_ROW_COLUMNS]
+
+
+def sensitivity_grid_json_to_dataframe(body: dict[str, Any]) -> pd.DataFrame:
+    """Flatten ``sensitivity_grid`` (erp x rf_tenor cells) into long form.
+
+    One row per (erp, rf_tenor) combination: ``erp``, ``rf_tenor``,
+    ``cost_of_equity``, ``wacc``, ``economic_profit``, plus the anchor
+    ``period_end_date`` / ``filed_date`` repeated on every row for convenient
+    ``groupby`` / heatmap pivoting.
+    """
+    grid = body.get("sensitivity_grid")
+    cols = [
+        "period_end_date",
+        "filed_date",
+        "erp",
+        "rf_tenor",
+        "cost_of_equity",
+        "wacc",
+        "economic_profit",
+    ]
+    if not grid or not grid.get("cells"):
+        return pd.DataFrame(columns=cols)
+    erp_values = grid["erp_values"]
+    tenor_values = grid["rf_tenor_values"]
+    records: list[dict[str, Any]] = []
+    for i, erp in enumerate(erp_values):
+        row = grid["cells"][i]
+        for j, tenor in enumerate(tenor_values):
+            cell = row[j]
+            records.append(
+                {
+                    "period_end_date": grid.get("period_end_date"),
+                    "filed_date": grid.get("filed_date"),
+                    "erp": erp,
+                    "rf_tenor": tenor,
+                    "cost_of_equity": cell.get("cost_of_equity"),
+                    "wacc": cell.get("wacc"),
+                    "economic_profit": cell.get("economic_profit"),
+                }
+            )
+    return pd.DataFrame.from_records(records, columns=cols)
+
+
+@dataclass(frozen=True)
+class NextEarningsEstimate:
+    """Cadence-based next-filing estimate — NOT a real earnings calendar.
+
+    Derived entirely from the already-shipped ``filed_date`` column (an
+    allowlisted PIT stamp, not a held-back raw field): the median gap between
+    consecutive observed filings, projected forward from the most recent one.
+    No analyst estimate, no vendor earnings-calendar feed exists in the store
+    (``eps_forecast`` / ``analyst_rating`` / ``target_price`` are permanently
+    held back — see ``FUNDAMENTALS_HELD_BACK_FIELDS`` in the API repo). This
+    is a statistical projection of a company's own historical filing cadence,
+    always echoed with ``basis="filed_date_cadence"`` so callers don't mistake
+    it for a confirmed date.
+    """
+
+    ticker: str
+    last_filed_date: str | None
+    estimated_next_filed_date: str | None
+    median_cadence_days: float | None
+    n_periods_observed: int
+    basis: str = "filed_date_cadence"
+    note: str = (
+        "Statistical projection from historical filing cadence, not a confirmed "
+        "earnings-calendar date. No analyst estimates or vendor earnings-calendar "
+        "feed are stored (derived-only licensing posture)."
+    )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "ticker": self.ticker,
+            "last_filed_date": self.last_filed_date,
+            "estimated_next_filed_date": self.estimated_next_filed_date,
+            "median_cadence_days": self.median_cadence_days,
+            "n_periods_observed": self.n_periods_observed,
+            "basis": self.basis,
+            "note": self.note,
+        }
+
+
+def estimate_next_earnings(
+    ticker: str,
+    rows: list[dict[str, Any]],
+    *,
+    min_periods: int = 2,
+) -> NextEarningsEstimate:
+    """Project the next filing date from the median gap between observed ``filed_date`` values.
+
+    Args:
+        ticker: Echoed on the result.
+        rows: Rows as returned by ``GET /fundamentals/{ticker}`` (oldest -> newest).
+        min_periods: Minimum number of filed quarters required to compute a
+            cadence; below this, the estimate is null (too little history to
+            be more than a guess — most fundamentals histories start ~2009,
+            so this only bites truly new stores).
+
+    Returns:
+        A :class:`NextEarningsEstimate`. All fields are null (but the object
+        is still returned, never ``None``) when fewer than ``min_periods``
+        filed dates are present.
+    """
+    filed = sorted(d for r in rows if (d := r.get("filed_date")))
+    if len(filed) < min_periods:
+        return NextEarningsEstimate(
+            ticker=ticker,
+            last_filed_date=filed[-1] if filed else None,
+            estimated_next_filed_date=None,
+            median_cadence_days=None,
+            n_periods_observed=len(filed),
+        )
+    gaps = [
+        (date.fromisoformat(b) - date.fromisoformat(a)).days
+        for a, b in zip(filed[:-1], filed[1:])
+    ]
+    median_gap = statistics.median(gaps)
+    last = date.fromisoformat(filed[-1])
+    next_estimated = last + timedelta(days=round(median_gap))
+    return NextEarningsEstimate(
+        ticker=ticker,
+        last_filed_date=filed[-1],
+        estimated_next_filed_date=next_estimated.isoformat(),
+        median_cadence_days=median_gap,
+        n_periods_observed=len(filed),
+    )
+
+
+def attach_fundamentals_metadata(df: pd.DataFrame, body: dict[str, Any]) -> None:
+    """Attach SDK lineage/legend/cheatsheet attrs so the frame rides ``to_llm_context()``."""
+    meta = body.get("_metadata") if isinstance(body, dict) else None
+    lineage = RiskLineage.from_metadata(meta) or RiskLineage()
+    attach_sdk_metadata(df, lineage, kind="fundamentals")
+    attach_fundamentals_semantic_hints(df)
+    disclosures = body.get("disclosures") if isinstance(body, dict) else None
+    if disclosures:
+        df.attrs["riskmodels_fundamentals_disclosures"] = disclosures

--- a/sdk/tests/test_aom_fundamentals.py
+++ b/sdk/tests/test_aom_fundamentals.py
@@ -1,0 +1,138 @@
+"""AOM `.with_fundamentals()` chain stage (H.89.6).
+
+Compiles to a `RestFetchStep` calling `client.get_fundamentals(...,
+as_dataframe=True)` — no executor changes needed (RestFetchStep already
+dispatches via getattr(client, client_method)). See sdk/riskmodels/aom/
+compiler.py `_compile_chain` and builder.py `with_fundamentals`/`fundamentals`.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+
+from riskmodels import rm, run
+from riskmodels.aom import analyze, compile_plan, fundamentals, hedge_action, stock, validate_aom
+from riskmodels.aom.plan_schema import RestFetchStep
+from riskmodels.exceptions import RiskModelsValidationError
+
+
+def test_with_fundamentals_alone_compiles_to_get_fundamentals_rest_fetch() -> None:
+    req = rm().subject(stock("AAPL")).scope(date_range_preset="1y").with_fundamentals().structured()
+    plan = compile_plan(req)
+    ops = [s.op for s in plan.steps]
+    assert ops == ["resolve_subject", "rest_fetch"]
+    fetch = plan.steps[1]
+    assert isinstance(fetch, RestFetchStep)
+    assert fetch.client_method == "get_fundamentals"
+    assert fetch.kwargs == {"ticker": "AAPL", "as_dataframe": True}
+    assert fetch.binding["kind"] == "fundamentals"
+
+
+def test_with_fundamentals_passes_cost_of_capital_overrides() -> None:
+    req = (
+        rm()
+        .subject(stock("AAPL"))
+        .scope(date_range_preset="1y")
+        .with_fundamentals(erp=0.06, tax_rate=0.25, rf_tenor="1y", periods=4)
+        .structured()
+    )
+    plan = compile_plan(req)
+    fetch = plan.steps[1]
+    assert isinstance(fetch, RestFetchStep)
+    assert fetch.kwargs == {
+        "ticker": "AAPL",
+        "as_dataframe": True,
+        "erp": 0.06,
+        "tax_rate": 0.25,
+        "rf_tenor": "1y",
+        "periods": 4,
+    }
+
+
+def test_with_fundamentals_appends_onto_an_existing_analyze_chain() -> None:
+    req = (
+        rm()
+        .subject(stock("AAPL"))
+        .scope(date_range_preset="mtd")
+        .chain(analyze(lens="exposure", resolution="full_stack", view="snapshot"))
+        .with_fundamentals()
+        .structured()
+    )
+    plan = compile_plan(req)
+    ops = [s.op for s in plan.steps]
+    assert ops == ["resolve_subject", "rest_fetch", "rest_fetch"]
+    fundamentals_step = plan.steps[2]
+    assert isinstance(fundamentals_step, RestFetchStep)
+    assert fundamentals_step.client_method == "get_fundamentals"
+
+
+def test_with_fundamentals_coexists_with_hedge_action_in_a_chain() -> None:
+    req = (
+        rm()
+        .subject(stock("AAPL"))
+        .scope(date_range_preset="mtd")
+        .chain(
+            analyze(lens="exposure", resolution="full_stack", view="snapshot"),
+            hedge_action(depends_on="previous"),
+        )
+        .with_fundamentals()
+        .structured()
+    )
+    plan = compile_plan(req)
+    ops = [s.op for s in plan.steps]
+    assert ops == ["resolve_subject", "rest_fetch", "hedge_action", "rest_fetch"]
+
+
+def test_fundamentals_chain_stage_kind_passes_validation() -> None:
+    req = {
+        "subject": stock("AAPL"),
+        "scope": {},
+        "chain": [fundamentals()],
+        "output_mode": "structured",
+    }
+    validate_aom(req)  # no raise
+
+
+def test_invalid_chain_stage_kind_error_mentions_fundamentals() -> None:
+    req = {
+        "subject": stock("AAPL"),
+        "scope": {},
+        "chain": [{"kind": "bogus"}],
+        "output_mode": "structured",
+    }
+    with pytest.raises(RiskModelsValidationError, match="fundamentals"):
+        validate_aom(req)
+
+
+def test_execute_plan_runs_get_fundamentals_and_rides_to_llm_context() -> None:
+    from riskmodels.aom.executor import execute_plan
+    from riskmodels.llm import to_llm_context
+
+    df = pd.DataFrame([{"period_end_date": "2025-09-30", "roe_ttm": 1.6}])
+    df.attrs["legend"] = "ERM3 legend stub"
+
+    req = rm().subject(stock("AAPL")).scope(date_range_preset="1y").with_fundamentals().structured()
+    plan = compile_plan(req)
+    client = MagicMock()
+    client.get_fundamentals.return_value = df
+
+    out = execute_plan(client, plan)
+    assert not out["errors"]
+    client.get_fundamentals.assert_called_once_with(ticker="AAPL", as_dataframe=True)
+    fundamentals_result = out["steps_out"][-1]["result"]
+    assert fundamentals_result is df
+    # Generic DataFrame dispatch — no fundamentals-specific code in llm.py required.
+    md = to_llm_context(fundamentals_result)
+    assert "roe_ttm" in md
+
+
+def test_run_end_to_end_with_mocked_client() -> None:
+    req = rm().subject(stock("MSFT")).scope(date_range_preset="1y").with_fundamentals().structured()
+    client = MagicMock()
+    client.get_fundamentals.return_value = pd.DataFrame([{"roe_ttm": 0.4}])
+    out = run(client, req)
+    assert not out["errors"]
+    assert out["steps_out"][-1]["client_method"] == "get_fundamentals"

--- a/sdk/tests/test_fundamentals.py
+++ b/sdk/tests/test_fundamentals.py
@@ -1,0 +1,306 @@
+"""Fundamentals SDK surface (H.89.6): client.get_fundamentals /
+client.get_fundamentals_sensitivity_grid / client.next_earnings, plus the
+pure parsing/estimation helpers in riskmodels.fundamentals.
+
+Mocked-HTTP coverage mirrors test_client_filers.py: URL/param construction,
+as_of pass-through, DataFrame shape, and the sensitivity-grid variant.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from riskmodels.client import RiskModelsClient
+from riskmodels.fundamentals import (
+    estimate_next_earnings,
+    fundamentals_json_to_dataframe,
+    sensitivity_grid_json_to_dataframe,
+)
+
+TICKER = "AAPL"
+
+ROWS = [
+    {
+        "period_end_date": "2025-06-30",
+        "filed_date": "2025-08-01",
+        "filed_date_source": "exact",
+        "gross_margin": None,
+        "operating_margin": None,
+        "roe_ttm": 1.5,
+        "roa_ttm": 0.3,
+        "leverage_ratio": 1.2,
+        "fcf_margin": 0.25,
+        "beta_market": 1.1,
+        "beta_sector": -0.1,
+        "beta_subsector": -0.05,
+        "beta_source": "in-universe",
+        "rf_rate": 0.04,
+        "cost_of_equity": 0.095,
+        "cost_of_debt": 0.03,
+        "wacc": 0.08,
+        "economic_profit": 12.0,
+    },
+    {
+        "period_end_date": "2025-09-30",
+        "filed_date": "2025-10-31",
+        "filed_date_source": "exact",
+        "gross_margin": None,
+        "operating_margin": None,
+        "roe_ttm": 1.6,
+        "roa_ttm": 0.33,
+        "leverage_ratio": 1.27,
+        "fcf_margin": 0.26,
+        "beta_market": 1.2,
+        "beta_sector": -0.2,
+        "beta_subsector": -0.1,
+        "beta_source": "in-universe",
+        "rf_rate": 0.04,
+        "cost_of_equity": 0.10,
+        "cost_of_debt": 0.03,
+        "wacc": 0.085,
+        "economic_profit": 13.0,
+    },
+]
+
+
+def _client(handler) -> RiskModelsClient:
+    return RiskModelsClient(
+        base_url="https://riskmodels.app/api",
+        api_key="test",
+        validate="off",
+        http_client=httpx.Client(transport=httpx.MockTransport(handler)),
+    )
+
+
+# ── client.get_fundamentals ─────────────────────────────────────────────────
+
+
+def test_get_fundamentals_builds_params_and_returns_raw_dict_by_default():
+    captured = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["params"] = dict(request.url.params)
+        return httpx.Response(
+            200,
+            json={
+                "ticker": TICKER,
+                "as_of": "2026-03-31",
+                "periods_returned": 2,
+                "rows": ROWS,
+                "market_cap": {"value": 3.5e12, "basis": "current_snapshot"},
+                "disclosures": {"parameters": {"erp": 0.06}},
+            },
+        )
+
+    out = _client(handler).get_fundamentals(
+        TICKER, as_of="2026-03-31", periods=4, erp=0.06, tax_rate=0.25, rf_tenor="1y"
+    )
+    assert f"/fundamentals/{TICKER}" in captured["url"]
+    assert captured["params"] == {
+        "periods": "4",
+        "erp": "0.06",
+        "tax_rate": "0.25",
+        "rf_tenor": "1y",
+        "as_of": "2026-03-31",
+    }
+    assert isinstance(out, dict)
+    assert out["rows"] == ROWS
+
+
+def test_get_fundamentals_omits_as_of_when_not_given():
+    captured = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["params"] = dict(request.url.params)
+        return httpx.Response(200, json={"ticker": TICKER, "rows": []})
+
+    _client(handler).get_fundamentals(TICKER)
+    assert "as_of" not in captured["params"]
+    # Defaults echoed even when not explicitly passed.
+    assert captured["params"]["periods"] == "8"
+    assert captured["params"]["rf_tenor"] == "10y"
+
+
+def test_get_fundamentals_as_dataframe_carries_sdk_attrs():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "ticker": TICKER,
+                "as_of": "2026-03-31",
+                "rows": ROWS,
+                "market_cap": {"value": 3.5e12},
+                "disclosures": {"realized_historical_only": "..."},
+            },
+        )
+
+    df = _client(handler).get_fundamentals(TICKER, as_dataframe=True)
+    assert list(df["period_end_date"]) == ["2025-06-30", "2025-09-30"]
+    assert (df["market_cap"] == 3.5e12).all()
+    assert df.attrs.get("riskmodels_semantic_cheatsheet") is not None
+    assert df.attrs.get("riskmodels_fundamentals_disclosures") == {
+        "realized_historical_only": "..."
+    }
+
+
+def test_get_fundamentals_dataframe_never_carries_held_back_columns():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"ticker": TICKER, "rows": ROWS})
+
+    df = _client(handler).get_fundamentals(TICKER, as_dataframe=True)
+    for held_back in ("revenue", "net_income", "eps_actual", "earnings_surprise"):
+        assert held_back not in df.columns
+
+
+# ── client.get_fundamentals_sensitivity_grid ────────────────────────────────
+
+
+def test_get_fundamentals_sensitivity_grid_builds_grid_params():
+    captured = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["params"] = dict(request.url.params)
+        return httpx.Response(
+            200,
+            json={
+                "ticker": TICKER,
+                "rows": ROWS,
+                "sensitivity_grid": {
+                    "period_end_date": "2025-09-30",
+                    "filed_date": "2025-10-31",
+                    "erp_values": [0.04, 0.06],
+                    "rf_tenor_values": ["1y", "10y"],
+                    "tax_rate": 0.21,
+                    "cells": [
+                        [
+                            {"cost_of_equity": 0.08, "wacc": 0.07, "economic_profit": 10.0},
+                            {"cost_of_equity": 0.09, "wacc": 0.075, "economic_profit": 11.0},
+                        ],
+                        [
+                            {"cost_of_equity": 0.10, "wacc": 0.08, "economic_profit": 12.0},
+                            {"cost_of_equity": 0.11, "wacc": 0.085, "economic_profit": 13.0},
+                        ],
+                    ],
+                },
+            },
+        )
+
+    out = _client(handler).get_fundamentals_sensitivity_grid(
+        TICKER, erp_grid=[0.04, 0.06], rf_tenor_grid=["1y", "10y"], tax_rate=0.21
+    )
+    assert captured["params"]["grid"] == "true"
+    assert captured["params"]["erp_grid"] == "0.04,0.06"
+    assert captured["params"]["rf_tenor_grid"] == "1y,10y"
+    assert out["sensitivity_grid"]["erp_values"] == [0.04, 0.06]
+
+
+def test_get_fundamentals_sensitivity_grid_as_dataframe_is_long_form():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "ticker": TICKER,
+                "rows": ROWS,
+                "sensitivity_grid": {
+                    "period_end_date": "2025-09-30",
+                    "filed_date": "2025-10-31",
+                    "erp_values": [0.04, 0.06],
+                    "rf_tenor_values": ["1y", "10y"],
+                    "tax_rate": 0.21,
+                    "cells": [
+                        [
+                            {"cost_of_equity": 0.08, "wacc": 0.07, "economic_profit": 10.0},
+                            {"cost_of_equity": 0.09, "wacc": 0.075, "economic_profit": 11.0},
+                        ],
+                        [
+                            {"cost_of_equity": 0.10, "wacc": 0.08, "economic_profit": 12.0},
+                            {"cost_of_equity": 0.11, "wacc": 0.085, "economic_profit": 13.0},
+                        ],
+                    ],
+                },
+            },
+        )
+
+    df = _client(handler).get_fundamentals_sensitivity_grid(TICKER, as_dataframe=True)
+    assert len(df) == 4
+    assert set(df["erp"]) == {0.04, 0.06}
+    assert set(df["rf_tenor"]) == {"1y", "10y"}
+    row = df[(df["erp"] == 0.06) & (df["rf_tenor"] == "10y")].iloc[0]
+    assert row["cost_of_equity"] == pytest.approx(0.11)
+    assert row["wacc"] == pytest.approx(0.085)
+
+
+def test_get_fundamentals_sensitivity_grid_null_when_no_pit_period():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"ticker": TICKER, "rows": [], "sensitivity_grid": None})
+
+    df = _client(handler).get_fundamentals_sensitivity_grid(TICKER, as_dataframe=True)
+    assert df.empty
+    raw = _client(handler).get_fundamentals_sensitivity_grid(TICKER)
+    assert raw["sensitivity_grid"] is None
+
+
+# ── client.next_earnings ────────────────────────────────────────────────────
+
+
+def test_next_earnings_projects_from_median_filing_cadence():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"ticker": TICKER, "rows": ROWS})
+
+    out = _client(handler).next_earnings(TICKER)
+    assert out["ticker"] == TICKER
+    assert out["last_filed_date"] == "2025-10-31"
+    # Median gap between 2025-08-01 and 2025-10-31 is 91 days.
+    assert out["median_cadence_days"] == 91
+    assert out["estimated_next_filed_date"] == "2026-01-30"
+    assert out["basis"] == "filed_date_cadence"
+    assert "not a confirmed earnings-calendar date" in out["note"]
+
+
+def test_next_earnings_null_with_fewer_than_two_filed_quarters():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"ticker": TICKER, "rows": ROWS[:1]})
+
+    out = _client(handler).next_earnings(TICKER)
+    assert out["estimated_next_filed_date"] is None
+    assert out["n_periods_observed"] == 1
+
+
+# ── pure helpers (no HTTP) ──────────────────────────────────────────────────
+
+
+def test_fundamentals_json_to_dataframe_empty_rows_keeps_full_columns():
+    df = fundamentals_json_to_dataframe({"rows": []})
+    assert df.empty
+    assert "roe_ttm" in df.columns
+    assert "wacc" in df.columns
+
+
+def test_estimate_next_earnings_never_reconstructs_held_back_fields():
+    # Only filed_date (an allowlisted PIT stamp) drives the estimate — no
+    # revenue/eps/surprise field is read even if present on the row.
+    dirty_rows = [
+        {"filed_date": "2025-01-30", "revenue": 999, "eps_estimate": 1.23},
+        {"filed_date": "2025-05-01", "revenue": 999, "eps_estimate": 1.23},
+        {"filed_date": "2025-08-01", "revenue": 999, "eps_estimate": 1.23},
+    ]
+    est = estimate_next_earnings(TICKER, dirty_rows)
+    assert est.estimated_next_filed_date == "2025-11-01"
+    assert "revenue" not in est.to_dict()
+    assert "eps_estimate" not in est.to_dict()
+
+
+def test_sensitivity_grid_json_to_dataframe_handles_missing_grid():
+    df = sensitivity_grid_json_to_dataframe({"rows": []})
+    assert df.empty
+    assert list(df.columns) == [
+        "period_end_date",
+        "filed_date",
+        "erp",
+        "rf_tenor",
+        "cost_of_equity",
+        "wacc",
+        "economic_profit",
+    ]

--- a/sdk/tests/test_integration_live.py
+++ b/sdk/tests/test_integration_live.py
@@ -50,3 +50,70 @@ def test_live_get_metrics_aapl_shape(live_client: RiskModelsClient) -> None:
         "l3_market_er",
         "l3_mkt_er",
     }, f"expected L3 metric keys in row, got {sorted(keys)[:20]}..."
+
+
+def test_live_get_fundamentals_aapl_shape(live_client: RiskModelsClient) -> None:
+    """H.89.6: client.get_fundamentals() against the live H.89.5 endpoint."""
+    df = live_client.get_fundamentals("AAPL", periods=4, as_dataframe=True)
+    assert isinstance(df, pd.DataFrame)
+    assert not df.empty
+    assert {"period_end_date", "filed_date", "roe_ttm", "cost_of_equity", "wacc"} <= set(df.columns)
+    last = df.iloc[-1]
+    assert last["roe_ttm"] is not None
+    assert df.attrs.get("riskmodels_fundamentals_disclosures") is not None
+    # Never a held-back raw field, even if the reader were to leak one.
+    for held_back in ("revenue", "net_income", "eps_actual", "earnings_surprise"):
+        assert held_back not in df.columns
+
+
+def test_live_get_fundamentals_sensitivity_grid_aapl(live_client: RiskModelsClient) -> None:
+    """H.89.6: sensitivity-grid variant — real erp x rf_tenor grid for the latest quarter.
+
+    The `grid=true` query param and `sensitivity_grid` response field are new
+    (this PR) and may not be deployed to the endpoint `RISKMODELS_BASE_URL`
+    points at yet — an older server silently ignores the unknown param and
+    omits the field, which the parser turns into an empty DataFrame (verified
+    directly against the DAL in tests/fundamentals-live.test.ts on the API
+    side). This test always exercises the client call end-to-end and asserts
+    the full grid shape once the field is present.
+    """
+    df = live_client.get_fundamentals_sensitivity_grid(
+        "AAPL", erp_grid=[0.04, 0.05, 0.06], rf_tenor_grid=["1y", "10y"], as_dataframe=True
+    )
+    assert isinstance(df, pd.DataFrame)
+    if df.empty:
+        pytest.skip(
+            "sensitivity_grid not present in the response — the grid=true variant "
+            "is not deployed yet at this RISKMODELS_BASE_URL."
+        )
+    assert len(df) == 6  # 3 erp values x 2 tenors
+    assert set(df["erp"]) == {0.04, 0.05, 0.06}
+    assert set(df["rf_tenor"]) == {"1y", "10y"}
+    # Higher erp -> higher cost_of_equity at a fixed tenor (positive beta_market for AAPL).
+    at_10y = df[df["rf_tenor"] == "10y"].sort_values("erp")
+    coe = at_10y["cost_of_equity"].tolist()
+    assert coe == sorted(coe)
+
+
+def test_live_next_earnings_aapl_projects_a_cadence(live_client: RiskModelsClient) -> None:
+    """H.89.6: cadence-based next-earnings estimate, not a confirmed calendar date."""
+    out = live_client.next_earnings("AAPL")
+    assert out["ticker"] == "AAPL"
+    assert out["basis"] == "filed_date_cadence"
+    assert out["n_periods_observed"] >= 2
+    assert out["estimated_next_filed_date"] is not None
+    # AAPL reports quarterly — cadence should be in the ~75-110 day band.
+    assert 75 <= out["median_cadence_days"] <= 110
+
+
+def test_live_aom_with_fundamentals_end_to_end(live_client: RiskModelsClient) -> None:
+    """H.89.6: AOM `.with_fundamentals()` end-to-end against the live client."""
+    from riskmodels import rm, run
+    from riskmodels.aom import stock
+
+    req = rm().subject(stock("AAPL")).scope(date_range_preset="1y").with_fundamentals().structured()
+    out = run(live_client, req)
+    assert not out["errors"]
+    fetch_result = out["steps_out"][-1]["result"]
+    assert isinstance(fetch_result, pd.DataFrame)
+    assert "roe_ttm" in fetch_result.columns

--- a/tests/fundamentals-live.test.ts
+++ b/tests/fundamentals-live.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
   costOfEquity,
+  DEFAULT_ERP_GRID,
   getFundamentalsForTicker,
+  getFundamentalsSensitivityGrid,
+  RF_TENORS,
 } from "@/lib/dal/fundamentals-zarr-reader";
 
 /**
@@ -104,6 +107,49 @@ describe.skipIf(!LIVE)("live GCS fundamentals panel — AAPL", () => {
     async () => {
       const result = await getFundamentalsForTicker("ZZZZNOTREAL", OPTS);
       expect(result).toBeNull();
+    },
+  );
+
+  it(
+    "H.89.6: sensitivity grid — real rf strip x real beta_market, monotonic in erp and tenor",
+    { timeout: 300_000 },
+    async () => {
+      const grid = await getFundamentalsSensitivityGrid("AAPL", {
+        asOf: "2026-07-03",
+        erpGrid: DEFAULT_ERP_GRID,
+        rfTenorGrid: RF_TENORS,
+        taxRate: 0.21,
+      });
+      expect(grid).not.toBeNull();
+      expect(grid!.erp_values).toEqual([...DEFAULT_ERP_GRID]);
+      expect(grid!.rf_tenor_values).toEqual([...RF_TENORS]);
+      expect(grid!.cells).toHaveLength(DEFAULT_ERP_GRID.length);
+
+      // Anchored on the same latest PIT-visible period as getFundamentalsForTicker.
+      const rows = (await getFundamentalsForTicker("AAPL", { ...OPTS, periods: 1 }))!.rows;
+      expect(grid!.period_end_date).toBe(rows[rows.length - 1]!.period_end_date);
+
+      // Monotonic in erp at a fixed tenor (10y column): higher erp -> higher cost_of_equity
+      // (beta_market is positive for AAPL, per the plausibility assertions above).
+      const tenIdx = grid!.rf_tenor_values.indexOf("10y");
+      const coeAcrossErp = grid!.cells.map((row) => row[tenIdx]!.cost_of_equity!);
+      for (let i = 1; i < coeAcrossErp.length; i++) {
+        expect(coeAcrossErp[i]).toBeGreaterThan(coeAcrossErp[i - 1]!);
+      }
+
+      // Every populated tenor strip is real (non-null) since the 2026-07-06 rebuild.
+      const erpIdx = grid!.erp_values.indexOf(0.05);
+      for (const cell of grid!.cells[erpIdx]!) {
+        expect(cell.cost_of_equity).not.toBeNull();
+        expect(cell.wacc).not.toBeNull();
+      }
+
+      // Cross-check the 0.05/10y cell against the scalar endpoint for the same as_of.
+      const scalar = rows[rows.length - 1]!;
+      expect(grid!.cells[erpIdx]![tenIdx]!.cost_of_equity).toBeCloseTo(
+        scalar.cost_of_equity!,
+        10,
+      );
     },
   );
 });

--- a/tests/fundamentals-reader.test.ts
+++ b/tests/fundamentals-reader.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
   buildFundamentalsRows,
+  buildSensitivityGrid,
   costOfDebt,
   costOfEquity,
+  DEFAULT_ERP_GRID,
   economicProfit,
   latestFinite,
   roeTtm,
@@ -230,5 +232,51 @@ describe("rf tenor strip (2026-07-06 store revision)", () => {
     // non-rf fields unaffected
     expect(last.beta_market).not.toBeNull();
     expect(last.roe_ttm).not.toBeNull();
+  });
+});
+
+describe("sensitivity grid (H.89.6) — erp x rf_tenor cost-of-capital grid", () => {
+  const GRID_OPTS = {
+    asOf: "2026-01-15",
+    erpGrid: DEFAULT_ERP_GRID,
+    rfTenorGrid: ["3m", "10y"] as const,
+    taxRate: 0.21,
+  };
+
+  it("anchors on the same latest PIT-visible period as buildFundamentalsRows", () => {
+    const grid = buildSensitivityGrid(syntheticPack(), GRID_OPTS)!;
+    expect(grid.period_end_date).toBe("2025-09-30");
+    expect(grid.filed_date).toBe("2025-10-31");
+  });
+
+  it("cells is row-major [erp][tenor] and matches costOfEquity for each combination", () => {
+    const grid = buildSensitivityGrid(syntheticPack(), GRID_OPTS)!;
+    expect(grid.erp_values).toEqual([...DEFAULT_ERP_GRID]);
+    expect(grid.rf_tenor_values).toEqual(["3m", "10y"]);
+    expect(grid.cells).toHaveLength(DEFAULT_ERP_GRID.length);
+    // anchor beta_market at 2025-09-30 = 1.2 (same anchor as the rf-tenor describe block above)
+    DEFAULT_ERP_GRID.forEach((erp, i) => {
+      expect(grid.cells[i]).toHaveLength(2);
+      expect(grid.cells[i]![0]!.cost_of_equity).toBeCloseTo(costOfEquity(0.03, 1.2, erp), 10);
+      expect(grid.cells[i]![1]!.cost_of_equity).toBeCloseTo(costOfEquity(0.04, 1.2, erp), 10);
+    });
+  });
+
+  it("a tenor absent from the store yields null cells for that column only", () => {
+    const grid = buildSensitivityGrid(syntheticPack(), {
+      ...GRID_OPTS,
+      rfTenorGrid: ["3m", "30y"] as const,
+    })!;
+    grid.cells.forEach((row) => {
+      expect(row[0]!.cost_of_equity).not.toBeNull();
+      expect(row[1]!.cost_of_equity).toBeNull();
+      expect(row[1]!.wacc).toBeNull();
+      expect(row[1]!.economic_profit).toBeNull();
+    });
+  });
+
+  it("returns null when no PIT-visible period exists at as_of", () => {
+    const grid = buildSensitivityGrid(syntheticPack(), { ...GRID_OPTS, asOf: "2024-01-01" });
+    expect(grid).toBeNull();
   });
 });

--- a/tests/fundamentals-route.test.ts
+++ b/tests/fundamentals-route.test.ts
@@ -6,9 +6,13 @@ vi.mock("@/lib/agent/billing-middleware", () => ({
 }));
 
 vi.mock("@/lib/dal/fundamentals-zarr-reader", async (importOriginal) => {
-  // Keep the real pure exports (accessors, types); mock only the GCS entry point.
+  // Keep the real pure exports (accessors, types); mock only the GCS entry points.
   const actual = await importOriginal<typeof import("@/lib/dal/fundamentals-zarr-reader")>();
-  return { ...actual, getFundamentalsForTicker: vi.fn() };
+  return {
+    ...actual,
+    getFundamentalsForTicker: vi.fn(),
+    getFundamentalsSensitivityGrid: vi.fn(),
+  };
 });
 
 vi.mock("@/lib/dal/risk-engine-v3", () => ({
@@ -20,7 +24,10 @@ vi.mock("@/lib/dal/risk-metadata", () => ({
   getRiskMetadata: vi.fn(),
 }));
 
-import { getFundamentalsForTicker } from "@/lib/dal/fundamentals-zarr-reader";
+import {
+  getFundamentalsForTicker,
+  getFundamentalsSensitivityGrid,
+} from "@/lib/dal/fundamentals-zarr-reader";
 import {
   fetchLatestMetricsWithFallback,
   resolveSymbolByTicker,
@@ -82,6 +89,7 @@ const CLEAN_ROW = {
 
 beforeEach(() => {
   vi.mocked(getFundamentalsForTicker).mockReset();
+  vi.mocked(getFundamentalsSensitivityGrid).mockReset();
   vi.mocked(resolveSymbolByTicker).mockReset();
   vi.mocked(fetchLatestMetricsWithFallback).mockReset();
   vi.mocked(getRiskMetadata).mockReset();
@@ -224,6 +232,37 @@ describe("GET /api/fundamentals/[ticker]", () => {
     expect(degraded.status).toBe(200);
     const degradedBody = await degraded.json();
     expect(degradedBody.market_cap.value).toBeNull();
+  });
+
+  it("sensitivity_grid is omitted by default and included only when grid=true", async () => {
+    vi.mocked(getFundamentalsForTicker).mockResolvedValue({ ticker: "AAPL", rows: [CLEAN_ROW] });
+
+    const withoutGrid = await fundamentalsGET(req("/api/fundamentals/AAPL"), fakeContext);
+    const withoutGridBody = await withoutGrid.json();
+    expect(withoutGridBody).not.toHaveProperty("sensitivity_grid");
+    expect(getFundamentalsSensitivityGrid).not.toHaveBeenCalled();
+
+    vi.mocked(getFundamentalsSensitivityGrid).mockResolvedValue({
+      period_end_date: "2025-09-30",
+      filed_date: "2025-10-31",
+      erp_values: [0.03, 0.04, 0.05, 0.06, 0.07],
+      rf_tenor_values: ["3m", "1y", "2y", "5y", "10y", "30y"],
+      tax_rate: 0.21,
+      cells: [],
+    });
+    const withGrid = await fundamentalsGET(
+      req("/api/fundamentals/AAPL?grid=true&erp_grid=0.04,0.06&rf_tenor_grid=1y,10y"),
+      fakeContext,
+    );
+    expect(withGrid.status).toBe(200);
+    const withGridBody = await withGrid.json();
+    expect(withGridBody.sensitivity_grid.period_end_date).toBe("2025-09-30");
+    expect(getFundamentalsSensitivityGrid).toHaveBeenCalledWith("AAPL", {
+      asOf: expect.any(String),
+      erpGrid: [0.04, 0.06],
+      rfTenorGrid: ["1y", "10y"],
+      taxRate: 0.21,
+    });
   });
 
   it("serves JSON only — no CSV/bulk export even when a format param is passed", async () => {

--- a/tests/onboarding-upgrade.test.ts
+++ b/tests/onboarding-upgrade.test.ts
@@ -239,6 +239,7 @@ describe("RiskModels MCP live-paper tools", () => {
       "riskmodels_search_filers",
       "riskmodels_search_etfs",
       "riskmodels_get_rankings",
+      "riskmodels_get_fundamentals",
       "riskmodels_screen_rankings",
       "riskmodels_get_macro_correlation",
       "riskmodels_get_residual_signal",


### PR DESCRIPTION
## Summary
- riskmodels-py: `client.get_fundamentals()` / `client.get_fundamentals_sensitivity_grid()` / `client.next_earnings()` (`sdk/riskmodels/fundamentals.py`), mirroring the H.89.5 endpoint contract (`GET /fundamentals/{ticker}`) exactly — derived-only, never reconstructs a held-back raw field client-side.
- Endpoint: new `grid=true` sensitivity-grid variant (`erp_grid` x `rf_tenor_grid` cost-of-capital table for the latest PIT-visible quarter) — pure computation, no extra I/O since the six-tenor rf strip is already loaded per request.
- AOM: `.with_fundamentals()` chain stage compiles to a `RestFetchStep` calling `get_fundamentals(as_dataframe=True)` — no executor changes needed; the result rides the existing generic DataFrame `to_llm_context()` dispatch.
- MCP: `riskmodels_get_fundamentals` tool registered (param-for-param mirror of the REST contract).
- Three use-case notebooks under `sdk/notebooks/`: quality-overlay screen (residual Sharpe x ROE spread), pre-earnings hedge timing (`next_earnings` + `decompose`), PIT anti-look-ahead event study — all executed live against production.
- `next_earnings()` is a transparently-labeled filing-cadence projection (median gap between historical `filed_date` values), not a real earnings calendar — the store has no analyst estimates or vendor calendar feed.

## Test plan
- [x] `cd sdk && pytest -q` — full SDK suite green
- [x] `pytest -m integration` (live, `RISKMODELS_API_KEY` set) — new fundamentals/AOM live tests pass; 2 pre-existing unrelated `test_peer_group.py` failures (bug in that test file, not touched here)
- [x] `npx vitest run` — 445 passed, 5 skipped
- [x] `FUNDAMENTALS_LIVE_TEST=1 npx vitest run tests/fundamentals-live.test.ts` — 5/5 against real GCS production data, including the new sensitivity-grid DAL function
- [x] All three notebooks executed end-to-end against production (`jupyter nbconvert --execute`) and produce sane output
- [x] `npx tsc --noEmit` clean; `ruff check` clean (aside from pre-existing E402 style debt in `client.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)