### PR TITLE
feat(chat): SSE streaming mode — runChatAgentStream + content-negotiated /api/chat

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -3,13 +3,25 @@ import { withBilling, BillingContext } from "@/lib/agent/billing-middleware";
 import { calculateRequestCost } from "@/lib/agent/capabilities";
 import { getCorsHeaders } from "@/lib/cors";
 import { ChatPostSchema } from "@/lib/api/schemas";
-import { runChatAgent, AgentUpstreamError } from "@/lib/chat/agent-runner";
+import {
+  runChatAgent,
+  runChatAgentStream,
+  summarizeToolCalls,
+  AgentUpstreamError,
+} from "@/lib/chat/agent-runner";
+import {
+  encodeSseEvent,
+  type ChatQuota,
+  type ChatStreamEvent,
+} from "@/lib/chat/stream-events";
+import { getUserBalance } from "@/lib/agent/billing";
 import { resolveAgentBackend, hasChatBackend } from "@/lib/chat/llm-backend";
 import { getRiskMetadata } from "@/lib/dal/risk-metadata";
 import { addMetadataHeaders, buildMetadataBody } from "@/lib/dal/response-headers";
 import type { ToolCallResult } from "@/lib/chat/tool-executor";
 
 export const dynamic = "force-dynamic";
+export const maxDuration = 120;
 
 // Backend (model + client) is resolved per-request by resolveAgentBackend():
 // Moonshot/Kimi when MOONSHOT_API_KEY is set, else Claude (AGENT_BACKEND=claude)
@@ -89,8 +101,7 @@ async function estimateChatTokens(req: NextRequest) {
   return { inputTokens, outputTokens };
 }
 
