### PR TITLE
feat(fundamentals-api): expose SEC-sourced raw line items via per-cell gate (H.69 Phase 1)

### DIFF
--- a/lib/api/fundamentals-contract.ts
+++ b/lib/api/fundamentals-contract.ts
@@ -22,6 +22,8 @@ export const FUNDAMENTALS_ROW_ALLOWED_FIELDS = [
   "period_end_date",
   "filed_date",
   "filed_date_source",
+  // SEC-sourced raw line items, gated PER CELL by secCellValue (H.69 per-row rule).
+  "sec_facts",
   // Derived margins/ratios (computed server-side; raw inputs stay internal)
   "gross_margin",
   "operating_margin",
@@ -47,40 +49,108 @@ export const FUNDAMENTALS_ROW_ALLOWED_FIELDS = [
 export type FundamentalsRowField = (typeof FUNDAMENTALS_ROW_ALLOWED_FIELDS)[number];
 
 /**
- * Raw vendor line items — HELD BACK pending SEC promotion or counsel clearance
- * (H.69 / EODHD Exhibit B). `earnings_surprise` and `book_value_per_share` are
- * parked gray pending counsel. No analyst/forecast fields exist in the store,
- * but they are listed so the contract test asserts their absence anyway.
+ * Fields that must never appear as a FLAT raw plane on a response row.
+ *
+ * The SEC-sourced raw line items in `SEC_FACT_CONCEPTS` are no longer here: they ship inside
+ * `sec_facts`, gated per cell by `secCellValue`, so a flat `revenue` key must still never appear
+ * (the test asserts this) while `sec_facts.revenue` may — but only for SEC cells.
+ *
+ * These remain hard-held-back as flat keys:
+ *  - EODHD-only levels with no clean SEC exposure yet: `ebitda` (not an XBRL concept),
+ *    `eps_actual`, `total_debt` (a roll-up), `shares_outstanding_q` (lives in the shares layer).
+ *  - `eps_estimate` and forecast/rating fields — no-investment-advice house rule (also in
+ *    SEC_FACT_DENY so they cannot enter sec_facts either).
+ *  - `earnings_surprise`, `book_value_per_share` — gray pending counsel.
  */
 export const FUNDAMENTALS_HELD_BACK_FIELDS = [
-  "revenue",
-  "net_income",
+  // EODHD-only, no clean SEC raw exposure
   "ebitda",
   "eps_actual",
-  "eps_estimate",
-  "eps_diluted",
-  "total_assets",
-  "total_equity",
   "total_debt",
   "shares_outstanding_q",
-  "cash_from_operations",
-  "capital_expenditures",
-  "interest_expense",
-  // gray pending counsel
-  "earnings_surprise",
-  "book_value_per_share",
-  // never in the store (no-investment-advice house rule) — asserted anyway
+  // house rule — analyst/forecast, never shipped (also denied inside sec_facts)
+  "eps_estimate",
   "eps_forecast",
   "revenue_forecast",
   "analyst_rating",
   "target_price",
+  // gray pending counsel
+  "earnings_surprise",
+  "book_value_per_share",
+  // derived, exposed only as the computed `fcf_margin` ratio, never as a raw flat plane
   "free_cash_flow",
 ] as const;
+
+/**
+ * SEC-sourced raw line items — the H.69 per-ROW rule made operable.
+ *
+ * A raw vendor line item is not redistributable (EODHD Exhibit B). But the store now serves many
+ * cells from SEC XBRL (public), marked per cell by a `{concept}_source` plane
+ * (0=none, 1=EODHD, 2=SEC us-gaap, 3=SEC ifrs). This block ships the raw value ONLY for cells
+ * whose SERVING row is SEC — regardless of the concept's internal promotion status, because even
+ * an EODHD-primary concept (e.g. interest_expense) is SEC-served on cells EODHD left empty.
+ *
+ * The gate is per CELL and lives in the DAL: a value reaches `sec_facts` only after
+ * `secCellValue` has confirmed its source is SEC. `sec_facts` therefore CANNOT contain an EODHD
+ * value by construction. That is the licensing invariant, asserted in the contract test.
+ *
+ * `eps_estimate` and any forecast/rating field are DENIED here unconditionally (no-investment-
+ * advice house rule) even though they never carry a SEC source today.
+ */
+export const SEC_FACT_CONCEPTS = [
+  // income statement
+  "revenue", "net_income", "operating_income", "pretax_income", "income_tax_expense",
+  "total_costs_and_expenses", "profit_loss", "nci_income", "eps_diluted", "interest_expense",
+  // balance sheet
+  "total_assets", "total_equity", "total_liabilities", "liabilities_and_equity",
+  "retained_earnings", "accumulated_oci",
+  // cash flow
+  "cash_from_operations", "capital_expenditures", "cash_from_investing", "cash_from_financing",
+  "fx_effect_on_cash", "change_in_cash",
+  // capital management
+  "dividends_paid", "dividends_declared", "dividends_preferred", "share_repurchases",
+  "share_issuance", "share_based_comp",
+] as const;
+export type SecFactConcept = (typeof SEC_FACT_CONCEPTS)[number];
+
+/** Concepts that must NEVER ship raw, whatever their source (house rule). */
+export const SEC_FACT_DENY = new Set<string>([
+  "eps_estimate", "eps_forecast", "revenue_forecast", "analyst_rating", "target_price",
+]);
+
+export type SecFactSource = "us_gaap" | "ifrs";
+export interface SecFact {
+  value: number;
+  /** basis of the serving SEC row: us-gaap or FX-converted ifrs-full. */
+  source: SecFactSource;
+}
+/** Per-period map of only the concepts SEC-served for that cell. Absent key = not SEC-served. */
+export type SecFacts = Partial<Record<SecFactConcept, SecFact>>;
+
+/**
+ * The per-cell licensing gate. Returns a SecFact iff the source plane says SEC (2=us-gaap,
+ * 3=ifrs) and the value is finite and the concept is not denied. Any other case → undefined,
+ * so the concept is simply absent from `sec_facts`. This is the ONLY door a raw value passes
+ * through; keep it that way.
+ */
+export function secCellValue(
+  concept: string,
+  value: number | null | undefined,
+  sourcePlane: number | null | undefined,
+): SecFact | undefined {
+  if (SEC_FACT_DENY.has(concept)) return undefined;
+  if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
+  if (sourcePlane === 2) return { value, source: "us_gaap" };
+  if (sourcePlane === 3) return { value, source: "ifrs" };
+  return undefined; // 0/1/null → EODHD or empty → not redistributable
+}
 
 export interface FundamentalsRow {
   period_end_date: string;
   filed_date: string | null;
   filed_date_source: "exact" | "approx" | null;
+  /** SEC-sourced raw line items for this period (only SEC-served concepts appear). */
+  sec_facts: SecFacts;
   gross_margin: number | null;
   operating_margin: number | null;
   roe_ttm: number | null;
@@ -111,9 +181,32 @@ export function sanitizeFundamentalsRow(
   const out: Record<string, unknown> = {};
   for (const key of FUNDAMENTALS_ROW_ALLOWED_FIELDS) {
     const v = row[key];
+    if (key === "sec_facts") {
+      // Defense in depth: even if a caller hands us a raw sec_facts, re-run every entry through
+      // the gate so a non-SEC or denied value cannot survive to serialization. The DAL already
+      // gated on read; this is the belt to that suspenders.
+      out[key] = sanitizeSecFacts(v);
+      continue;
+    }
     out[key] = v === undefined || (typeof v === "number" && !Number.isFinite(v)) ? null : v;
   }
   return out as unknown as FundamentalsRow;
+}
+
+/** Re-assert the licensing invariant: keep only finite SEC-basis, non-denied entries. */
+export function sanitizeSecFacts(v: unknown): SecFacts {
+  const out: SecFacts = {};
+  if (!v || typeof v !== "object") return out;
+  const allowed = new Set<string>(SEC_FACT_CONCEPTS);
+  for (const [concept, fact] of Object.entries(v as Record<string, unknown>)) {
+    if (!allowed.has(concept) || SEC_FACT_DENY.has(concept)) continue;
+    if (!fact || typeof fact !== "object") continue;
+    const { value, source } = fact as { value?: unknown; source?: unknown };
+    if (typeof value !== "number" || !Number.isFinite(value)) continue;
+    if (source !== "us_gaap" && source !== "ifrs") continue;
+    out[concept as SecFactConcept] = { value, source };
+  }
+  return out;
 }
 
 /**
@@ -140,8 +233,12 @@ export function buildFundamentalsDisclosures(params: {
       "WACC uses BOOK-value weights (balance-sheet equity and debt). Market-value weights are the textbook convention; compute them yourself if you have market-cap access.",
     ttm_convention:
       "TTM aggregates sum flows over the trailing 4 reported quarters; stock quantities are point-in-time (ROE denominator uses the trailing-4-quarter average equity). Ratios need 4 finite quarters or they are null.",
-    derived_only:
-      "Raw vendor line items (revenue, net income, EPS, balance-sheet levels) are not redistributable and are not included. gross_margin and operating_margin are null pending store inputs. market_cap is a current snapshot, not point-in-time per quarter.",
+    sec_facts_provenance:
+      "sec_facts carries RAW line items only for cells whose serving value is SEC XBRL (public, redistributable), tagged us_gaap or ifrs. A concept is absent for a period when that cell is EODHD-sourced (not redistributable) or empty. Coverage varies by concept and filer: income-statement/balance-sheet levels are ~30-50% SEC on large caps; cash-flow and capital-management items are near-100% SEC where reported. Values are as-originally-reported (earliest filing), not restated.",
+    sec_facts_definitions:
+      "Bank/insurer revenue is the CONSOLIDATED top line (interest+dividend income + noninterest income for banks), not the parent-company (Schedule I) figure. This can differ materially from a vendor total; for mortgage REITs it excludes investment gains. total_equity is PARENT-attributable. dividends_declared (accrual, drives retained earnings) and dividends_paid (cash) are distinct. All cash flows are POSITIVE = cash out.",
+    market_cap_note:
+      "market_cap is a current snapshot (Exhibit B(e)), not point-in-time per quarter. gross_margin and operating_margin ratios are null pending store inputs.",
     parameters: {
       as_of: params.as_of,
       erp: params.erp,

--- a/lib/dal/fundamentals-zarr-reader.ts
+++ b/lib/dal/fundamentals-zarr-reader.ts
@@ -14,12 +14,13 @@
  *   - Windows look at the last 8 visible quarters so TTM can find 4 finite
  *     values when the newest quarter is only partially reported.
  *
- * LICENSING: raw line items in this store are EODHD-primary and NOT
- * redistributable. This module reads them as internal compute inputs only;
- * everything that leaves the server goes through
- * lib/api/fundamentals-contract.ts (allowlist). Raw planes must never be
- * attached to a response object. Never expose bucket paths or store names in
- * errors or API JSON.
+ * LICENSING: raw line items are EODHD-primary and NOT redistributable, EXCEPT
+ * per cell where the store serves a SEC-XBRL value (public). Those cells ship
+ * inside `sec_facts`, gated one cell at a time by `secCellValue` (H.69 per-row
+ * rule): an EODHD-served or empty cell never enters sec_facts. Everything else
+ * that leaves the server still goes through lib/api/fundamentals-contract.ts.
+ * A raw EODHD plane must never be attached flat to a response object. Never
+ * expose bucket paths or store names in errors or API JSON.
  *
  * Store layout (one whole-panel chunk per variable) makes a cold read heavy,
  * so the extracted single-symbol row pack is cached in Redis and all PIT
@@ -38,6 +39,12 @@ import {
   getCache,
   setCache,
 } from "@/lib/cache/redis";
+import {
+  SEC_FACT_CONCEPTS,
+  secCellValue,
+  type SecFactConcept,
+  type SecFacts,
+} from "@/lib/api/fundamentals-contract";
 
 export const DEFAULT_ERP = 0.05; // suggested only; ERP is ALWAYS caller-supplied
 export const DEFAULT_TAX_RATE = 0.21;
@@ -190,6 +197,10 @@ export interface FundamentalsRowPack {
   /** 1=exact, 2=approx, 0/null=none — per column. */
   filedDateSource: (number | null)[];
   vars: Record<PackVar, (number | null)[]>;
+  /** Raw SEC-facts concept values per column (value plane). Gated at row-build, not here. */
+  secRaw: Record<SecFactConcept, (number | null)[]>;
+  /** `{concept}_source` plane per column (0=none,1=EODHD,2=SEC us-gaap,3=SEC ifrs). */
+  secSource: Record<SecFactConcept, (number | null)[]>;
   /** 1-D rf strip per tenor over the shared period_end axis (fraction, e.g. 0.0448). */
   rfCurve: Partial<Record<RfTenor, (number | null)[]>>;
 }
@@ -214,6 +225,8 @@ export interface FundamentalsInternalRow {
   cost_of_debt: number | null;
   wacc: number | null;
   economic_profit: number | null;
+  /** SEC-sourced raw line items for this period, gated per cell (H.69 per-row rule). */
+  sec_facts: SecFacts;
 }
 
 /**
@@ -297,6 +310,15 @@ export function buildFundamentalsRows(
     const fdsRaw = pack.filedDateSource[i];
     const fds = fdsRaw === 1 ? "exact" : fdsRaw === 2 ? "approx" : null;
 
+    // SEC facts for this period: a concept enters ONLY when secCellValue confirms its cell is
+    // SEC-served (source plane 2/3). EODHD-served or empty cells are simply absent. This is the
+    // single door raw values pass through.
+    const secFacts: SecFacts = {};
+    for (const concept of SEC_FACT_CONCEPTS) {
+      const fact = secCellValue(concept, pack.secRaw[concept]?.[i], pack.secSource[concept]?.[i]);
+      if (fact) secFacts[concept] = fact;
+    }
+
     out.push({
       period_end_date: pack.periodEndDates[i]!,
       filed_date: pack.filedDates[i] ?? null,
@@ -318,6 +340,7 @@ export function buildFundamentalsRows(
       cost_of_debt: toNull(costOfDebt(ieTtm, debtLast)),
       wacc: toNull(waccBookWeights(rf, bm, ieTtm, eqLast, debtLast, opts.taxRate, opts.erp)),
       economic_profit: toNull(economicProfit(niTtm, eqAvg, eqLast, rf, bm, opts.erp)),
+      sec_facts: secFacts,
     });
   }
   return out;
@@ -646,6 +669,18 @@ async function computeRowPack(ticker: string): Promise<FundamentalsRowPack | nul
     vars[name] = decoded ?? new Array<number | null>(periodEndDates.length).fill(null);
   }
 
+  // SEC-fact concepts: read the value plane AND its `{concept}_source` companion. A concept or
+  // source plane absent from the store leaves an all-null column, so the gate simply omits it.
+  const nulls = () => new Array<number | null>(periodEndDates.length).fill(null);
+  const secRaw = {} as Record<SecFactConcept, (number | null)[]>;
+  const secSource = {} as Record<SecFactConcept, (number | null)[]>;
+  for (const concept of SEC_FACT_CONCEPTS) {
+    const valRaw = await readVarRow(grp, concept, symIdx);
+    const srcRaw = await readVarRow(grp, `${concept}_source`, symIdx);
+    secRaw[concept] = (valRaw ? decodeFloatsNullable(valRaw.data) : null) ?? nulls();
+    secSource[concept] = (srcRaw ? decodeFloatsNullable(srcRaw.data) : null) ?? nulls();
+  }
+
   // rf tenor strip: six tiny 1-D arrays, read once per pack so any tenor is
   // served from cache. A missing tenor variable (pre-2026-07-06 store) leaves
   // that tenor absent → rf/CoC null, never a wrong-tenor substitute.
@@ -662,13 +697,16 @@ async function computeRowPack(ticker: string): Promise<FundamentalsRowPack | nul
     filedDateSource:
       filedDateSource ?? new Array<number | null>(periodEndDates.length).fill(null),
     vars,
+    secRaw,
+    secSource,
     rfCurve,
   };
 }
 
 async function readRowPackCached(ticker: string): Promise<FundamentalsRowPack | null> {
-  // v2: pack shape changed 2026-07-07 (per-cell rf_rate → rfCurve tenor strip)
-  const ck = generateCacheKey("fundamentals_zarr", "row_pack_v2", { ticker });
+  // v3: pack shape changed 2026-07-10 (added secRaw/secSource for SEC-fact exposure).
+  // Bumping the key invalidates v2 packs that lack those fields.
+  const ck = generateCacheKey("fundamentals_zarr", "row_pack_v3", { ticker });
   const hit = await getCache<FundamentalsRowPack | typeof EMPTY_SENTINEL>(ck);
   if (hit !== null && hit !== undefined) {
     return (hit as { __empty?: boolean }).__empty === true

--- a/tests/fundamentals-contract.test.ts
+++ b/tests/fundamentals-contract.test.ts
@@ -2,14 +2,20 @@ import { describe, expect, it } from "vitest";
 import {
   FUNDAMENTALS_HELD_BACK_FIELDS,
   FUNDAMENTALS_ROW_ALLOWED_FIELDS,
+  SEC_FACT_CONCEPTS,
+  SEC_FACT_DENY,
   sanitizeFundamentalsRow,
+  sanitizeSecFacts,
+  secCellValue,
 } from "@/lib/api/fundamentals-contract";
 
 /**
- * LICENSING GATE TESTS — these are the enforcement mechanism for the EODHD
- * Exhibit-B posture: raw vendor line items must never appear in a response
- * row. If a raw field is ever added to the allowlist (or leaks through
- * sanitize), this file fails.
+ * LICENSING GATE TESTS — the enforcement mechanism for the EODHD Exhibit-B posture.
+ *
+ * Since 2026-07-10 raw line items may ship, but ONLY inside `sec_facts` and ONLY for cells whose
+ * serving value is SEC XBRL (public). Two invariants this file guards:
+ *  1. no raw vendor line item appears as a FLAT key on a response row;
+ *  2. `sec_facts` only ever contains SEC-basis (us_gaap/ifrs), non-denied, finite values.
  */
 describe("fundamentals response allowlist", () => {
   it("held-back raw fields are disjoint from the allowlist", () => {
@@ -19,46 +25,35 @@ describe("fundamentals response allowlist", () => {
     }
   });
 
-  it("every raw vendor line item from the store is on the held-back list", () => {
-    // The 13 stored line items — raw levels ship only if promoted to
-    // SEC-sourced or cleared by counsel.
-    const rawStorePlanes = [
-      "revenue",
-      "net_income",
-      "ebitda",
-      "eps_actual",
-      "eps_estimate",
-      "eps_diluted",
-      "total_assets",
-      "total_equity",
-      "total_debt",
-      "shares_outstanding_q",
-      "cash_from_operations",
-      "capital_expenditures",
-      "interest_expense",
-    ];
-    const heldBack = new Set<string>(FUNDAMENTALS_HELD_BACK_FIELDS);
-    for (const plane of rawStorePlanes) {
-      expect(heldBack.has(plane), `store plane "${plane}" must be held back`).toBe(true);
+  it("SEC-fact concepts are NOT flat-allowlisted — they ship only nested in sec_facts", () => {
+    const allowed = new Set<string>(FUNDAMENTALS_ROW_ALLOWED_FIELDS);
+    for (const c of SEC_FACT_CONCEPTS) {
+      expect(allowed.has(c), `concept "${c}" must never be a flat allowlist key`).toBe(false);
     }
+    expect(allowed.has("sec_facts")).toBe(true);
   });
 
-  it("gray-pending-counsel and analyst/forecast fields are held back (asserted even though absent from the store)", () => {
+  it("EODHD-only and house-rule fields remain hard-held-back as flat keys", () => {
     const heldBack = new Set<string>(FUNDAMENTALS_HELD_BACK_FIELDS);
     for (const f of [
-      "earnings_surprise",
-      "book_value_per_share",
-      "eps_forecast",
-      "revenue_forecast",
-      "analyst_rating",
-      "target_price",
+      // EODHD-only, no clean SEC raw exposure
+      "ebitda", "eps_actual", "total_debt", "shares_outstanding_q",
+      // no-investment-advice house rule
+      "eps_estimate", "eps_forecast", "revenue_forecast", "analyst_rating", "target_price",
+      // gray pending counsel
+      "earnings_surprise", "book_value_per_share",
     ]) {
       expect(heldBack.has(f), `"${f}" must be held back`).toBe(true);
     }
   });
 
-  it("sanitizeFundamentalsRow strips every held-back field even when present on the input", () => {
-    // Simulate a future refactor accidentally attaching raw planes to the row.
+  it("house-rule fields are in SEC_FACT_DENY so they cannot enter sec_facts either", () => {
+    for (const f of ["eps_estimate", "eps_forecast", "revenue_forecast", "analyst_rating", "target_price"]) {
+      expect(SEC_FACT_DENY.has(f), `"${f}" must be denied inside sec_facts`).toBe(true);
+    }
+  });
+
+  it("sanitizeFundamentalsRow strips held-back and stray flat SEC-concept keys", () => {
     const dirty: Record<string, unknown> = {
       period_end_date: "2025-12-31",
       filed_date: "2026-01-30",
@@ -66,32 +61,67 @@ describe("fundamentals response allowlist", () => {
       roe_ttm: 1.6,
       cost_of_equity: 0.093,
     };
-    for (const f of FUNDAMENTALS_HELD_BACK_FIELDS) {
-      dirty[f] = 123456789;
-    }
+    for (const f of FUNDAMENTALS_HELD_BACK_FIELDS) dirty[f] = 123456789;
+    // a future refactor accidentally attaching a raw flat plane:
+    for (const c of SEC_FACT_CONCEPTS) dirty[c] = 999;
     const clean = sanitizeFundamentalsRow(dirty) as unknown as Record<string, unknown>;
-    for (const f of FUNDAMENTALS_HELD_BACK_FIELDS) {
-      expect(f in clean, `held-back field "${f}" leaked through sanitize`).toBe(false);
-    }
-    // And nothing outside the allowlist survives at all.
     const allowed = new Set<string>(FUNDAMENTALS_ROW_ALLOWED_FIELDS);
     for (const key of Object.keys(clean)) {
-      expect(allowed.has(key), `unexpected key "${key}" in sanitized row`).toBe(true);
+      expect(allowed.has(key), `unexpected key "${key}" survived sanitize`).toBe(true);
     }
+    for (const f of FUNDAMENTALS_HELD_BACK_FIELDS) expect(f in clean).toBe(false);
+    for (const c of SEC_FACT_CONCEPTS) expect(c in clean).toBe(false); // no flat raw plane
     expect(clean.roe_ttm).toBe(1.6);
-    expect(clean.period_end_date).toBe("2025-12-31");
   });
 
-  it("sanitize null-fills missing allowlisted keys and maps non-finite numbers to null", () => {
+  it("sanitize null-fills allowlisted keys; sec_facts defaults to {}", () => {
     const clean = sanitizeFundamentalsRow({
       period_end_date: "2025-12-31",
       wacc: NaN,
-      cost_of_debt: Infinity,
     }) as unknown as Record<string, unknown>;
     expect(Object.keys(clean).sort()).toEqual([...FUNDAMENTALS_ROW_ALLOWED_FIELDS].sort());
     expect(clean.wacc).toBeNull();
-    expect(clean.cost_of_debt).toBeNull();
-    expect(clean.filed_date).toBeNull();
-    expect(clean.roe_ttm).toBeNull();
+    expect(clean.sec_facts).toEqual({});
+  });
+});
+
+describe("secCellValue — the per-cell licensing gate", () => {
+  it("passes a finite value only for SEC source planes (2=us_gaap, 3=ifrs)", () => {
+    expect(secCellValue("revenue", 100, 2)).toEqual({ value: 100, source: "us_gaap" });
+    expect(secCellValue("revenue", 100, 3)).toEqual({ value: 100, source: "ifrs" });
+  });
+
+  it("blocks EODHD (1), none (0) and null source — not redistributable", () => {
+    expect(secCellValue("revenue", 100, 1)).toBeUndefined();
+    expect(secCellValue("revenue", 100, 0)).toBeUndefined();
+    expect(secCellValue("revenue", 100, null)).toBeUndefined();
+  });
+
+  it("blocks non-finite values and denied concepts", () => {
+    expect(secCellValue("revenue", NaN, 2)).toBeUndefined();
+    expect(secCellValue("revenue", null, 2)).toBeUndefined();
+    expect(secCellValue("eps_estimate", 5, 2)).toBeUndefined(); // denied even with SEC source
+  });
+});
+
+describe("sanitizeSecFacts — belt to the DAL suspenders", () => {
+  it("keeps only allowed concepts with a SEC basis and finite value", () => {
+    const clean = sanitizeSecFacts({
+      revenue: { value: 100, source: "us_gaap" },
+      total_equity: { value: 50, source: "ifrs" },
+      net_income: { value: 10, source: "eodhd" }, // wrong basis → dropped
+      capital_expenditures: { value: NaN, source: "us_gaap" }, // non-finite → dropped
+      eps_estimate: { value: 5, source: "us_gaap" }, // denied → dropped
+      not_a_concept: { value: 1, source: "us_gaap" }, // unknown → dropped
+    });
+    expect(clean).toEqual({
+      revenue: { value: 100, source: "us_gaap" },
+      total_equity: { value: 50, source: "ifrs" },
+    });
+  });
+
+  it("never lets a non-SEC basis survive (the licensing invariant)", () => {
+    const clean = sanitizeSecFacts({ revenue: { value: 1, source: "eodhd" } });
+    expect(clean).toEqual({});
   });
 });

--- a/tests/fundamentals-route.test.ts
+++ b/tests/fundamentals-route.test.ts
@@ -85,6 +85,7 @@ const CLEAN_ROW = {
   cost_of_debt: null,
   wacc: null,
   economic_profit: null,
+  sec_facts: {},
 };
 
 beforeEach(() => {


### PR DESCRIPTION
Turns on raw exposure of SEC-sourced fundamentals via a new per-period `sec_facts` object, gated one cell at a time by `secCellValue` — a concept ships raw only where its serving cell is SEC XBRL (public), and is absent on EODHD/empty cells. This is the H.69 per-row rule; the contract already had the hook, but nothing was SEC-sourced until the promotion work landed (ERM3 PR #93) and the store was republished to GCS.

**Licensing invariant** enforced twice: `secCellValue` is the single door (source 2/3 only, finite, non-denied); `sanitizeSecFacts` re-checks at serialization. Contract test asserts no EODHD value can ever reach `sec_facts` and no raw flat plane appears on a row.

**Corrects a stale contract**: net_income/total_assets/cash_from_operations/eps_diluted were SEC-promoted 2026-07-05 but still held back here.

Verified against live GCS: 28 concept+source planes present; AAPL returns 20 SEC facts with Assets == liabilities_and_equity to the dollar. 19 tests pass. Phase 2/3 separate.

Plan: `docs/plans/fundamentals_api_sec_exposure.md`.