### PR TITLE
feat(openbb): copilot streams real tokens — SSE consumer + streaming deLatex

### DIFF
--- a/app/openbb/_lib/chat-stream.ts
+++ b/app/openbb/_lib/chat-stream.ts
@@ -1,0 +1,306 @@
+/**
+ * Streaming glue for the OpenBB adapter (G.23 P1).
+ *
+ * `POST /api/chat` streams its ChatStreamEvent vocabulary as SSE when called
+ * with `Accept: text/event-stream` (see lib/chat/stream-events.ts — consumers
+ * must ignore unknown event types / fields). This module:
+ *
+ *  - parses that SSE byte stream back into events (`parseSseEvents`),
+ *  - applies deLatex incrementally on token deltas (`StreamingDeLatex`), and
+ *  - translates engine events into OpenBB copilot frames
+ *    (`translateChatStream`): status/tool → copilotStatusUpdate,
+ *    delta → copilotMessageChunk, final → tail flush + authoritative-suffix
+ *    emission (the engine appends a tool-cost line to `final.content` that
+ *    never appears in deltas).
+ */
+import { deLatex } from "./delatex";
+
+/* ------------------------------------------------------------------ */
+/* Streaming deLatex                                                    */
+/* ------------------------------------------------------------------ */
+
+// Mirror the bounds in delatex.ts: inline $...$ / \(...\) inner ≤ 120 chars
+// (no newline), display $$...$$ / \[...\] inner ≤ 300 chars.
+const INLINE_MAX = 120;
+const BLOCK_MAX = 300;
+
+/**
+ * Largest prefix of `buf` that is safe to run through `deLatex` now: it ends
+ * at a whitespace boundary in plain text (never a partial word or command)
+ * and never splits a completed — or still-completable — math region.
+ * Openers whose region can no longer match deLatex's bounded patterns
+ * (e.g. a lone `$5` price once 120+ chars pass without a closer) are
+ * released as plain text so a dollar amount can't stall the stream forever.
+ */
+function safeCut(buf: string): number {
+  let i = 0;
+  let cut = 0;
+  while (i < buf.length) {
+    const c = buf[i];
+    if (c === "$") {
+      if (buf[i + 1] === "$") {
+        const close = buf.indexOf("$$", i + 2);
+        if (close !== -1) {
+          i = close + 2;
+          continue;
+        }
+        if (buf.length - (i + 2) > BLOCK_MAX + 2) {
+          i += 2; // inner already too long to ever match — plain text
+          continue;
+        }
+        return cut; // unclosed display block — hold from the opener
+      }
+      const rest = buf.slice(i + 1);
+      const stop = rest.search(/[$\n]/);
+      if (stop === -1) {
+        if (rest.length > INLINE_MAX) {
+          i += 1; // closer can no longer arrive in range — plain '$'
+          continue;
+        }
+        return cut; // may still become inline math — hold
+      }
+      if (rest[stop] === "$" && stop >= 1 && stop <= INLINE_MAX) {
+        i += 1 + stop + 1; // completed inline region — skip it whole
+        continue;
+      }
+      i += 1; // newline first, or closer out of range — plain '$'
+      continue;
+    }
+    if (c === "\\") {
+      const next = buf[i + 1];
+      if (next === undefined) return cut; // could become \[ or \(
+      if (next === "[") {
+        const close = buf.indexOf("\\]", i + 2);
+        if (close !== -1) {
+          i = close + 2;
+          continue;
+        }
+        if (buf.length - (i + 2) > BLOCK_MAX + 2) {
+          i += 2;
+          continue;
+        }
+        return cut;
+      }
+      if (next === "(") {
+        const rest = buf.slice(i + 2);
+        const stop = rest.search(/[)\n]/);
+        if (stop === -1) {
+          if (rest.length > INLINE_MAX + 1) {
+            i += 2;
+            continue;
+          }
+          return cut;
+        }
+        if (
+          rest[stop] === ")" &&
+          rest[stop - 1] === "\\" &&
+          stop - 1 >= 1 &&
+          stop - 1 <= INLINE_MAX
+        ) {
+          i += 2 + stop + 1; // completed \(...\) region
+          continue;
+        }
+        i += 2; // first ')' isn't a '\)' closer — can never match
+        continue;
+      }
+      i += 1; // bare command/escape — plain outside math regions
+      continue;
+    }
+    if (/\s/.test(c)) cut = i + 1;
+    i += 1;
+  }
+  return cut;
+}
+
+/**
+ * Stateful per-delta deLatex: feed provider token deltas via `push` (returns
+ * text safe to emit now, possibly ""), then `flush` the remainder at final.
+ * Buffers until whitespace so words/commands are never split, and holds
+ * open math regions ($$…$$, $…$, \[…\], \(…\)) until they close.
+ */
+export class StreamingDeLatex {
+  private buf = "";
+
+  push(text: string): string {
+    this.buf += text;
+    const cut = safeCut(this.buf);
+    if (cut === 0) return "";
+    const out = deLatex(this.buf.slice(0, cut));
+    this.buf = this.buf.slice(cut);
+    return out;
+  }
+
+  flush(): string {
+    if (!this.buf) return "";
+    const out = deLatex(this.buf);
+    this.buf = "";
+    return out;
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/* SSE parsing                                                          */
+/* ------------------------------------------------------------------ */
+
+/** One upstream ChatStreamEvent, loosely typed (unknown fields ignored). */
+export type UpstreamChatEvent = { type: string } & Record<string, unknown>;
+
+function parseFrame(frame: string): UpstreamChatEvent | null {
+  let type = "message";
+  const dataLines: string[] = [];
+  for (const line of frame.split("\n")) {
+    if (line.startsWith(":")) continue; // SSE comment / keepalive
+    if (line.startsWith("event:")) type = line.slice(6).trim();
+    else if (line.startsWith("data:")) dataLines.push(line.slice(5).replace(/^ /, ""));
+  }
+  if (!dataLines.length) return null;
+  try {
+    const payload: unknown = JSON.parse(dataLines.join("\n"));
+    if (payload && typeof payload === "object" && !Array.isArray(payload)) {
+      return { ...(payload as Record<string, unknown>), type };
+    }
+    return { type };
+  } catch {
+    return null; // malformed frame — skip (additive/forward-compatible)
+  }
+}
+
+/** Parse an SSE byte stream (as emitted by /api/chat) into upstream events. */
+export async function* parseSseEvents(
+  body: ReadableStream<Uint8Array>,
+): AsyncGenerator<UpstreamChatEvent, void, undefined> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buf = "";
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buf += decoder.decode(value, { stream: true }).replace(/\r\n/g, "\n");
+      let idx: number;
+      while ((idx = buf.indexOf("\n\n")) !== -1) {
+        const evt = parseFrame(buf.slice(0, idx));
+        buf = buf.slice(idx + 2);
+        if (evt) yield evt;
+      }
+    }
+    buf += decoder.decode();
+    const tail = parseFrame(buf);
+    if (tail) yield tail;
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/* Event translation                                                    */
+/* ------------------------------------------------------------------ */
+
+export interface TranslateResult {
+  /** Engine emitted `final` (stream completed normally). */
+  sawFinal: boolean;
+  /** Engine emitted a terminal `error` event. */
+  errored: boolean;
+  errorMessage: string | null;
+  /** At least one copilotMessageChunk was sent. */
+  streamedText: boolean;
+}
+
+/**
+ * Translate upstream ChatStreamEvents into OpenBB copilot SSE frames.
+ *
+ *   status → copilotStatusUpdate (message as-is)
+ *   tool   → copilotStatusUpdate "Consulted: <label>" (TOOL_LABELS, deduped)
+ *   delta  → copilotMessageChunk (deLatex applied via StreamingDeLatex)
+ *   final  → flush transformer tail; emit the authoritative suffix of
+ *            final.content beyond the streamed deltas (the tool-cost line);
+ *            if no deltas arrived at all, emit final.content whole
+ *   error  → terminal; reported in the result (caller renders the message)
+ *
+ * Unknown event types are ignored (additive vocabulary). Citations and the
+ * error copy are the caller's concern.
+ */
+export async function translateChatStream(opts: {
+  events: AsyncIterable<UpstreamChatEvent>;
+  send: (event: string, data: unknown) => void;
+  toolLabels: Record<string, string>;
+  /** Called on every upstream event — the caller stops its heartbeat here. */
+  onEvent?: () => void;
+}): Promise<TranslateResult> {
+  const { events, send, toolLabels, onEvent } = opts;
+  const dl = new StreamingDeLatex();
+  const seenLabels = new Set<string>();
+  let rawDeltas = "";
+  let streamedText = false;
+  let sawFinal = false;
+  let errored = false;
+  let errorMessage: string | null = null;
+
+  const say = (delta: string) => {
+    if (!delta) return;
+    send("copilotMessageChunk", { delta });
+    streamedText = true;
+  };
+
+  for await (const ev of events) {
+    onEvent?.();
+    if (ev.type === "status") {
+      if (typeof ev.message === "string" && ev.message) {
+        send("copilotStatusUpdate", {
+          eventType: "INFO",
+          message: ev.message,
+          group: "reasoning",
+          hidden: false,
+        });
+      }
+    } else if (ev.type === "tool") {
+      if (typeof ev.name === "string" && ev.name) {
+        const label = toolLabels[ev.name] ?? ev.name;
+        if (!seenLabels.has(label)) {
+          seenLabels.add(label);
+          send("copilotStatusUpdate", {
+            eventType: "INFO",
+            message: `Consulted: ${label}`,
+            group: "reasoning",
+            hidden: false,
+          });
+        }
+      }
+    } else if (ev.type === "delta") {
+      if (typeof ev.text === "string" && ev.text) {
+        rawDeltas += ev.text;
+        say(dl.push(ev.text));
+      }
+    } else if (ev.type === "final") {
+      sawFinal = true;
+      say(dl.flush());
+      const content = typeof ev.content === "string" ? ev.content : "";
+      if (content.trim()) {
+        const base = rawDeltas.trimEnd();
+        if (!rawDeltas.trim()) {
+          // No deltas at all (unusual) — final.content is all we have.
+          say(deLatex(content));
+        } else if (base && content.startsWith(base) && content.length > base.length) {
+          // The route appends a tool-cost line to final.content that the
+          // provider deltas never carried — emit just that suffix.
+          say(deLatex(content.slice(base.length)));
+        }
+        // Otherwise final.content diverges from the streamed text in a way
+        // we can't reconcile without duplicating — keep what was streamed.
+      }
+      break; // final is terminal
+    } else if (ev.type === "error") {
+      errored = true;
+      errorMessage = typeof ev.message === "string" ? ev.message : null;
+      break; // terminal — no final follows
+    }
+    // Unknown event types: ignore (vocabulary is additive).
+  }
+
+  if (!sawFinal && !errored) {
+    // Upstream dropped mid-stream — flush whatever survived.
+    say(dl.flush());
+  }
+
+  return { sawFinal, errored, errorMessage, streamedText };
+}

--- a/app/openbb/query/route.ts
+++ b/app/openbb/query/route.ts
@@ -13,18 +13,20 @@
  * forwarding the OpenBB user's `X-API-KEY` as a Bearer token so auth, billing,
  * entitlements, and the institutional analyst doctrine are all reused unchanged.
  *
- * NOT true token-level LLM streaming: `/api/chat` (`lib/chat/agent-runner.ts`)
- * runs its multi-round tool loop as a single blocking call with no SSE mode of
- * its own, and that's shared with the main portal chat — adding real streaming
- * there is a core-engine change beyond this thin-adapter's scope, tracked as a
- * follow-up in app/openbb/README.md. What this endpoint does instead: paces
- * the already-complete answer out word-by-word over real `copilotMessageChunk`
- * events (a genuine typewriter reveal, not a fabricated one), and reports
- * `copilotStatusUpdate` reasoning steps + `copilotCitationCollection` entries
- * built from data that's actually true of the run (tools actually called,
- * dashboard context actually supplied) — no invented sources or timings.
+ * Keyed requests stream real tokens (G.23 P1): the adapter calls `/api/chat`
+ * with `Accept: text/event-stream` and translates the engine's event
+ * vocabulary (`lib/chat/stream-events.ts`) live — `status` / `tool` →
+ * `copilotStatusUpdate` ("Consulted: <label>"), `delta` →
+ * `copilotMessageChunk` (deLatex applied per-delta via a stateful buffer),
+ * `final` → `copilotCitationCollection` + close. Two paths keep the previous
+ * blocking + word-paced reveal: the keyless demo (`/api/landing/chat` has no
+ * SSE mode in P1) and a non-SSE upstream response (older deploy). Statuses and
+ * citations are built only from data that's actually true of the run (tools
+ * actually called, dashboard context actually supplied) — no invented sources
+ * or timings.
  */
 import { NextRequest } from "next/server";
