### PR TITLE
fix(landing-chat): get_fundamentals in the demo tool set (OpenBB copilot path)

### DIFF
--- a/app/api/landing/chat/route.ts
+++ b/app/api/landing/chat/route.ts
@@ -11,7 +11,12 @@ import { resolveAgentBackend, hasChatBackend } from "@/lib/chat/llm-backend";
  *
  *   - Skips per-tool billing (skipBilling: true, no deductBalance).
  *   - Restricts the tool registry to a tight subset (search_tickers,
- *     get_risk_metrics, get_correlation, get_rankings).
+ *     get_risk_metrics, get_correlation, get_rankings, get_fundamentals).
+ *     get_fundamentals is in the demo deliberately: the OpenBB copilot is
+ *     structurally keyless (OpenBB never forwards the backend key to agent
+ *     queries), so this route is the ONLY agent path in OpenBB Workspace —
+ *     without the tool the model answers cost-of-capital questions from
+ *     recalled third-party estimates instead of our PIT surface.
  *   - preFlightGuard rejects any tool arg that references a non-MAG7
  *     ticker.
  *   - Caps tool rounds at 2 and max_tokens at ~700 to bound LLM spend.
@@ -41,6 +46,7 @@ const ALLOWED_TOOLS = [
   "get_risk_metrics",
   "get_correlation",
   "get_rankings",
+  "get_fundamentals",
 ] as const;
 
 // Model + client come from resolveAgentBackend() (Moonshot/Kimi when


### PR DESCRIPTION
## Why

Live connect-test of the new Fundamentals surface (E.23 g) showed the OpenBB copilot answering AAPL cost-of-capital with recalled third-party numbers (market-value weights 98.22/1.78, implied ERP ~4%, WACC 9.18%) instead of our PIT surface — while correctly reading `rm_single_name_metrics` from dashboard context.

Root cause: OpenBB never forwards the backend key to agent queries (`QueryRequest.api_keys` is OpenAI-only, see #200), so **all** OpenBB copilot traffic runs keyless through `/api/landing/chat` — whose `ALLOWED_TOOLS` did not include `get_fundamentals`. The agent could not reach the tool at all.

## Change

- Add `get_fundamentals` to the landing demo allowlist (one line) + header-comment rationale.
- No other changes: the MAG7 `preFlightGuard` already covers the tool's `ticker` arg via the generic `args.ticker` extraction, `skipBilling` applies as with the other billed-capability demo tools (`get_risk_metrics`), and the 2-round/700-token caps bound spend. The shared `buildSystemPrompt()` doctrine (fundamentals routing, realized-only, caller-ERP framing) shipped in #236.

## Verification

`tsc` clean; 468 tests pass. Post-deploy: re-ask the OpenBB copilot "walk me through AAPL's cost of capital" — expect conditional-beta, caller-ERP (5% default), book-weight WACC framing with the tool's usage_notes caveats, not external estimates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)