### PR TITLE
feat(admin): fundamentals-zarr cache purge endpoint

### DIFF
--- a/app/api/admin/cache/fundamentals/route.ts
+++ b/app/api/admin/cache/fundamentals/route.ts
@@ -1,0 +1,53 @@
+/**
+ * POST /api/admin/cache/fundamentals
+ *
+ * Purge the fundamentals-zarr Redis cache namespace
+ * (`riskmodels:fundamentals_zarr:*` — the per-ticker row packs and any
+ * siblings). Call after an ERM3 ds_fundamentals rebuild + GCS republish so
+ * popular tickers stop serving a stale pack for up to the weekly TTL
+ * (H.97: the rf-strip repair was live in GCS while AAPL kept serving
+ * null-rf rows from this cache). Safe to call any time — the next request
+ * per ticker recomputes from GCS.
+ *
+ * Auth: Authorization: Bearer CRON_SECRET (same machine-to-machine secret
+ * as /api/admin/cache/funds).
+ *
+ * Manual: curl -sS -X POST -H "Authorization: Bearer $CRON_SECRET" "https://riskmodels.app/api/admin/cache/fundamentals"
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { deleteCachePattern } from "@/lib/cache/redis";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+const FUNDAMENTALS_ZARR_CACHE_PATTERN = "riskmodels:fundamentals_zarr:*";
+
+function authorize(request: NextRequest): boolean {
+  const secret = process.env.CRON_SECRET?.trim();
+  if (!secret) return false;
+  const auth = request.headers.get("authorization");
+  return auth === `Bearer ${secret}`;
+}
+
+export async function POST(request: NextRequest) {
+  if (!authorize(request)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const deleted = await deleteCachePattern(FUNDAMENTALS_ZARR_CACHE_PATTERN);
+    console.log(
+      `[admin/cache/fundamentals] purged ${deleted} keys (${FUNDAMENTALS_ZARR_CACHE_PATTERN})`,
+    );
+    return NextResponse.json({
+      ok: true,
+      pattern: FUNDAMENTALS_ZARR_CACHE_PATTERN,
+      deleted,
+    });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    console.error("[admin/cache/fundamentals]", msg);
+    return NextResponse.json({ ok: false, error: msg }, { status: 500 });
+  }
+}

--- a/tests/admin-cache-fundamentals-route.test.ts
+++ b/tests/admin-cache-fundamentals-route.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/cache/redis", () => ({
+  deleteCachePattern: vi.fn(),
+}));
+
+import { deleteCachePattern } from "@/lib/cache/redis";
+import { POST } from "@/app/api/admin/cache/fundamentals/route";
+
+const URL = "http://localhost/api/admin/cache/fundamentals";
+
+function request(auth?: string): NextRequest {
+  return new NextRequest(URL, {
+    method: "POST",
+    headers: auth ? { authorization: auth } : {},
+  });
+}
+
+describe("POST /api/admin/cache/fundamentals", () => {
+  beforeEach(() => {
+    vi.mocked(deleteCachePattern).mockReset();
+    process.env.CRON_SECRET = "test-secret";
+  });
+
+  afterEach(() => {
+    delete process.env.CRON_SECRET;
+  });
+
+  it("rejects missing or wrong bearer token", async () => {
+    for (const auth of [undefined, "Bearer wrong", "test-secret"]) {
+      const res = await POST(request(auth));
+      expect(res.status).toBe(401);
+    }
+    expect(deleteCachePattern).not.toHaveBeenCalled();
+  });
+
+  it("rejects when CRON_SECRET is unset", async () => {
+    delete process.env.CRON_SECRET;
+    const res = await POST(request("Bearer test-secret"));
+    expect(res.status).toBe(401);
+    expect(deleteCachePattern).not.toHaveBeenCalled();
+  });
+
+  it("purges the fundamentals_zarr namespace and reports the count", async () => {
+    vi.mocked(deleteCachePattern).mockResolvedValueOnce(42);
+    const res = await POST(request("Bearer test-secret"));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      ok: true,
+      pattern: "riskmodels:fundamentals_zarr:*",
+      deleted: 42,
+    });
+    expect(deleteCachePattern).toHaveBeenCalledWith(
+      "riskmodels:fundamentals_zarr:*",
+    );
+  });
+
+  it("returns 500 with the error message on redis failure", async () => {
+    vi.mocked(deleteCachePattern).mockRejectedValueOnce(new Error("redis down"));
+    const res = await POST(request("Bearer test-secret"));
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ ok: false, error: "redis down" });
+  });
+});


### PR DESCRIPTION
## What

`POST /api/admin/cache/fundamentals` — purges `riskmodels:fundamentals_zarr:*` (the per-ticker row packs). Exact mirror of the existing `/api/admin/cache/funds` route: `CRON_SECRET` bearer auth, count reported, safe to call any time (next request per ticker recomputes from GCS).

## Why

H.97 follow-through: the rf-strip repair is live in GCS, but row packs cache per ticker at a weekly TTL — so AAPL/MAG7 keep serving null-rf rows until eviction. This endpoint is the sanctioned bust, and the ERM3 fundamentals publish should call it after every rebuild+republish (same pattern as the Funds_DAG sync calling the funds purge) — that wiring is an ERM3-side follow-up.

## Post-merge operational step (unblocks E.23 screenshots)

```
doppler run -p erm3 -c prd -- sh -c 'curl -sS -X POST -H "Authorization: Bearer $CRON_SECRET" https://riskmodels.app/api/admin/cache/fundamentals'
```

Then verify AAPL serves finite rf: ask the keyless demo for AAPL cost of capital — expect the actual 10y rate (~4.44%) quoted, not "illustrative".

## Verification

`tsc` clean; 4 new route tests (auth rejects, unset-secret reject, purge + count, redis-failure 500); full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)