+import { translateChatStream, parseSseEvents } from "../_lib/chat-stream";
 import { openbbCors } from "../_lib/cors";
 import { deLatex } from "../_lib/delatex";
 import { bearerFromRequest, upstreamBase } from "../_lib/upstream";
@@ -201,8 +203,9 @@ export async function POST(req: NextRequest) {
       // for direct API callers — unlocks the full universe via /api/chat.
       const isDemo = !key;
 
-      // Flush an early status so OpenBB starts the stream, then heartbeat while
-      // the (blocking) tool-calling agent runs so the SSE doesn't idle-timeout.
+      // Flush an early status so OpenBB starts the stream, then heartbeat
+      // until the upstream produces its first event (keyed SSE path) or the
+      // blocking call returns (demo / fallback) so the SSE doesn't idle out.
       send("copilotStatusUpdate", {
         eventType: "INFO",
         message: "Analyzing with RiskModels…",
@@ -218,22 +221,10 @@ export async function POST(req: NextRequest) {
         });
       }, 5000);
 
-      try {
-        const res = await fetch(
-          `${upstreamBase()}${isDemo ? "/landing/chat" : "/chat"}`,
-          {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-              ...(isDemo ? {} : { Authorization: `Bearer ${key}` }),
-            },
-            // No model override — /api/chat and /api/landing/chat resolve the
-            // backend themselves (Moonshot/Kimi when configured).
-            body: JSON.stringify({ messages }),
-          },
-        );
-        clearInterval(heartbeat);
-
+      // Blocking JSON response → paced word-by-word reveal. Used by the demo
+      // path (no SSE mode on /api/landing/chat in P1) and as the fallback when
+      // a keyed upstream doesn't speak SSE (older deploy).
+      const handleBlockingResponse = async (res: Response) => {
         const json = (await res.json().catch(() => ({}))) as {
           message?: { content?: string };
           error?: string;
@@ -245,7 +236,6 @@ export async function POST(req: NextRequest) {
             json?.error ||
             "Sorry — the analyst is unavailable right now. Please try again.";
           say(typeof err === "string" ? err : "Sorry — the analyst is unavailable.");
-          controller.close();
           return;
         }
 
@@ -282,9 +272,8 @@ export async function POST(req: NextRequest) {
         const content =
           typeof rawContent === "string" ? deLatex(rawContent) : rawContent;
         if (typeof content === "string" && content.trim()) {
-          // Not true token-level LLM streaming (the upstream call is
-          // blocking) — pace the complete answer out word-by-word so it
-          // reads as a live reveal rather than one dump. See file docstring.
+          // The upstream call was blocking — pace the complete answer out
+          // word-by-word so it reads as a live reveal rather than one dump.
           for (const chunk of wordChunks(content)) {
             say(chunk);
             await sleep(12);
@@ -300,6 +289,62 @@ export async function POST(req: NextRequest) {
               ? "This free demo answers fundamentals and cost-of-capital questions for any covered US ticker, and risk questions for the Magnificent 7 (AAPL, MSFT, GOOGL, AMZN, NVDA, META, TSLA). For the full universe plus portfolio hedging, get a key at riskmodels.app."
               : "I couldn't find an answer for that. Try naming a specific US ticker.",
           );
+        }
+      };
+
+      try {
+        if (isDemo) {
+          const res = await fetch(`${upstreamBase()}/landing/chat`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            // No model override — /api/landing/chat resolves the backend
+            // itself (Moonshot/Kimi when configured).
+            body: JSON.stringify({ messages }),
+          });
+          clearInterval(heartbeat);
+          await handleBlockingResponse(res);
+        } else {
+          const res = await fetch(`${upstreamBase()}/chat`, {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              // Opt into the engine's SSE mode (G.23 P1) — real token deltas.
+              Accept: "text/event-stream",
+              Authorization: `Bearer ${key}`,
+            },
+            body: JSON.stringify({ messages }),
+          });
+          const contentType = res.headers.get("content-type") ?? "";
+          if (res.ok && res.body && contentType.includes("text/event-stream")) {
+            // Keep the heartbeat until the first upstream event arrives, then
+            // let real status/delta frames carry the stream.
+            const result = await translateChatStream({
+              events: parseSseEvents(res.body),
+              send,
+              toolLabels: TOOL_LABELS,
+              onEvent: () => clearInterval(heartbeat),
+            });
+            clearInterval(heartbeat);
+            if (result.errored) {
+              say(
+                result.errorMessage ||
+                  "Sorry — the analyst is unavailable right now. Please try again.",
+              );
+            } else {
+              // Cite the dashboard widgets that actually fed this answer.
+              if (result.sawFinal && citations.length) {
+                send("copilotCitationCollection", { citations });
+              }
+              if (!result.streamedText) {
+                say("I couldn't find an answer for that. Try naming a specific US ticker.");
+              }
+            }
+          } else {
+            // Upstream doesn't speak SSE (older deploy) or returned an error —
+            // fall back to today's blocking + pacing behavior.
+            clearInterval(heartbeat);
+            await handleBlockingResponse(res);
+          }
         }
       } catch {
         clearInterval(heartbeat);

--- a/tests/openbb-chat-stream.test.ts
+++ b/tests/openbb-chat-stream.test.ts
@@ -1,0 +1,284 @@
+import { describe, expect, it } from "vitest";
+import {
+  StreamingDeLatex,
+  parseSseEvents,
+  translateChatStream,
+  type UpstreamChatEvent,
+} from "@/app/openbb/_lib/chat-stream";
+import { deLatex } from "@/app/openbb/_lib/delatex";
+
+/** Run a full string through the streaming transformer in fixed-size chunks. */
+function streamed(text: string, chunkSize: number): string {
+  const dl = new StreamingDeLatex();
+  let out = "";
+  for (let i = 0; i < text.length; i += chunkSize) {
+    out += dl.push(text.slice(i, i + chunkSize));
+  }
+  return out + dl.flush();
+}
+
+const CHUNK_SIZES = [1, 2, 3, 5, 7, 11, 1000];
+
+describe("StreamingDeLatex", () => {
+  // The blocking path applies deLatex to the whole answer; the streaming path
+  // must produce the same text no matter how the provider splits the deltas.
+  const CORPUS = [
+    "$$\\text{Cost of Equity} = R_f + \\beta \\times \\text{ERP}$$",
+    "where $R_{f}$ is the rate and $\\beta$ is sensitivity",
+    "buybacks of $12.29B versus dividends of $3.82B",
+    "EP of $146.3 billion and equity of $60B",
+    "$$\\frac{E}{D+E} \\cdot R_e$$",
+    "$\\gamma_{t}$",
+    "\\[R_d \\times (1-T)\\]",
+    "\\(R_e\\)",
+    "Cost of equity:\n\n$$R_f + \\beta \\times ERP$$\n\nwhere $\\beta$ is levered.",
+    "plain text with no math at all, just words and numbers 42",
+  ];
+
+  it("matches whole-string deLatex for every chunking of the corpus", () => {
+    for (const text of CORPUS) {
+      const expected = deLatex(text);
+      for (const size of CHUNK_SIZES) {
+        expect(streamed(text, size), `text=${JSON.stringify(text)} size=${size}`).toBe(
+          expected,
+        );
+      }
+    }
+  });
+
+  it("handles a $$ block split across deltas", () => {
+    const dl = new StreamingDeLatex();
+    let out = dl.push("The formula $$\\bet");
+    out += dl.push("a \\times ERP$$ holds.");
+    out += dl.flush();
+    expect(out).toBe("The formula `β × ERP` holds.");
+  });
+
+  it("handles inline math split across deltas", () => {
+    const dl = new StreamingDeLatex();
+    let out = dl.push("where $R_");
+    out += dl.push("{f}$ is the rate");
+    out += dl.flush();
+    expect(out).toBe("where R_f is the rate");
+  });
+
+  it("handles a \\command split across deltas inside a block", () => {
+    const dl = new StreamingDeLatex();
+    let out = dl.push("$$\\ti");
+    out += dl.push("mes 2$$");
+    out += dl.flush();
+    expect(out).toBe(deLatex("$$\\times 2$$"));
+  });
+
+  it("emits plain text incrementally, before flush", () => {
+    const dl = new StreamingDeLatex();
+    const out = dl.push("Hello world, this is a long plain sentence ");
+    expect(out).toBe("Hello world, this is a long plain sentence ");
+    expect(dl.flush()).toBe("");
+  });
+
+  it("holds an open $$ block until it closes, then emits it converted", () => {
+    const dl = new StreamingDeLatex();
+    expect(dl.push("Result: $$\\beta")).toBe("Result: ");
+    expect(dl.push(" + 1")).toBe("");
+    const out = dl.push("$$ done ");
+    expect(out).toBe("`β + 1` done ");
+  });
+
+  it("does not let a lone dollar amount stall the stream forever", () => {
+    const dl = new StreamingDeLatex();
+    let out = dl.push("costs $5 ");
+    // Inline math needs a closer within 120 chars — after that the '$' is
+    // released as plain text at the next whitespace boundary.
+    out += dl.push("word ".repeat(30));
+    expect(out.length).toBeGreaterThan(0);
+    out += dl.flush();
+    const full = "costs $5 " + "word ".repeat(30);
+    expect(out).toBe(deLatex(full));
+  });
+
+  it("flushes an unterminated math region as-is at final", () => {
+    const dl = new StreamingDeLatex();
+    expect(dl.push("truncated $$\\beta +")).toBe("truncated ");
+    expect(dl.flush()).toBe(deLatex("$$\\beta +"));
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/* SSE parsing + event translation                                      */
+/* ------------------------------------------------------------------ */
+
+function sseFrame(event: string, data: unknown): string {
+  return `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+function byteStream(text: string, chunkSize: number): ReadableStream<Uint8Array> {
+  const bytes = new TextEncoder().encode(text);
+  let i = 0;
+  return new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (i >= bytes.length) {
+        controller.close();
+        return;
+      }
+      controller.enqueue(bytes.slice(i, i + chunkSize));
+      i += chunkSize;
+    },
+  });
+}
+
+async function collect(stream: ReadableStream<Uint8Array>): Promise<UpstreamChatEvent[]> {
+  const out: UpstreamChatEvent[] = [];
+  for await (const ev of parseSseEvents(stream)) out.push(ev);
+  return out;
+}
+
+describe("parseSseEvents", () => {
+  const wire =
+    sseFrame("status", { round: 0, message: "Analyzing request" }) +
+    ": keepalive comment\n\n" +
+    sseFrame("delta", { text: "hello " }) +
+    sseFrame("final", { content: "hello world", usage: { total_tokens: 3 } });
+
+  it("parses frames regardless of byte-chunk boundaries", async () => {
+    for (const size of [1, 3, 7, 4096]) {
+      const events = await collect(byteStream(wire, size));
+      expect(events.map((e) => e.type)).toEqual(["status", "delta", "final"]);
+      expect(events[0].message).toBe("Analyzing request");
+      expect(events[1].text).toBe("hello ");
+      expect(events[2].content).toBe("hello world");
+    }
+  });
+
+  it("skips malformed data frames instead of throwing", async () => {
+    const events = await collect(
+      byteStream("event: delta\ndata: {not json\n\n" + sseFrame("delta", { text: "x " }), 5),
+    );
+    expect(events.map((e) => e.type)).toEqual(["delta"]);
+  });
+});
+
+describe("translateChatStream", () => {
+  const TOOL_LABELS = { get_risk_metrics: "risk metrics" };
+
+  type Frame = { event: string; data: unknown };
+
+  async function run(wire: string) {
+    const frames: Frame[] = [];
+    let heartbeats = 0;
+    const result = await translateChatStream({
+      events: parseSseEvents(byteStream(wire, 9)),
+      send: (event, data) => frames.push({ event, data }),
+      toolLabels: TOOL_LABELS,
+      onEvent: () => {
+        heartbeats += 1;
+      },
+    });
+    const text = frames
+      .filter((f) => f.event === "copilotMessageChunk")
+      .map((f) => (f.data as { delta: string }).delta)
+      .join("");
+    const statuses = frames
+      .filter((f) => f.event === "copilotStatusUpdate")
+      .map((f) => (f.data as { message: string }).message);
+    return { frames, text, statuses, result, heartbeats };
+  }
+
+  it("translates status/tool/delta/final into copilot frames with real tokens", async () => {
+    const answer = "AAPL cost of equity is $$R_f + \\beta \\times ERP$$ per CAPM.";
+    const costLine = "\n\n---\n**API tool costs:** $0.0100 (1 tool call)";
+    const wire =
+      sseFrame("status", { round: 0, message: "Analyzing request" }) +
+      sseFrame("status", { round: 0, message: "Running get_risk_metrics" }) +
+      sseFrame("tool", { name: "get_risk_metrics", latency_ms: 420 }) +
+      sseFrame("tool", { name: "get_risk_metrics", latency_ms: 100 }) + // dedup
+      sseFrame("tool", { name: "get_unknown_tool", latency_ms: 5 }) + // raw-name fallback
+      sseFrame("status", { round: 1, message: "Composing response" }) +
+      sseFrame("delta", { text: "AAPL cost of equity is " }) +
+      sseFrame("delta", { text: "$$R_f + \\beta \\times" }) +
+      sseFrame("delta", { text: " ERP$$ per CAPM." }) +
+      sseFrame("final", {
+        content: answer + costLine,
+        tool_calls_summary: [],
+        usage: { prompt_tokens: 1, completion_tokens: 2, total_tokens: 3 },
+        quota: null,
+        persisted_id: null,
+      });
+
+    const { text, statuses, result, heartbeats } = await run(wire);
+
+    expect(statuses).toEqual([
+      "Analyzing request",
+      "Running get_risk_metrics",
+      "Consulted: risk metrics",
+      "Consulted: get_unknown_tool",
+      "Composing response",
+    ]);
+    // Streamed tokens + the final-only cost-line suffix, deLatex'd — identical
+    // to what the blocking path would have rendered from final.content.
+    expect(text).toBe(deLatex(answer + costLine));
+    expect(result).toEqual({
+      sawFinal: true,
+      errored: false,
+      errorMessage: null,
+      streamedText: true,
+    });
+    expect(heartbeats).toBeGreaterThanOrEqual(10);
+  });
+
+  it("emits final.content whole when no deltas arrived", async () => {
+    const wire =
+      sseFrame("status", { round: 0, message: "Analyzing request" }) +
+      sseFrame("final", {
+        content: "Answer with $\\beta$ inline.",
+        tool_calls_summary: null,
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+        quota: null,
+        persisted_id: null,
+      });
+    const { text, result } = await run(wire);
+    expect(text).toBe("Answer with β inline.");
+    expect(result.sawFinal).toBe(true);
+    expect(result.streamedText).toBe(true);
+  });
+
+  it("reports terminal error events without emitting error text itself", async () => {
+    const wire =
+      sseFrame("delta", { text: "partial answer " }) +
+      sseFrame("error", { status: 502, message: "upstream exploded" });
+    const { text, result } = await run(wire);
+    expect(text).toBe("partial answer ");
+    expect(result).toEqual({
+      sawFinal: false,
+      errored: true,
+      errorMessage: "upstream exploded",
+      streamedText: true,
+    });
+  });
+
+  it("flushes buffered text when the stream drops before final", async () => {
+    const wire =
+      sseFrame("delta", { text: "the answer is $$\\beta" }) +
+      sseFrame("delta", { text: " + 1$$" });
+    const { text, result } = await run(wire);
+    expect(text).toBe("the answer is `β + 1`");
+    expect(result.sawFinal).toBe(false);
+    expect(result.errored).toBe(false);
+  });
+
+  it("ignores unknown event types (additive vocabulary)", async () => {
+    const wire =
+      sseFrame("telemetry", { anything: true }) +
+      sseFrame("delta", { text: "hello world " }) +
+      sseFrame("final", {
+        content: "hello world",
+        tool_calls_summary: null,
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+        quota: null,
+        persisted_id: null,
+      });
+    const { text, result } = await run(wire);
+    expect(text).toBe("hello world ");
+    expect(result.sawFinal).toBe(true);
+  });
+});


### PR DESCRIPTION
Agent-built, orchestrator-reviewed. Consumer #2 of the streaming design (engine merged in #243).

Keyed copilot queries now consume `/api/chat`'s SSE: `status`/`tool` → `copilotStatusUpdate` (existing "Consulted:" labels, deduped), `delta` → real `copilotMessageChunk` tokens through a **streaming deLatex** (safe-cut at whitespace boundaries; `$$` regions held until closed with the same char bounds as the batch transform; a lone dollar amount can delay ≤120 chars, never stall), `final` → authoritative tail + citations. Word-pacing loop retired on this path. Fallback to today's blocking+paced behavior on any non-SSE response; keyless demo path byte-identical; heartbeat semantics preserved.

typecheck clean; vitest **502/502** (15 new: streaming-vs-batch deLatex equivalence over 10 strings × 7 chunk sizes incl. all existing delatex cases, split-region variants, no-stall property, SSE parsing at arbitrary byte boundaries, full mock-upstream translation incl. tool dedupe/error/drop). Post-deploy check: ask the OpenBB copilot a keyed question — status lines then live tokens, no LaTeX residue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)