### PR TITLE
fix(fundamentals-api): null-safe SEC-plane access (repairs broken main)

### DIFF
--- a/lib/dal/fundamentals-zarr-reader.ts
+++ b/lib/dal/fundamentals-zarr-reader.ts
@@ -331,7 +331,7 @@ export function buildFundamentalsRows(
   // Capital-management concepts live in secRaw (the served plane value). Used here for DERIVED
   // ratios only — not gated, because derived analytics are redistributable.
   const secWindow = (name: SecFactConcept, positions: number[]): (number | null)[] =>
-    positions.map((i) => pack.secRaw[name]?.[i] ?? null);
+    positions.map((i) => pack.secRaw?.[name]?.[i] ?? null);
 
   for (let p = Math.max(0, visible.length - periods); p < visible.length; p++) {
     const i = visible[p]!;
@@ -376,7 +376,7 @@ export function buildFundamentalsRows(
     // single door raw values pass through.
     const secFacts: SecFacts = {};
     for (const concept of SEC_FACT_CONCEPTS) {
-      const fact = secCellValue(concept, pack.secRaw[concept]?.[i], pack.secSource[concept]?.[i]);
+      const fact = secCellValue(concept, pack.secRaw?.[concept]?.[i], pack.secSource?.[concept]?.[i]);
       if (fact) secFacts[concept] = fact;
     }
 

--- a/tests/fundamentals-reader.test.ts
+++ b/tests/fundamentals-reader.test.ts
@@ -51,6 +51,19 @@ function syntheticPack(): FundamentalsRowPack {
       beta_subsector: fill([0.2, 0.2, 0.2, 0.2, 0.2, 0.2]),
       beta_source: fill([1, 1, 1, 1, 1, 1]),
     },
+    // SEC-fact planes (Phase 1+2). dividends_paid + share_repurchases feed the capital-return
+    // ratios; source planes drive per-cell gating. Only the newest quarter is SEC-served here so
+    // the ratios have flows and the gate has a positive case.
+    secRaw: {
+      dividends_paid: fill([2, 2, 2, 2, 2, 3]),
+      share_repurchases: fill([4, 4, 4, 4, 4, 5]),
+      revenue: fill([100, 100, 100, 100, 100, 120]),
+    } as FundamentalsRowPack["secRaw"],
+    secSource: {
+      dividends_paid: fill([1, 1, 1, 1, 2, 2]),
+      share_repurchases: fill([1, 1, 1, 1, 2, 2]),
+      revenue: fill([1, 1, 1, 1, 2, 2]),
+    } as FundamentalsRowPack["secSource"],
     // rf is a 1-D per-tenor strip on the period axis (2026-07-06 store revision);
     // 3m deliberately different so tenor selection is observable.
     rfCurve: {


### PR DESCRIPTION
Repairs 10 failing reader tests on main. buildFundamentalsRows accessed pack.secRaw/secSource without guarding the object; the reader always sets them, but the reader-test's syntheticPack is cast `as FundamentalsRowPack` and omitted them — the cast hid the gap from typecheck (green through #229/#230), so it only broke at Vitest runtime.

Fix: defensive `pack.secRaw?.[name]?.[i]` at both access sites + a faithful syntheticPack that carries the SEC planes (one SEC-served quarter), so the mock exercises the real ratio + gate paths. 48 fundamentals tests pass.