### PR TITLE
docs(fundamentals-api): tool/SDK/reference text for the sec_facts response

### DIFF
--- a/OPENAPI_SPEC.yaml
+++ b/OPENAPI_SPEC.yaml
@@ -4160,7 +4160,7 @@ paths:
           example: "1y,10y,30y"
       responses:
         "200":
-          description: PIT quarterly fundamentals rows (derived analytics only).
+          description: PIT quarterly fundamentals rows.
           headers:
             X-API-Cost-USD:
               schema: { type: string }

--- a/lib/api-reference-data.ts
+++ b/lib/api-reference-data.ts
@@ -326,14 +326,14 @@ export const ENDPOINT_GROUPS: EndpointGroup[] = [
   {
     name: 'Fundamentals',
     description:
-      'Point-in-time quarterly fundamentals — derived analytics only (TTM profitability ratios, leverage, cascade betas, cost-of-capital layer). Realized historical data; no forecasts, no analyst fields, no raw vendor line items.',
+      'Point-in-time quarterly fundamentals (TTM profitability + capital-return ratios, leverage, cascade betas, cost-of-capital layer, equity-bridge decomposition, and SEC-sourced raw line items in sec_facts). Realized historical data; no forecasts, no analyst fields.',
     endpoints: [
       {
         path: '/fundamentals/{ticker}',
         method: 'get',
-        summary: 'Point-in-time quarterly fundamentals (derived)',
+        summary: 'Point-in-time quarterly fundamentals',
         description:
-          'Quarterly fundamentals rows, point-in-time filtered: a row is visible only if its filed_date is on or before as_of (never "latest"). Rows carry TTM ROE/ROA/FCF margin, leverage, ERM3 cascade betas with provenance, and the cost-of-capital layer (cost of equity, cost of debt, book-weight WACC, economic profit). Coverage starts ~2009 for most filers. beta_market is a short-half-life conditional beta, so cost_of_equity can fall below the risk-free rate for defensive names — a property of the beta, not an error. Raw vendor line items (revenue, net income, EPS, balance-sheet levels) are not redistributable and never included. Per-symbol per-call only; JSON only. Cost: $0.005/request.',
+          'Quarterly fundamentals rows, point-in-time filtered: a row is visible only if its filed_date is on or before as_of (never "latest"). Rows carry TTM ROE/ROA/FCF margin, capital-return ratios (payout, retention, buyback, total payout, sustainable growth), leverage, ERM3 cascade betas with provenance, the cost-of-capital layer (cost of equity, cost of debt, book-weight WACC, economic profit), and an equity-bridge decomposition. sec_facts carries raw line items per cell where the serving value is SEC XBRL (revenue, net income, equity, cash flows, dividends, buybacks); vendor-sourced cells are not exposed as raw. Coverage starts ~2009 for most filers. beta_market is a short-half-life conditional beta, so cost_of_equity can fall below the risk-free rate for defensive names — a property of the beta, not an error. Per-symbol per-call only; JSON only. Cost: $0.005/request.',
         operationId: 'getFundamentals',
         tag: 'Fundamentals',
         params: [

--- a/lib/mcp/tools/riskmodels-tools.ts
+++ b/lib/mcp/tools/riskmodels-tools.ts
@@ -649,7 +649,7 @@ export function registerRiskModelsTools(
       title: "RiskModels PIT Quarterly Fundamentals",
       annotations: { readOnlyHint: true },
       description:
-        "PIT quarterly fundamentals, derived analytics only (GET /fundamentals/{ticker}): TTM profitability ratios (roe_ttm, roa_ttm, fcf_margin), leverage_ratio, ERM3 cascade betas, and the cost-of-capital layer (cost_of_equity, wacc, economic_profit). Rows are visible iff filed_date <= as_of — never \"latest\". Raw vendor line items (revenue, net income, EPS, balance-sheet levels) are never included (derived-only licensing). Set grid=true for a cost-of-capital sensitivity table across erp_grid x rf_tenor_grid instead of a scalar wacc/cost_of_equity.",
+        "PIT quarterly fundamentals (GET /fundamentals/{ticker}): TTM profitability ratios (roe_ttm, roa_ttm, fcf_margin), capital-return ratios (payout, retention, buyback, total_payout, sustainable_growth), leverage_ratio, ERM3 cascade betas, the cost-of-capital layer (cost_of_equity, wacc, economic_profit), and an equity-bridge decomposition. sec_facts carries raw line items per cell where the serving value is SEC XBRL (revenue, net income, equity, cash flows, dividends, buybacks); vendor-sourced cells are not exposed as raw. Rows are visible iff filed_date <= as_of — never \"latest\". Realized historical only; no forecasts or analyst fields. Set grid=true for a cost-of-capital sensitivity table across erp_grid x rf_tenor_grid instead of a scalar wacc/cost_of_equity.",
       inputSchema: {
         ticker: z.string().min(1).describe("Ticker symbol, e.g. AAPL"),
         as_of: z.string().optional().describe("Point-in-time date YYYY-MM-DD (default: today)"),

--- a/lib/zarr-config.ts
+++ b/lib/zarr-config.ts
@@ -87,9 +87,10 @@ export function zarrLinkBetasBasename(marketFactorEtf = "SPY"): string {
 
 /**
  * Quarterly fundamentals panel — (symbol, period_end_date) with a separate
- * filed_date PIT stamp. INTERNAL store (EODHD-primary line items): the API
- * serves DERIVED analytics only; raw planes never leave the DAL. See
- * lib/api/fundamentals-contract.ts for the response allowlist.
+ * filed_date PIT stamp. INTERNAL store (EODHD-primary line items). The API
+ * serves derived analytics plus raw line items ONLY for cells whose serving
+ * value is SEC XBRL (exposed in sec_facts); vendor-sourced raw planes never
+ * leave the DAL. See lib/api/fundamentals-contract.ts for the response allowlist.
  */
 export function zarrFundamentalsBasename(): string {
   return "ds_fundamentals.zarr";

--- a/mcp/data/openapi.json
+++ b/mcp/data/openapi.json
@@ -5742,7 +5742,7 @@
         ],
         "responses": {
           "200": {
-            "description": "PIT quarterly fundamentals rows (derived analytics only).",
+            "description": "PIT quarterly fundamentals rows.",
             "headers": {
               "X-API-Cost-USD": {
                 "schema": {

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -501,9 +501,9 @@ export function createMcpServer(opts: McpServerOptions = {}): McpServer {
   server.registerTool(
     "get_fundamentals",
     {
-      title: "PIT Quarterly Fundamentals (Derived)",
+      title: "PIT Quarterly Fundamentals",
       description:
-        "Point-in-time quarterly fundamentals for a ticker — derived analytics only: TTM ROE/ROA/FCF margin, leverage, ERM3 cascade betas with provenance, and the cost-of-capital layer (cost of equity, cost of debt, book-weight WACC, economic profit). Rows are visible iff filed_date <= as_of (never 'latest'). Realized historical data only: no forecasts, no analyst fields, no raw vendor line items. Coverage starts ~2009 for most filers. beta_market is a short-half-life conditional beta, so cost_of_equity can fall below the risk-free rate for defensive names. Per-symbol per-call only — no batch.",
+        "Point-in-time quarterly fundamentals for a ticker: TTM ROE/ROA/FCF margin, capital-return ratios (payout, retention, buyback, total payout, sustainable growth), leverage, ERM3 cascade betas with provenance, the cost-of-capital layer (cost of equity, cost of debt, book-weight WACC, economic profit), and an equity-bridge decomposition. sec_facts carries raw line items per cell where the serving value is SEC XBRL (revenue, net income, equity, cash flows, dividends, buybacks); vendor-sourced cells are not exposed as raw. Rows are visible iff filed_date <= as_of (never 'latest'). Realized historical data only: no forecasts, no analyst fields. Coverage starts ~2009 for most filers. beta_market is a short-half-life conditional beta, so cost_of_equity can fall below the risk-free rate for defensive names. Per-symbol per-call only — no batch.",
       inputSchema: z.object({
         ticker: z.string().describe("Stock ticker symbol, e.g. AAPL, NVDA"),
         as_of: z

--- a/sdk/riskmodels/client.py
+++ b/sdk/riskmodels/client.py
@@ -2489,14 +2489,17 @@ class RiskModelsClient:
         rf_tenor: RfTenor = "10y",
         as_dataframe: bool = False,
     ) -> dict[str, Any] | pd.DataFrame:
-        """PIT quarterly fundamentals — derived analytics only (H.89.5, ``$0.005``).
+        """PIT quarterly fundamentals (H.89.5, ``$0.005``).
 
         Calls ``GET /fundamentals/{ticker}``. Rows carry TTM profitability
-        ratios (``roe_ttm``, ``roa_ttm``, ``fcf_margin``), ``leverage_ratio``,
-        ERM3 cascade betas with provenance, and the cost-of-capital layer
-        (``cost_of_equity``, ``cost_of_debt``, ``wacc``, ``economic_profit``).
-        Raw vendor line items (revenue, net income, EPS, balance-sheet
-        levels) are never included — see the API's
+        ratios (``roe_ttm``, ``roa_ttm``, ``fcf_margin``), capital-return
+        ratios (payout, retention, buyback, total payout, sustainable growth),
+        ``leverage_ratio``, ERM3 cascade betas with provenance, the
+        cost-of-capital layer (``cost_of_equity``, ``cost_of_debt``, ``wacc``,
+        ``economic_profit``), and an equity-bridge decomposition. ``sec_facts``
+        carries raw line items per cell where the serving value is SEC XBRL
+        (revenue, net income, equity, cash flows, dividends, buybacks);
+        vendor-sourced cells are not exposed as raw — see the API's
         ``lib/api/fundamentals-contract.ts`` allowlist.
 
         PIT: a row is visible iff its ``filed_date`` is on or before


### PR DESCRIPTION
The get_fundamentals MCP tool description, the standalone MCP server tool, the Python SDK docstring, and the /api-reference data still said raw line items are never returned. That contradicts the shipped response — sec_facts carries raw line items per cell where the serving value is SEC XBRL, alongside the capital-return ratios and equity-bridge decomposition.

Aligns all four description surfaces + the OpenAPI 200 description with the live contract. Regenerated mcp/data/openapi.json.

Cross-repo drift: pairs with Risk_Models #162 (mirror sync) — merge that first so the drift check passes here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)