-export const POST = withBilling(
-  async (request: NextRequest, context: BillingContext) => {
+const chatHandler = async (request: NextRequest, context: BillingContext) => {
     const origin = request.headers.get("origin");
 
     // At least one backend must be configured. The runner picks per-request
@@ -229,12 +240,188 @@ export const POST = withBilling(
     );
     addMetadataHeaders(response, metadata);
     return response;
-  },
-  {
-    capabilityId: "chat-risk-analyst",
-    getTokenEstimates: estimateChatTokens,
-  },
-);
+};
+
+/** $20 = 1M tokens (mirrors billing-middleware's token-bucket headers). */
+const TOKEN_PRICE_USD = 0.00002;
+
+/**
+ * SSE handler for `Accept: text/event-stream` (G.23 P1).
+ *
+ * Frames = the ChatStreamEvent vocabulary (lib/chat/stream-events.ts). The
+ * engine's `final` is intercepted and re-emitted enriched: same cost-line
+ * append as the blocking path, plus `quota`. Billing settles at `final` via
+ * `context.settleBilling` (deferBillingToHandler) — deduct only on success,
+ * after the run completes, identical to the blocking path's semantics. A
+ * dropped connection does not cancel the run: it proceeds to `final` and
+ * still bills (enqueue failures are swallowed). Turn persistence is a
+ * consumer concern in P1, so `persisted_id` is always null here.
+ */
+const chatStreamHandler = async (
+  request: NextRequest,
+  context: BillingContext,
+) => {
+  const origin = request.headers.get("origin");
+
+  if (!hasChatBackend()) {
+    return NextResponse.json(
+      {
+        error: "Service unavailable",
+        message:
+          "AI chat is not configured (need MOONSHOT_API_KEY or ANTHROPIC_API_KEY)",
+      },
+      { status: 503, headers: getCorsHeaders(origin) },
+    );
+  }
+
+  let raw: unknown;
+  try {
+    raw = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid request body", message: "Expected JSON body" },
+      { status: 400, headers: getCorsHeaders(origin) },
+    );
+  }
+
+  const validation = ChatPostSchema.safeParse(raw);
+  if (!validation.success) {
+    return NextResponse.json(
+      {
+        error: "Invalid request",
+        message: validation.error.issues[0]?.message ?? "Validation failed",
+      },
+      { status: 400, headers: getCorsHeaders(origin) },
+    );
+  }
+
+  const {
+    messages: userMessages,
+    model: modelOpt,
+    parallel_tool_calls: bodyParallelToolCalls,
+    execute_tools_sequentially: bodyExecSequential,
+  } = validation.data;
+  const backend = resolveAgentBackend(modelOpt);
+
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      const send = (event: ChatStreamEvent) => {
+        try {
+          controller.enqueue(encoder.encode(encodeSseEvent(event)));
+        } catch {
+          // Client gone — keep running so billing still settles at final.
+        }
+      };
+      let engineErrorSent = false;
+      try {
+        const result = await runChatAgentStream(
+          {
+            userMessages,
+            model: backend.model,
+            openai: backend.openai,
+            userId: context.userId,
+            requestId: context.requestId,
+            maxToolRounds: MAX_TOOL_ROUNDS,
+            allowParallelOpenAI:
+              backend.allowParallel && bodyParallelToolCalls !== false,
+            omitParallelToolCalls: backend.omitParallelToolCalls,
+            execParallel: !bodyExecSequential,
+          },
+          (event) => {
+            if (event.type === "final") return; // re-emitted enriched below
+            if (event.type === "error") engineErrorSent = true;
+            send(event);
+          },
+        );
+
+        const toolCostTotal = result.toolCallResults.reduce(
+          (s, r) => s + r.cost_usd,
+          0,
+        );
+        const finalContent = appendCostLineIfMissing(
+          result.finalContent,
+          toolCostTotal,
+          result.toolCallResults.length,
+        );
+
+        await context.settleBilling?.(true);
+
+        let quota: ChatQuota | null = null;
+        try {
+          const balance = await getUserBalance(context.userId);
+          quota = {
+            tokens_consumed: Math.ceil(
+              (context.costUsd + toolCostTotal) / TOKEN_PRICE_USD,
+            ),
+            tokens_remaining: Math.floor(balance / TOKEN_PRICE_USD),
+          };
+        } catch {
+          quota = null;
+        }
+
+        send({
+          type: "final",
+          content: finalContent,
+          tool_calls_summary: summarizeToolCalls(result.toolCallResults),
+          usage: result.usage,
+          quota,
+          persisted_id: null,
+        });
+      } catch (e) {
+        await context.settleBilling?.(false).catch(() => {});
+        if (!engineErrorSent) {
+          send({
+            type: "error",
+            status: e instanceof AgentUpstreamError ? 502 : 500,
+            message: e instanceof Error ? e.message : "Chat agent failed",
+          });
+        }
+        console.error("[chat:stream]", e);
+      } finally {
+        try {
+          controller.close();
+        } catch {
+          // already closed/errored
+        }
+      }
+    },
+  });
+
+  return new NextResponse(stream, {
+    headers: {
+      ...getCorsHeaders(origin),
+      "Content-Type": "text/event-stream; charset=utf-8",
+      "Cache-Control": "no-cache, no-transform",
+      Connection: "keep-alive",
+      "X-Accel-Buffering": "no",
+    },
+  });
+};
+
+const postBlocking = withBilling(chatHandler, {
+  capabilityId: "chat-risk-analyst",
+  getTokenEstimates: estimateChatTokens,
+});
+
+const postStreaming = withBilling(chatStreamHandler, {
+  capabilityId: "chat-risk-analyst",
+  getTokenEstimates: estimateChatTokens,
+  deferBillingToHandler: true,
+});
+
+/**
+ * Content negotiation: `Accept: text/event-stream` opts into SSE streaming;
+ * every other request takes the existing blocking JSON path unchanged
+ * (OpenBB adapter, .net portal, eval harness stay byte-identical).
+ */
+export async function POST(request: NextRequest) {
+  const accept = request.headers.get("accept")?.toLowerCase() ?? "";
+  if (accept.includes("text/event-stream")) {
+    return postStreaming(request);
+  }
+  return postBlocking(request);
+}
 
 export async function OPTIONS(request: NextRequest) {
   const origin = request.headers.get("origin");

--- a/lib/agent/billing-middleware.ts
+++ b/lib/agent/billing-middleware.ts
@@ -252,6 +252,16 @@ export interface BillingOptions {
    * Use for public JSON intended for Shields.io or README embeds so traffic does not bypass all limits.
    */
   publicIpRateLimitPerMinute?: number;
+  /**
+   * Streaming routes (SSE): run every pre-flight check (auth, rate limit,
+   * caps, balance) as usual, but defer deduction + free-tier increment +
+   * telemetry to the handler via `context.settleBilling(success)`. A streaming
+   * handler returns its Response at stream START, so wrapper-side deduction
+   * would bill before the work ran; the handler settles at its terminal event
+   * instead, keeping "deduct only on success, after completion" semantics
+   * identical to blocking routes.
+   */
+  deferBillingToHandler?: boolean;
 }
 
 export interface BillingContext {
@@ -265,6 +275,12 @@ export interface BillingContext {
   freeTierStatus?: any;
   /** First-party gateway traffic — unlimited internal allowance (no 402/deduct). */
   internalUnlimited?: boolean;
+  /**
+   * Present only with `deferBillingToHandler`: the handler MUST call this once
+   * when the request outcome is known (e.g. at the SSE `final`/`error` event).
+   * Idempotent; deducts + increments free tier + logs telemetry on success.
+   */
+  settleBilling?: (success: boolean) => Promise<void>;
 }
 
 /**
@@ -702,6 +718,49 @@ export function withBilling(
         internalUnlimited,
       };
 
+      // 4.5. Deferred billing (streaming handlers): expose a one-shot settle
+      // callback instead of deducting at handler-return (see BillingOptions).
+      if (options.deferBillingToHandler) {
+        const settleUserId = userId;
+        let settled = false;
+        context.settleBilling = async (settleSuccess: boolean) => {
+          if (settled) return;
+          settled = true;
+          if (costUsd > 0 && settleSuccess && !internalUnlimited) {
+            try {
+              await deductBalance(
+                settleUserId,
+                costUsd,
+                requestId,
+                options.capabilityId,
+                {
+                  original_url: req.url,
+                  user_agent: req.headers.get("user-agent"),
+                  ip_address: req.headers.get("x-forwarded-for") || "unknown",
+                },
+              );
+            } catch (deductError) {
+              // Mid-stream there is no way to return 402 — pre-flight balance
+              // check above is the gate; log and continue.
+              console.error("[Billing] Deferred deduction failed:", deductError);
+            }
+          }
+          if (costUsd > 0 && settleSuccess && context.tier === "free") {
+            await incrementFreeTierUsage(settleUserId).catch(console.error);
+          }
+          await logTelemetry({
+            request_id: requestId,
+            capability_id: options.capabilityId,
+            user_id: settleUserId,
+            latency_ms: Date.now() - startTime,
+            status_code: settleSuccess ? 200 : 502,
+            success: settleSuccess,
+            cost_usd: settleSuccess ? costUsd : 0,
+            timestamp: new Date().toISOString(),
+          }).catch(console.error);
+        };
+      }
+
       // 5. Process the request
       const handlerStart = Date.now();
       const response = await handler(req, context);
@@ -712,7 +771,8 @@ export function withBilling(
 
       // 6. Atomically deduct balance on success (only if cost > 0).
       //    The deduct_balance RPC uses FOR UPDATE — immune to race conditions.
-      if (costUsd > 0 && success && !internalUnlimited) {
+      //    (Deferred mode: the handler settles via context.settleBilling.)
+      if (costUsd > 0 && success && !internalUnlimited && !options.deferBillingToHandler) {
         try {
           await deductBalance(
             userId,
@@ -741,25 +801,27 @@ export function withBilling(
       }
 
       // 6.5. Increment free tier usage (for free tier accounts)
-      if (costUsd > 0 && success && context.tier === "free") {
+      if (costUsd > 0 && success && context.tier === "free" && !options.deferBillingToHandler) {
         await incrementFreeTierUsage(userId);
       }
 
-      // 7. Log telemetry
-      await logTelemetry({
-        request_id: requestId,
-        capability_id: options.capabilityId,
-        user_id: userId,
-        latency_ms: latencyMs,
-        status_code: response.status,
-        success,
-        cost_usd: success ? costUsd : 0, // Only charge on success
-        timestamp: new Date().toISOString(),
-        metadata: {
-          fetch_latency_ms: fetchLatencyMs,
-          agent_decision_latency_ms: agentDecisionLatencyMs,
-        },
-      }).catch(console.error);
+      // 7. Log telemetry (deferred mode logs at settle time instead)
+      if (!options.deferBillingToHandler) {
+        await logTelemetry({
+          request_id: requestId,
+          capability_id: options.capabilityId,
+          user_id: userId,
+          latency_ms: latencyMs,
+          status_code: response.status,
+          success,
+          cost_usd: success ? costUsd : 0, // Only charge on success
+          timestamp: new Date().toISOString(),
+          metadata: {
+            fetch_latency_ms: fetchLatencyMs,
+            agent_decision_latency_ms: agentDecisionLatencyMs,
+          },
+        }).catch(console.error);
+      }
 
       // 8. Add billing headers to response
       response.headers.set("X-Request-ID", requestId);
@@ -838,11 +900,14 @@ export function withBilling(
       // the idempotency store so replays return the identical enriched body.
       const finalResponse = await injectAgentMeta(response, { latencyMs, requestId });
 
+      // Never buffer a streaming (SSE) body for the idempotency cache —
+      // clone().text() would drain the whole stream inside the middleware.
       if (
         idempotencyFingerprintVal &&
         userId &&
         req.method === "POST" &&
-        finalResponse.status < 500
+        finalResponse.status < 500 &&
+        !finalResponse.headers.get("content-type")?.includes("text/event-stream")
       ) {
         try {
           const bodyText = await finalResponse.clone().text();

--- a/lib/chat/agent-runner.ts
+++ b/lib/chat/agent-runner.ts
@@ -1,11 +1,19 @@
 import OpenAI from "openai";
 import type {
+  ChatCompletionAssistantMessageParam,
   ChatCompletionMessageParam,
+  ChatCompletionMessageToolCall,
   ChatCompletionTool,
 } from "openai/resources/chat/completions";
+import type { CompletionUsage } from "openai/resources/completions";
 import { CHAT_TOOLS } from "@/lib/chat/tools";
 import { buildSystemPrompt } from "@/lib/chat/system-prompt";
 import { executeToolCalls, type ToolCallResult } from "@/lib/chat/tool-executor";
+import {
+  roundStatusMessage,
+  type ChatStreamEmit,
+  type ToolCallSummaryEntry,
+} from "@/lib/chat/stream-events";
 
 export interface AgentMessage {
   role: "user" | "assistant";
@@ -29,6 +37,8 @@ export interface RunChatAgentOptions {
   skipBilling?: boolean;
   /** Reject tool calls whose args fail this gate (e.g. non-MAG7 ticker). */
   preFlightGuard?: (toolName: string, parsedArgs: unknown) => string | null;
+  /** Optional cancellation; checked between rounds and passed to provider round-trips. */
+  signal?: AbortSignal;
 }
 
 export interface RunChatAgentResult {
@@ -49,10 +59,31 @@ export class AgentUpstreamError extends Error {
   }
 }
 
+export class AgentAbortError extends Error {
+  constructor() {
+    super("Chat agent run aborted");
+    this.name = "AgentAbortError";
+  }
+}
+
 export function modelSupportsParallelToolCalls(model: string): boolean {
   const m = model.toLowerCase();
   if (m.startsWith("o1") || m.startsWith("o3")) return false;
   return true;
+}
+
+/** Map ToolCallResults to the wire summary shape shared by both response modes. */
+export function summarizeToolCalls(
+  results: ToolCallResult[],
+): ToolCallSummaryEntry[] | null {
+  if (results.length === 0) return null;
+  return results.map((r) => ({
+    tool: r.name,
+    capability: r.capability_id,
+    cost_usd: r.cost_usd,
+    latency_ms: r.latency_ms,
+    error: r.error ?? null,
+  }));
 }
 
 /**
@@ -74,7 +105,151 @@ export async function runChatAgent(
     const { runAnthropicChatAgent } = await import("@/lib/chat/anthropic-agent");
     return runAnthropicChatAgent(opts);
   }
+  return runOpenAIChatAgent(opts);
+}
 
+/**
+ * Streaming twin of `runChatAgent`: same options, same result, plus an `emit`
+ * callback receiving the ChatStreamEvent vocabulary. Both entry points run the
+ * SAME provider loop (`runOpenAIChatAgent` / `runAnthropicChatAgent`) — the
+ * only difference is that with `emit` present each provider round-trip uses the
+ * provider's token streaming and forwards text as `delta` events.
+ *
+ * Tool execution stays blocking (P1). `final` / `error` are emitted here, once,
+ * regardless of provider path, so the runners cannot drift on terminal events.
+ * `final.quota` / `final.persisted_id` are null at engine level — the transport
+ * layer (route) enriches quota; turn persistence is a consumer concern in P1.
+ */
+export async function runChatAgentStream(
+  opts: RunChatAgentOptions,
+  emit: ChatStreamEmit,
+): Promise<RunChatAgentResult> {
+  let result: RunChatAgentResult;
+  try {
+    if (opts.model.startsWith("claude-")) {
+      const { runAnthropicChatAgent } = await import(
+        "@/lib/chat/anthropic-agent"
+      );
+      result = await runAnthropicChatAgent(opts, emit);
+    } else {
+      result = await runOpenAIChatAgent(opts, emit);
+    }
+  } catch (e) {
+    if (e instanceof AgentAbortError) {
+      emit({ type: "error", status: 499, message: e.message });
+    } else if (e instanceof AgentUpstreamError) {
+      emit({ type: "error", status: 502, message: e.message });
+    } else {
+      emit({
+        type: "error",
+        status: 500,
+        message: e instanceof Error ? e.message : "Chat agent failed",
+      });
+    }
+    throw e;
+  }
+  emit({
+    type: "final",
+    content: result.finalContent,
+    tool_calls_summary: summarizeToolCalls(result.toolCallResults),
+    usage: result.usage,
+    quota: null,
+    persisted_id: null,
+  });
+  return result;
+}
+
+interface StreamedRound {
+  message: ChatCompletionAssistantMessageParam;
+  toolCalls: ChatCompletionMessageToolCall[];
+  usage: CompletionUsage | null;
+  model: string;
+}
+
+/**
+ * One provider round with `stream: true`: forward content deltas via `emit`,
+ * accumulate tool-call deltas into complete ChatCompletionMessageToolCalls.
+ *
+ * Usage is read from `chunk.usage` (OpenAI `stream_options.include_usage`
+ * shape) or `chunk.choices[0].usage` (Moonshot puts usage on the last chunk's
+ * choice). Once tool-call deltas appear the round is a tool round — content
+ * deltas stop being forwarded (P1: tool rounds are blocking; any preamble text
+ * already forwarded is narration and `final.content` stays authoritative).
+ */
+async function streamOneOpenAIRound(
+  openai: OpenAI,
+  params: OpenAI.Chat.Completions.ChatCompletionCreateParamsNonStreaming,
+  emit: ChatStreamEmit,
+  signal?: AbortSignal,
+): Promise<StreamedRound> {
+  const stream = await openai.chat.completions.create(
+    // Moonshot rejects some optional params; keep the wire identical to the
+    // blocking round except for the stream flag itself.
+    { ...params, stream: true },
+    signal ? { signal } : undefined,
+  );
+
+  let content = "";
+  let model = "";
+  let usage: CompletionUsage | null = null;
+  let sawToolCalls = false;
+  const toolAcc = new Map<number, { id: string; name: string; args: string }>();
+
+  for await (const chunk of stream) {
+    if (chunk.model) model = chunk.model;
+    const choice = chunk.choices?.[0];
+    const chunkUsage =
+      chunk.usage ?? (choice as { usage?: CompletionUsage } | undefined)?.usage;
+    if (chunkUsage) usage = chunkUsage;
+    const delta = choice?.delta;
+    if (!delta) continue;
+
+    if (delta.tool_calls?.length) {
+      sawToolCalls = true;
+      for (const tc of delta.tool_calls) {
+        const cur = toolAcc.get(tc.index) ?? { id: "", name: "", args: "" };
+        if (tc.id) cur.id = tc.id;
+        if (tc.function?.name) cur.name = tc.function.name;
+        if (tc.function?.arguments) cur.args += tc.function.arguments;
+        toolAcc.set(tc.index, cur);
+      }
+    }
+    if (typeof delta.content === "string" && delta.content.length > 0) {
+      content += delta.content;
+      if (!sawToolCalls) emit({ type: "delta", text: delta.content });
+    }
+  }
+
+  const toolCalls: ChatCompletionMessageToolCall[] = [...toolAcc.entries()]
+    .sort((a, b) => a[0] - b[0])
+    .map(([, t]) => ({
+      id: t.id,
+      type: "function" as const,
+      function: { name: t.name, arguments: t.args },
+    }));
+
+  return {
+    message: {
+      role: "assistant",
+      content: content.length > 0 ? content : null,
+      ...(toolCalls.length > 0 ? { tool_calls: toolCalls } : {}),
+    },
+    toolCalls,
+    usage,
+    model,
+  };
+}
+
+/**
+ * OpenAI-compatible tool loop (Moonshot/Kimi). Blocking and streaming modes
+ * share this single loop: with `emit` absent every round uses a plain
+ * completion (byte-identical to the historical behavior); with `emit` present
+ * each round streams and text deltas are forwarded live.
+ */
+async function runOpenAIChatAgent(
+  opts: RunChatAgentOptions,
+  emit?: ChatStreamEmit,
+): Promise<RunChatAgentResult> {
   const {
     userMessages,
     model,
@@ -88,6 +263,7 @@ export async function runChatAgent(
     omitParallelToolCalls = false,
     skipBilling = false,
     preFlightGuard,
+    signal,
   } = opts;
 
   // Moonshot (Kimi) is the only OpenAI-compatible backend; callers normally
@@ -126,9 +302,11 @@ export async function runChatAgent(
   let finalModel = model;
 
   for (let round = 0; round < maxToolRounds; round++) {
-    let completion;
-    try {
-      completion = await openai.chat.completions.create({
+    if (signal?.aborted) throw new AgentAbortError();
+    emit?.({ type: "status", round, message: roundStatusMessage(round) });
+
+    const requestParams: OpenAI.Chat.Completions.ChatCompletionCreateParamsNonStreaming =
+      {
         model,
         messages,
         tools,
@@ -139,29 +317,74 @@ export async function runChatAgent(
             ? { parallel_tool_calls: true }
             : { parallel_tool_calls: false }),
         ...(maxCompletionTokens ? { max_tokens: maxCompletionTokens } : {}),
-      });
-    } catch (e) {
-      const msg = e instanceof Error ? e.message : "OpenAI request failed";
-      throw new AgentUpstreamError(msg);
+      };
+
+    let toolCalls: ChatCompletionMessageToolCall[] | undefined;
+
+    if (emit) {
+      let streamed: StreamedRound;
+      try {
+        streamed = await streamOneOpenAIRound(openai, requestParams, emit, signal);
+      } catch (e) {
+        if (signal?.aborted) throw new AgentAbortError();
+        const msg = e instanceof Error ? e.message : "OpenAI request failed";
+        throw new AgentUpstreamError(msg);
+      }
+      if (streamed.usage) {
+        totalUsage.prompt_tokens += streamed.usage.prompt_tokens;
+        totalUsage.completion_tokens += streamed.usage.completion_tokens;
+        totalUsage.total_tokens += streamed.usage.total_tokens;
+      }
+      if (streamed.model) finalModel = streamed.model;
+
+      messages.push(streamed.message);
+      toolCalls = streamed.toolCalls.length > 0 ? streamed.toolCalls : undefined;
+      if (!toolCalls) {
+        finalContent =
+          typeof streamed.message.content === "string"
+            ? streamed.message.content
+            : "";
+        break;
+      }
+    } else {
+      let completion;
+      try {
+        completion = await openai.chat.completions.create(
+          requestParams,
+          signal ? { signal } : undefined,
+        );
+      } catch (e) {
+        if (signal?.aborted) throw new AgentAbortError();
+        const msg = e instanceof Error ? e.message : "OpenAI request failed";
+        throw new AgentUpstreamError(msg);
+      }
+
+      if (completion.usage) {
+        totalUsage.prompt_tokens += completion.usage.prompt_tokens;
+        totalUsage.completion_tokens += completion.usage.completion_tokens;
+        totalUsage.total_tokens += completion.usage.total_tokens;
+      }
+      finalModel = completion.model;
+
+      const choice = completion.choices[0];
+      if (!choice) break;
+
+      const assistantMessage = choice.message;
+      messages.push(assistantMessage);
+
+      toolCalls = assistantMessage.tool_calls;
+      if (!toolCalls?.length) {
+        finalContent = assistantMessage.content ?? "";
+        break;
+      }
     }
 
-    if (completion.usage) {
-      totalUsage.prompt_tokens += completion.usage.prompt_tokens;
-      totalUsage.completion_tokens += completion.usage.completion_tokens;
-      totalUsage.total_tokens += completion.usage.total_tokens;
-    }
-    finalModel = completion.model;
-
-    const choice = completion.choices[0];
-    if (!choice) break;
-
-    const assistantMessage = choice.message;
-    messages.push(assistantMessage);
-
-    const toolCalls = assistantMessage.tool_calls;
-    if (!toolCalls?.length) {
-      finalContent = assistantMessage.content ?? "";
-      break;
+    if (emit) {
+      for (const tc of toolCalls) {
+        if (tc.type === "function") {
+          emit({ type: "status", round, message: `Running ${tc.function.name}` });
+        }
+      }
     }
 
     const results = await executeToolCalls(toolCalls, {
@@ -174,6 +397,12 @@ export async function runChatAgent(
 
     for (const r of results) {
       toolCallResults.push(r);
+      emit?.({
+        type: "tool",
+        name: r.name,
+        latency_ms: r.latency_ms,
+        ...(r.error ? { error: r.error } : {}),
+      });
     }
 
     for (let i = 0; i < toolCalls.length; i++) {

--- a/lib/chat/anthropic-agent.ts
+++ b/lib/chat/anthropic-agent.ts
@@ -7,10 +7,12 @@ import { CHAT_TOOLS } from "@/lib/chat/tools";
 import { buildSystemPrompt } from "@/lib/chat/system-prompt";
 import { executeToolCalls } from "@/lib/chat/tool-executor";
 import {
+  AgentAbortError,
   AgentUpstreamError,
   type RunChatAgentOptions,
   type RunChatAgentResult,
 } from "@/lib/chat/agent-runner";
+import { roundStatusMessage, type ChatStreamEmit } from "@/lib/chat/stream-events";
 
 const DEFAULT_MAX_TOKENS = 4096;
 
@@ -65,9 +67,15 @@ function toolUseToFakeOpenAICall(
  *
  * Models: dispatch is based on `model.startsWith("claude-")`; callers pass any
  * canonical alias from shared/models.md (e.g. claude-sonnet-4-6).
+ *
+ * Streaming: with `emit` present each round uses `client.messages.stream()` and
+ * forwards text deltas live; tool execution stays blocking. Text blocks that
+ * precede tool_use in a tool round stream as narration — `final.content`
+ * (emitted by runChatAgentStream) is authoritative.
  */
 export async function runAnthropicChatAgent(
   opts: RunChatAgentOptions,
+  emit?: ChatStreamEmit,
 ): Promise<RunChatAgentResult> {
   const {
     userMessages,
@@ -80,6 +88,7 @@ export async function runAnthropicChatAgent(
     execParallel = true,
     skipBilling = false,
     preFlightGuard,
+    signal,
   } = opts;
 
   if (!process.env.ANTHROPIC_API_KEY) {
@@ -110,22 +119,40 @@ export async function runAnthropicChatAgent(
   let finalModel = model;
 
   for (let round = 0; round < maxToolRounds; round++) {
+    if (signal?.aborted) throw new AgentAbortError();
+    emit?.({ type: "status", round, message: roundStatusMessage(round) });
+
+    const requestParams: Anthropic.MessageCreateParamsNonStreaming = {
+      model,
+      max_tokens: maxCompletionTokens ?? DEFAULT_MAX_TOKENS,
+      system: [
+        {
+          type: "text",
+          text: buildSystemPrompt(),
+          cache_control: { type: "ephemeral" },
+        },
+      ],
+      tools: anthropicTools,
+      messages,
+    };
+
     let response: Anthropic.Message;
     try {
-      response = await client.messages.create({
-        model,
-        max_tokens: maxCompletionTokens ?? DEFAULT_MAX_TOKENS,
-        system: [
-          {
-            type: "text",
-            text: buildSystemPrompt(),
-            cache_control: { type: "ephemeral" },
-          },
-        ],
-        tools: anthropicTools,
-        messages,
-      });
+      if (emit) {
+        const stream = client.messages.stream(
+          requestParams,
+          signal ? { signal } : undefined,
+        );
+        stream.on("text", (text) => emit({ type: "delta", text }));
+        response = await stream.finalMessage();
+      } else {
+        response = await client.messages.create(
+          requestParams,
+          signal ? { signal } : undefined,
+        );
+      }
     } catch (e) {
+      if (signal?.aborted) throw new AgentAbortError();
       if (e instanceof Anthropic.APIError) {
         throw new AgentUpstreamError(
           `Anthropic API error (${e.status}): ${e.message}`,
@@ -181,6 +208,11 @@ export async function runAnthropicChatAgent(
     }
 
     const fakeCalls = toolUseBlocks.map(toolUseToFakeOpenAICall);
+    if (emit) {
+      for (const block of toolUseBlocks) {
+        emit({ type: "status", round, message: `Running ${block.name}` });
+      }
+    }
     const results = await executeToolCalls(fakeCalls, {
       parallel: execParallel,
       userId,
@@ -190,6 +222,12 @@ export async function runAnthropicChatAgent(
     });
     for (const r of results) {
       toolCallResults.push(r);
+      emit?.({
+        type: "tool",
+        name: r.name,
+        latency_ms: r.latency_ms,
+        ...(r.error ? { error: r.error } : {}),
+      });
     }
 
     const toolResultBlocks: Anthropic.ToolResultBlockParam[] = toolUseBlocks.map(

--- a/lib/chat/stream-events.ts
+++ b/lib/chat/stream-events.ts
@@ -1,0 +1,66 @@
+/**
+ * Event vocabulary for the streaming chat engine (versioned, additive).
+ *
+ * `runChatAgentStream(opts, emit)` produces these events; the SSE transport in
+ * POST /api/chat serializes them 1:1 as `event: <type>` frames. Consumers must
+ * ignore unknown event types and unknown payload fields (additive evolution).
+ *
+ * P1 semantics:
+ *  - `status`  — round start + per tool-call start.
+ *  - `tool`    — each tool completes (tool execution is always blocking).
+ *  - `delta`   — provider token deltas. Only the final composition round
+ *    produces text with our tool-calling providers, so deltas effectively
+ *    stream the final answer; if a tool round emits preamble text it is
+ *    forwarded as narration and `final.content` remains authoritative.
+ *  - `final`   — exactly once on success. `content` is authoritative (clients
+ *    replace accumulated deltas with it). `quota` / `persisted_id` are
+ *    engine-level null; the route enriches `quota`, and turn persistence is a
+ *    consumer concern in P1 (`persisted_id` stays null).
+ *  - `error`   — terminal failure; no `final` follows.
+ */
+
+export interface ToolCallSummaryEntry {
+  tool: string;
+  capability: string | null;
+  cost_usd: number;
+  latency_ms: number;
+  error: string | null;
+}
+
+export interface ChatUsage {
+  prompt_tokens: number;
+  completion_tokens: number;
+  total_tokens: number;
+}
+
+export interface ChatQuota {
+  tokens_consumed: number;
+  tokens_remaining: number | null;
+}
+
+export type ChatStreamEvent =
+  | { type: "status"; round: number; message: string }
+  | { type: "tool"; name: string; latency_ms: number; error?: string }
+  | { type: "delta"; text: string }
+  | {
+      type: "final";
+      content: string;
+      tool_calls_summary: ToolCallSummaryEntry[] | null;
+      usage: ChatUsage;
+      quota: ChatQuota | null;
+      persisted_id: string | null;
+    }
+  | { type: "error"; status: number; message: string };
+
+export type ChatStreamEmit = (event: ChatStreamEvent) => void;
+
+/** Serialize one event as an SSE frame (`event:` = type, `data:` = payload sans type). */
+export function encodeSseEvent(event: ChatStreamEvent): string {
+  const { type, ...payload } = event;
+  return `event: ${type}\ndata: ${JSON.stringify(payload)}\n\n`;
+}
+
+/** Shared round-start status copy so both provider runners emit identical text. */
+export function roundStatusMessage(round: number): string {
+  return round === 0 ? "Analyzing request" : "Composing response";
+}

--- a/scripts/evals/copilot-eval.mjs
+++ b/scripts/evals/copilot-eval.mjs
@@ -7,6 +7,14 @@
  *   node scripts/evals/copilot-eval.mjs                 # production
  *   node scripts/evals/copilot-eval.mjs --base http://localhost:3000
  *   node scripts/evals/copilot-eval.mjs --only aapl-coc,no-advice
+ *   node scripts/evals/copilot-eval.mjs --stream        # SSE mode check (needs RISKMODELS_API_KEY)
+ *
+ * --stream targets POST /api/chat (Accept: text/event-stream) with one golden
+ * question: asserts event ordering (>=1 status, >=1 delta, exactly 1 final,
+ * status before delta before final), non-empty final content, and that the
+ * same tool ran as in blocking mode. /api/chat is authenticated (the keyless
+ * landing route stays blocking in P1), so without RISKMODELS_API_KEY the
+ * stream check skips gracefully.
  *
  * NOTE: the demo endpoint is rate-limited per IP (10 msgs/hour) — the full
  * suite spends 5. Run after copilot-affecting deploys, not in CI loops.
@@ -20,6 +28,7 @@ const flag = (name) => {
 };
 const BASE = flag("base") ?? "https://riskmodels.app";
 const ONLY = flag("only")?.split(",");
+const STREAM = args.includes("--stream");
 
 // Raw LaTeX reaching users (adapter deLatex + doctrine both guard this).
 const LATEX_RESIDUE = /\$\$|\\beta|\\text\{|\\frac\{|\\times|\$[A-Za-z]_[A-Za-z]?\$/;
@@ -97,6 +106,107 @@ async function runCase(c) {
     if (m) failures.push(`forbidden: ${re} → "${m[0]}"`);
   }
   return { id: c.id, ms, failures, tools };
+}
+
+/** Parse an SSE body into [{event, data}] frames. */
+function parseSse(text) {
+  const frames = [];
+  for (const block of text.split("\n\n")) {
+    let event = "message";
+    let data = "";
+    for (const line of block.split("\n")) {
+      if (line.startsWith("event: ")) event = line.slice(7).trim();
+      else if (line.startsWith("data: ")) data += line.slice(6);
+    }
+    if (data) {
+      try {
+        frames.push({ event, data: JSON.parse(data) });
+      } catch {
+        frames.push({ event, data });
+      }
+    }
+  }
+  return frames;
+}
+
+async function runStreamCheck() {
+  const key = process.env.RISKMODELS_API_KEY;
+  if (!key) {
+    console.log(
+      "⏭  --stream skipped: RISKMODELS_API_KEY not set (streaming lives on the authenticated /api/chat; the keyless landing route stays blocking in P1)",
+    );
+    return 0;
+  }
+  const question = CASES[0].question; // aapl-coc golden question
+  const post = (headers) =>
+    fetch(`${BASE}/api/chat`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${key}`,
+        ...headers,
+      },
+      body: JSON.stringify({ messages: [{ role: "user", content: question }] }),
+    });
+
+  const failures = [];
+
+  // Blocking reference run (same route, no Accept header).
+  const t0 = Date.now();
+  const blockRes = await post({});
+  if (!blockRes.ok) {
+    console.log(`✗  stream-check — blocking reference HTTP ${blockRes.status}`);
+    return 1;
+  }
+  const blockBody = await blockRes.json();
+  const blockTools = (blockBody?.tool_calls_summary ?? []).map((t) => t.tool);
+  const blockMs = Date.now() - t0;
+
+  // Streaming run.
+  const t1 = Date.now();
+  const res = await post({ Accept: "text/event-stream" });
+  if (!res.ok || !res.headers.get("content-type")?.includes("text/event-stream")) {
+    console.log(
+      `✗  stream-check — HTTP ${res.status}, content-type ${res.headers.get("content-type")}`,
+    );
+    return 1;
+  }
+  const frames = parseSse(await res.text());
+  const streamMs = Date.now() - t1;
+  const types = frames.map((f) => f.event);
+
+  const nStatus = types.filter((t) => t === "status").length;
+  const nDelta = types.filter((t) => t === "delta").length;
+  const nFinal = types.filter((t) => t === "final").length;
+  if (nStatus < 1) failures.push("expected >=1 status event");
+  if (nDelta < 1) failures.push("expected >=1 delta event");
+  if (nFinal !== 1) failures.push(`expected exactly 1 final event, got ${nFinal}`);
+  if (types.includes("error")) failures.push("stream emitted an error event");
+  if (nStatus && nDelta && types.indexOf("status") > types.indexOf("delta"))
+    failures.push("first status must precede first delta");
+  if (nFinal && types.at(-1) !== "final") failures.push("final must be the last event");
+
+  const final = frames.find((f) => f.event === "final")?.data;
+  if (!final?.content?.trim()) failures.push("final content is empty");
+  const streamTools = (final?.tool_calls_summary ?? []).map((t) => t.tool);
+  for (const t of blockTools) {
+    if (!streamTools.includes(t))
+      failures.push(`blocking mode called ${t}; streaming mode called [${streamTools.join(",") || "none"}]`);
+  }
+
+  if (failures.length) {
+    console.log(`✗  stream-check (blocking ${blockMs}ms, stream ${streamMs}ms)`);
+    for (const f of failures) console.log(`   - ${f}`);
+    return 1;
+  }
+  console.log(
+    `✓  stream-check (blocking ${blockMs}ms → ${blockTools.join(",") || "none"}; stream ${streamMs}ms → ${streamTools.join(",") || "none"}; ${nStatus} status / ${nDelta} delta / 1 final)`,
+  );
+  return 0;
+}
+
+if (STREAM) {
+  process.exit(await runStreamCheck());
 }
 
 const cases = ONLY ? CASES.filter((c) => ONLY.includes(c.id)) : CASES;

--- a/tests/chat-stream-runner.test.ts
+++ b/tests/chat-stream-runner.test.ts
@@ -1,0 +1,252 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type OpenAI from "openai";
+
+vi.mock("@/lib/chat/tool-executor", () => ({
+  executeToolCalls: vi.fn(),
+}));
+
+import { executeToolCalls } from "@/lib/chat/tool-executor";
+import {
+  runChatAgent,
+  runChatAgentStream,
+  AgentUpstreamError,
+} from "@/lib/chat/agent-runner";
+import {
+  encodeSseEvent,
+  type ChatStreamEvent,
+} from "@/lib/chat/stream-events";
+
+const TOOL_RESULT = {
+  tool_call_id: "call_1",
+  name: "get_fundamentals",
+  result: { symbol: "AAPL", wacc: 0.09 },
+  cost_usd: 0.002,
+  capability_id: "fundamentals",
+  latency_ms: 42,
+};
+
+/** Round 1: model requests one tool via split argument deltas (Moonshot puts usage on the last chunk's choice). */
+async function* toolRoundChunks() {
+  yield {
+    id: "cmpl-1",
+    model: "kimi-test",
+    choices: [
+      {
+        index: 0,
+        delta: {
+          role: "assistant",
+          tool_calls: [
+            {
+              index: 0,
+              id: "call_1",
+              type: "function",
+              function: { name: "get_fundamentals", arguments: '{"sym' },
+            },
+          ],
+        },
+      },
+    ],
+  };
+  yield {
+    choices: [
+      {
+        index: 0,
+        delta: {
+          tool_calls: [{ index: 0, function: { arguments: 'bol":"AAPL"}' } }],
+        },
+      },
+    ],
+  };
+  yield {
+    choices: [
+      {
+        index: 0,
+        delta: {},
+        finish_reason: "tool_calls",
+        usage: { prompt_tokens: 100, completion_tokens: 10, total_tokens: 110 },
+      },
+    ],
+  };
+}
+
+/** Round 2: final composition round streams text; usage arrives OpenAI-style on the last chunk. */
+async function* finalRoundChunks() {
+  yield { choices: [{ index: 0, delta: { role: "assistant", content: "AAPL's " } }] };
+  yield { choices: [{ index: 0, delta: { content: "cost of capital is " } }] };
+  yield { choices: [{ index: 0, delta: { content: "9.0%." }, finish_reason: "stop" }] };
+  yield {
+    choices: [],
+    usage: { prompt_tokens: 200, completion_tokens: 20, total_tokens: 220 },
+  };
+}
+
+function fakeOpenAI(create: ReturnType<typeof vi.fn>): OpenAI {
+  return { chat: { completions: { create } } } as unknown as OpenAI;
+}
+
+const BASE_OPTS = {
+  userMessages: [{ role: "user" as const, content: "What is AAPL's cost of capital?" }],
+  model: "kimi-test",
+  userId: "user-1",
+  requestId: "req-1",
+};
+
+beforeEach(() => {
+  vi.mocked(executeToolCalls).mockReset();
+});
+
+describe("runChatAgentStream — event sequence (OpenAI-compatible path)", () => {
+  async function runGolden() {
+    const create = vi
+      .fn()
+      .mockImplementationOnce(async () => toolRoundChunks())
+      .mockImplementationOnce(async () => finalRoundChunks());
+    vi.mocked(executeToolCalls).mockResolvedValue([TOOL_RESULT]);
+
+    const events: ChatStreamEvent[] = [];
+    const result = await runChatAgentStream(
+      { ...BASE_OPTS, openai: fakeOpenAI(create) },
+      (e) => events.push(e),
+    );
+    return { events, result, create };
+  }
+
+  it("emits status → tool → delta+ → exactly one final, in order", async () => {
+    const { events } = await runGolden();
+    const types = events.map((e) => e.type);
+    expect(types).toEqual([
+      "status", // round 0 start
+      "status", // Running get_fundamentals
+      "tool",
+      "status", // round 1 start (composition)
+      "delta",
+      "delta",
+      "delta",
+      "final",
+    ]);
+    // Ordering invariants the eval harness also asserts:
+    expect(types.indexOf("status")).toBeLessThan(types.indexOf("delta"));
+    expect(types.filter((t) => t === "final")).toHaveLength(1);
+    expect(types.at(-1)).toBe("final");
+    expect(types).not.toContain("error");
+  });
+
+  it("final content equals the concatenated deltas and carries summary/usage", async () => {
+    const { events, result } = await runGolden();
+    const deltas = events
+      .filter((e): e is Extract<ChatStreamEvent, { type: "delta" }> => e.type === "delta")
+      .map((e) => e.text)
+      .join("");
+    const final = events.find(
+      (e): e is Extract<ChatStreamEvent, { type: "final" }> => e.type === "final",
+    )!;
+    expect(final.content).toBe("AAPL's cost of capital is 9.0%.");
+    expect(final.content).toBe(deltas);
+    expect(final.tool_calls_summary).toEqual([
+      {
+        tool: "get_fundamentals",
+        capability: "fundamentals",
+        cost_usd: 0.002,
+        latency_ms: 42,
+        error: null,
+      },
+    ]);
+    expect(final.usage).toEqual({
+      prompt_tokens: 300,
+      completion_tokens: 30,
+      total_tokens: 330,
+    });
+    expect(final.quota).toBeNull();
+    expect(final.persisted_id).toBeNull();
+    // Returned result matches the blocking-path contract.
+    expect(result.finalContent).toBe(final.content);
+    expect(result.toolCallResults).toEqual([TOOL_RESULT]);
+    expect(result.model).toBe("kimi-test");
+  });
+
+  it("reassembles split tool-call argument deltas before executing", async () => {
+    await runGolden();
+    expect(vi.mocked(executeToolCalls)).toHaveBeenCalledTimes(1);
+    const [calls] = vi.mocked(executeToolCalls).mock.calls[0];
+    expect(calls).toEqual([
+      {
+        id: "call_1",
+        type: "function",
+        function: { name: "get_fundamentals", arguments: '{"symbol":"AAPL"}' },
+      },
+    ]);
+  });
+
+  it("requests provider streaming only in stream mode", async () => {
+    const { create } = await runGolden();
+    for (const call of create.mock.calls) {
+      expect(call[0].stream).toBe(true);
+    }
+
+    const blockingCreate = vi.fn().mockResolvedValue({
+      model: "kimi-test",
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+      choices: [{ message: { role: "assistant", content: "hi" } }],
+    });
+    await runChatAgent({ ...BASE_OPTS, openai: fakeOpenAI(blockingCreate) });
+    expect(blockingCreate.mock.calls[0][0].stream).toBeUndefined();
+  });
+});
+
+describe("runChatAgentStream — error path", () => {
+  it("emits a terminal 502 error event and rejects with AgentUpstreamError", async () => {
+    const create = vi.fn().mockRejectedValue(new Error("upstream boom"));
+    const events: ChatStreamEvent[] = [];
+
+    await expect(
+      runChatAgentStream({ ...BASE_OPTS, openai: fakeOpenAI(create) }, (e) =>
+        events.push(e),
+      ),
+    ).rejects.toBeInstanceOf(AgentUpstreamError);
+
+    const types = events.map((e) => e.type);
+    expect(types).toEqual(["status", "error"]);
+    const err = events.at(-1) as Extract<ChatStreamEvent, { type: "error" }>;
+    expect(err.status).toBe(502);
+    expect(err.message).toContain("upstream boom");
+    expect(types).not.toContain("final");
+  });
+});
+
+describe("runChatAgentStream — abort path", () => {
+  it("stops between rounds, emits error 499, no final", async () => {
+    const controller = new AbortController();
+    const create = vi.fn().mockImplementation(async () => toolRoundChunks());
+    // Simulate the client dropping while the tool executes.
+    vi.mocked(executeToolCalls).mockImplementation(async () => {
+      controller.abort();
+      return [TOOL_RESULT];
+    });
+
+    const events: ChatStreamEvent[] = [];
+    await expect(
+      runChatAgentStream(
+        { ...BASE_OPTS, openai: fakeOpenAI(create), signal: controller.signal },
+        (e) => events.push(e),
+      ),
+    ).rejects.toMatchObject({ name: "AgentAbortError" });
+
+    const types = events.map((e) => e.type);
+    expect(types.at(-1)).toBe("error");
+    const err = events.at(-1) as Extract<ChatStreamEvent, { type: "error" }>;
+    expect(err.status).toBe(499);
+    expect(types).not.toContain("final");
+    expect(create).toHaveBeenCalledTimes(1); // no second round after abort
+  });
+});
+
+describe("encodeSseEvent", () => {
+  it("frames the event type and payload without the type field", () => {
+    expect(encodeSseEvent({ type: "delta", text: "hi" })).toBe(
+      'event: delta\ndata: {"text":"hi"}\n\n',
+    );
+    expect(
+      encodeSseEvent({ type: "status", round: 0, message: "Analyzing request" }),
+    ).toBe('event: status\ndata: {"round":0,"message":"Analyzing request"}\n\n');
+  });
+});


### PR DESCRIPTION
## What

Streaming engine per the committed design (P1 scope): `runChatAgentStream(opts, emit)` beside the unchanged `runChatAgent`, one shared round loop per provider (no fork — terminal events emitted once in the dispatcher), both provider paths stream (OpenAI-compatible incl. Moonshot chunk-usage quirk; Anthropic `messages.stream()`). `POST /api/chat` content-negotiates on `Accept: text/event-stream`; every other request takes the blocking path byte-identical. Event vocabulary: `status`/`tool`/`delta`/`final`/`error` (`lib/chat/stream-events.ts`). Tool rounds stay blocking; the final composition round streams real tokens. Abort → `error{499}`, no `final`.

## Billing (review focus)

`withBilling` deducts at handler-return — for SSE that is stream *start*. New opt-in `deferBillingToHandler`: all pre-flight checks unchanged; deduction + free-tier increment + telemetry move to a one-shot `context.settleBilling(success)` invoked at `final` (failure settles unbilled). Double-deduction guarded (`!options.deferBillingToHandler` on both wrapper-side paths — verified in review). Dropped connections still run to `final` and bill, matching blocking semantics. Mid-stream 402 is impossible by construction; the pre-flight balance check remains the gate.

## Not in this PR

Consumers (`app/openbb/query` word-pacing → real deltas; .net ChatAgent reader) — next PR. `persisted_id` is `null` in P1 (persistence is consumer-side in this codebase).

## Verification

typecheck clean; vitest **487 passed** (7 new: exact event-sequence golden path, split tool-arg delta reassembly, error path, abort path, stream-flag isolation). Eval harness gains `--stream` (asserts status→delta→final ordering + same-tool parity vs blocking); skips gracefully without a key — post-merge check: `node scripts/evals/copilot-eval.mjs --stream` with a key against prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)