### PR TITLE
chore(ci): Node 20 → 24 in prod-copilot-eval (follow-up to #244)

### DIFF
--- a/.github/workflows/prod-copilot-eval.yml
+++ b/.github/workflows/prod-copilot-eval.yml
@@ -22,6 +22,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
       - name: Run golden-question evals vs production
         run: node scripts/evals/copilot-eval.mjs


### PR DESCRIPTION
The one workflow missed by #244. All RiskModels_API CI now on Node 24 to match Vercel prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)