### PR TITLE
feat(13f): snapshot/holdings routes accept composite entity ids

### DIFF
--- a/OPENAPI_SPEC.yaml
+++ b/OPENAPI_SPEC.yaml
@@ -9639,6 +9639,10 @@ paths:
           required: true
           schema:
             type: string
+          description: >
+            Canonical filer id (BW-FILER-CIK{cik}). Composite entities
+            (BW-SYNTH-*) are served by the same route; registry-only fields
+            (cik, filer_type, aum_tier) return null.
         - name: limit
           in: query
           required: false
@@ -9834,6 +9838,12 @@ paths:
           required: true
           schema:
             type: string
+          description: >
+            Canonical filer id (BW-FILER-CIK{cik}). Composite entities
+            (BW-SYNTH-*) are served by the same route; the snapshot adds
+            entity_kind: synthetic_composite, evidence_class: reconstructed,
+            recipe, and composition coverage; registry-only fields return
+            null.
       responses:
         "200":
           description: Composed FilerSnapshot.

--- a/app/api/13f/filers/[bw_filer_id]/holdings/route.ts
+++ b/app/api/13f/filers/[bw_filer_id]/holdings/route.ts
@@ -1,7 +1,12 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { withBilling, type BillingContext } from "@/lib/agent/billing-middleware";
-import { fetchFiler } from "@/lib/dal/filers-engine";
-import { readFilerHoldingsTopN } from "@/lib/dal/funds-zarr-reader";
+import { fetchFiler, type FilerRow } from "@/lib/dal/filers-engine";
+import {
+  isSyntheticEntityId,
+  readFilerHoldingsTopN,
+  readSyntheticEntityMeta,
+  type SyntheticEntityMeta,
+} from "@/lib/dal/funds-zarr-reader";
 import { enrichFilerHoldingsWithL3 } from "@/lib/13f/enrich-filer-holdings";
 
 export const dynamic = "force-dynamic";
@@ -29,6 +34,9 @@ const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
  * X-Data-Filing-Date headers.
  *
  * Default `limit = 25`; caller can request up to 1000.
+ *
+ * Composite entities (BW-SYNTH-*) are served by the same route; registry-only
+ * fields (cik, filer_type, aum_tier) return null.
  */
 export const GET = withBilling(
   async (request: NextRequest, _context: BillingContext) => {
@@ -62,9 +70,21 @@ export const GET = withBilling(
       );
     }
 
-    const filer = await fetchFiler(bwFilerId);
-    if (!filer) {
-      return NextResponse.json({ error: "Filer not found" }, { status: 404 });
+    // Synthetic composite entities (BW-SYNTH-*) are served by the same
+    // route: no registry row, entity resolves from its zarr attrs.
+    const synthetic = isSyntheticEntityId(bwFilerId);
+    let filer: FilerRow | null = null;
+    let synthMeta: SyntheticEntityMeta | null = null;
+    if (synthetic) {
+      synthMeta = await readSyntheticEntityMeta(bwFilerId);
+      if (!synthMeta) {
+        return NextResponse.json({ error: "Entity not found" }, { status: 404 });
+      }
+    } else {
+      filer = await fetchFiler(bwFilerId);
+      if (!filer) {
+        return NextResponse.json({ error: "Filer not found" }, { status: 404 });
+      }
     }
 
     const snapshot = await enrichFilerHoldingsWithL3(
@@ -86,17 +106,23 @@ export const GET = withBilling(
     const headers = new Headers({ "X-Data-As-Of": snapshot.teo });
     if (snapshot.filing_date) {
       headers.set("X-Data-Filing-Date", snapshot.filing_date);
-    } else if (filer.latest_filing_date) {
+    } else if (filer?.latest_filing_date) {
       headers.set("X-Data-Filing-Date", filer.latest_filing_date);
     }
 
     return NextResponse.json(
       {
         bw_filer_id: bwFilerId,
-        cik: filer.cik,
-        name: filer.name,
-        filer_type: filer.filer_type,
-        aum_tier: filer.aum_tier,
+        ...(synthetic
+          ? {
+              entity_kind: "synthetic_composite" as const,
+              evidence_class: "reconstructed" as const,
+            }
+          : {}),
+        cik: filer?.cik ?? null,
+        name: synthetic ? synthMeta!.name : (filer?.name ?? null),
+        filer_type: filer?.filer_type ?? null,
+        aum_tier: filer?.aum_tier ?? null,
         ...(asOf ? { as_of: asOf } : {}),
         ...snapshot,
       },

--- a/app/api/13f/filers/[bw_filer_id]/snapshot/route.ts
+++ b/app/api/13f/filers/[bw_filer_id]/snapshot/route.ts
@@ -16,6 +16,10 @@ export const dynamic = "force-dynamic";
  * ratios are Phase 3 (D.8.10) and not present today.
  *
  * All sub-fetches run in parallel inside loadFilerSnapshot.
+ *
+ * Composite entities (BW-SYNTH-*) are served by the same route; registry-only
+ * fields return null and the snapshot adds entity_kind/evidence_class/recipe
+ * plus composition coverage.
  */
 export const GET = withBilling(
   async (request: NextRequest, _context: BillingContext) => {

--- a/lib/13f/filer-snapshot-composer.ts
+++ b/lib/13f/filer-snapshot-composer.ts
@@ -26,6 +26,7 @@ import type {
   FilerPortfolioRow,
   FilerReturnsDecomposition,
   FundHedgeSnapshot,
+  SyntheticEntityMeta,
 } from "@/lib/dal/funds-zarr-reader";
 import {
   formatFilerMetrics,
@@ -51,6 +52,12 @@ export interface FilerSnapshotPrimitives {
   returnsDecomposition: FilerReturnsDecomposition | null;
   /** Latest hedge legs when ``ds_hr.zarr`` exists (Phase 3). */
   hedgeSleeve: FundHedgeSnapshot | null;
+  /**
+   * Present only for synthetic composite entities (BW-SYNTH-*). Switches
+   * `entity_kind`, adds `evidence_class`/`recipe`, and merges composition
+   * coverage into the `coverage` block. Registry-only fields stay null.
+   */
+  synthetic?: SyntheticEntityMeta | null;
 }
 
 export interface FilerCohortRankEntry {
@@ -65,7 +72,11 @@ export interface FilerCohortRankEntry {
 
 export interface FilerSnapshot {
   /** Discriminator so renderers can branch off this rather than route shape. */
-  entity_kind: "13f_filer";
+  entity_kind: "13f_filer" | "synthetic_composite";
+  /** Synthetic composites only: holdings are reconstructed from a recipe, not filed. */
+  evidence_class?: "reconstructed";
+  /** Synthetic composites only: the self-describing composition spec (zarr attrs). */
+  recipe?: Record<string, unknown> | null;
   bw_filer_id: string;
   cik: string | null;
   name: string | null;
@@ -108,6 +119,11 @@ export interface FilerSnapshot {
     aum_in_erm3: number | null;
     n_holdings_in_erm3: number | null;
     effective_n_in_erm3: number | null;
+    /** Synthetic composites only: recipe-composition coverage at the latest teo. */
+    mapped_weight_frac?: number | null;
+    child_coverage?: number | null;
+    effective_coverage?: number | null;
+    n_children?: number | null;
   };
   /**
    * Filer modelability gate result. A filer can have low coverage_in_erm3
@@ -149,6 +165,7 @@ export function composeFilerSnapshot(
     returnsDecomposition,
     hedgeSleeve,
   } = p;
+  const synthetic = p.synthetic ?? null;
 
   const trimmed = trimToLookbackMonths(portfolioHistory, FILER_LOOKBACK_MONTHS);
 
@@ -180,7 +197,10 @@ export function composeFilerSnapshot(
       : null;
 
   return {
-    entity_kind: "13f_filer",
+    entity_kind: synthetic ? "synthetic_composite" : "13f_filer",
+    ...(synthetic
+      ? { evidence_class: "reconstructed" as const, recipe: synthetic.recipe }
+      : {}),
     bw_filer_id: filer.bw_filer_id,
     cik: filer.cik,
     name: filer.name,
@@ -208,6 +228,7 @@ export function composeFilerSnapshot(
       aum_in_erm3: latest?.aum_in_erm3 ?? null,
       n_holdings_in_erm3: latest?.n_holdings_in_erm3 ?? null,
       effective_n_in_erm3: latest?.effective_n_in_erm3 ?? null,
+      ...(synthetic ? synthetic.coverage : {}),
     },
     is_modelable: latest?.is_modelable ?? null,
     cohort_context: ranks.length > 0

--- a/lib/13f/filer-snapshot-loader.ts
+++ b/lib/13f/filer-snapshot-loader.ts
@@ -9,12 +9,15 @@
 import {
   fetchFilerRanks,
   resolveFilerById,
+  type FilerRow,
 } from "@/lib/dal/filers-engine";
 import {
+  isSyntheticEntityId,
   readFilerHoldingsTopN,
   readFilerPortfolioSeries,
   readFilerReturnsDecomposition,
   readFilerHedgeLatest,
+  readSyntheticEntityMeta,
 } from "@/lib/dal/funds-zarr-reader";
 import {
   composeFilerSnapshot,
@@ -38,6 +41,11 @@ export type LoadFilerSnapshotResult =
 export async function loadFilerSnapshot(
   bwFilerId: string,
 ): Promise<LoadFilerSnapshotResult> {
+  // Synthetic composite entities (BW-SYNTH-*) are served by the same route.
+  // They have no registry row — the zarr attrs are self-describing.
+  if (isSyntheticEntityId(bwFilerId)) {
+    return loadSyntheticCompositeSnapshot(bwFilerId);
+  }
   const resolved = await resolveFilerById(bwFilerId);
   if (!resolved) {
     return { ok: false, status: 404, error: "Filer not found" };
@@ -49,15 +57,7 @@ export async function loadFilerSnapshot(
   // rather than 404. This matches the schema-ready-but-empty state of the
   // table during Phase 1 ramp-up.
   const referenceDate = latest?.report_date ?? filer.latest_report_date ?? null;
-  let startDate: string | undefined = undefined;
-  if (referenceDate) {
-    const ref = new Date(`${referenceDate}T12:00:00Z`);
-    const startWindow = new Date(ref);
-    startWindow.setUTCMonth(
-      startWindow.getUTCMonth() - FILER_LOOKBACK_MONTHS - 1,
-    );
-    startDate = startWindow.toISOString().slice(0, 10);
-  }
+  const startDate = lookbackStartDate(referenceDate);
 
   const [holdingsRaw, portfolioHistory, cohortRanks, returnsDec, hedgeSleeve] =
     await Promise.all([
@@ -92,5 +92,89 @@ export async function loadFilerSnapshot(
     reportDate: latest?.report_date ?? filer.latest_report_date ?? null,
     filingDate: latest?.filing_date ?? filer.latest_filing_date ?? null,
     modelVersion: latest?.model_version ?? null,
+  };
+}
+
+function lookbackStartDate(referenceDate: string | null): string | undefined {
+  if (!referenceDate) return undefined;
+  const startWindow = new Date(`${referenceDate}T12:00:00Z`);
+  startWindow.setUTCMonth(startWindow.getUTCMonth() - FILER_LOOKBACK_MONTHS - 1);
+  return startWindow.toISOString().slice(0, 10);
+}
+
+/**
+ * Snapshot for a synthetic composite entity. Same composed shape; the
+ * entity resolves from its zarr (attrs + coverage vars) instead of the
+ * registry, so registry-only fields (cik, filer_type, aum_tier, cohort
+ * ranks) are null/empty. Additive fields: `entity_kind:
+ * "synthetic_composite"`, `evidence_class: "reconstructed"`, `recipe`, and
+ * composition coverage merged into `coverage`.
+ */
+async function loadSyntheticCompositeSnapshot(
+  bwSynthId: string,
+): Promise<LoadFilerSnapshotResult> {
+  const meta = await readSyntheticEntityMeta(bwSynthId);
+  if (!meta) {
+    return { ok: false, status: 404, error: "Entity not found" };
+  }
+
+  const referenceDate = meta.teo;
+  const startDate = lookbackStartDate(referenceDate);
+
+  const [holdingsRaw, portfolioHistory, returnsDec, hedgeSleeve] =
+    await Promise.all([
+      readFilerHoldingsTopN(bwSynthId, HOLDINGS_TOP_N),
+      readFilerPortfolioSeries(bwSynthId, {
+        startDate,
+        endDate: referenceDate,
+      }),
+      readFilerReturnsDecomposition(bwSynthId, {
+        startDate,
+        endDate: referenceDate,
+      }),
+      readFilerHedgeLatest(bwSynthId),
+    ]);
+
+  const holdings = await enrichFilerHoldingsWithL3(holdingsRaw);
+
+  const filer: FilerRow = {
+    bw_filer_id: bwSynthId,
+    cik: null,
+    lei: null,
+    name: meta.name,
+    filer_type: null,
+    filer_subtype: null,
+    country: null,
+    status: null,
+    style_label: null,
+    factset_entity_id: null,
+    latest_report_date: meta.teo,
+    latest_filing_date: null,
+    latest_extracted_at: null,
+    latest_aum_usd: null,
+    aum_tier: null,
+    latest_n_holdings: null,
+    last_in_eligible_universe_at: null,
+    n_funds_managed: null,
+    metadata: null,
+  };
+
+  const snapshot = composeFilerSnapshot({
+    filer,
+    latest: null,
+    holdings,
+    portfolioHistory,
+    cohortRanks: [],
+    returnsDecomposition: returnsDec,
+    hedgeSleeve,
+    synthetic: meta,
+  });
+
+  return {
+    ok: true,
+    snapshot,
+    reportDate: meta.teo,
+    filingDate: null,
+    modelVersion: null,
   };
 }

--- a/lib/13f/filer-snapshot-loader.ts
+++ b/lib/13f/filer-snapshot-loader.ts
@@ -147,7 +147,7 @@ async function loadSyntheticCompositeSnapshot(
     country: null,
     status: null,
     style_label: null,
-    factset_entity_id: null,
+    factset_entity_id: null, // licensed-id-ok: hardcoded null for synthetic entities — field name only, no licensed value ever present
     latest_report_date: meta.teo,
     latest_filing_date: null,
     latest_extracted_at: null,

--- a/lib/agent/capabilities.ts
+++ b/lib/agent/capabilities.ts
@@ -2386,7 +2386,8 @@ export const CAPABILITIES: Capability[] = [
         type: "string",
         required: true,
         description:
-          "Funds_DAG canonical filer id (format: BW-FILER-CIK{cik}).",
+          "Funds_DAG canonical filer id (format: BW-FILER-CIK{cik}). " +
+          "Composite entities (BW-SYNTH-*) are served by the same route.",
       },
       limit: {
         type: "integer",
@@ -2525,7 +2526,8 @@ export const CAPABILITIES: Capability[] = [
         type: "string",
         required: true,
         description:
-          "Funds_DAG canonical filer id (format: BW-FILER-CIK{cik}).",
+          "Funds_DAG canonical filer id (format: BW-FILER-CIK{cik}). " +
+          "Composite entities (BW-SYNTH-*) are served by the same route.",
       },
     },
     pricing: {

--- a/lib/dal/funds-zarr-reader.ts
+++ b/lib/dal/funds-zarr-reader.ts
@@ -4,6 +4,7 @@
  * Per-entity stores live at:
  *   gs://{bucket}/{basePath}/bw_fund_id/{BW-FUND-...}/{ds_portfolio,ds_ph,ds_hr,ds_nav}.zarr
  *   gs://{bucket}/{basePath}/bw_filer_id/{BW-FILER-CIK...}/{ds_portfolio,ds_ph}.zarr
+ *   gs://{bucket}/{basePath}/bw_synth_id/{BW-SYNTH-...}/{ds_portfolio,ds_ph}.zarr
  *
  * Default GCS prefix is `rm_api_data/ERM3_Funds` (env override:
  * `ZARR_FUNDS_GCS_PREFIX`). The bucket is shared with the stocks-side
@@ -25,6 +26,7 @@
  * stocks-side module stays untouched.
  */
 
+import { readFile } from "node:fs/promises";
 import { Storage, type Bucket } from "@google-cloud/storage";
 import {
   get,
@@ -156,6 +158,28 @@ class GcsZarrStore {
   }
 }
 
+/**
+ * Local filesystem mirror of the funds zarr tree (dev/tests only). When
+ * `ZARR_FUNDS_LOCAL_ROOT` is set, all reads in this module resolve against
+ * `${root}/${relativePath}` instead of GCS. Unset in production.
+ */
+class FsZarrStore {
+  constructor(private readonly rootDir: string) {}
+
+  async get(key: AbsolutePath): Promise<Uint8Array | undefined> {
+    const rel = key.startsWith("/") ? key.slice(1) : key;
+    try {
+      const buf = await readFile(`${this.rootDir}/${rel}`);
+      return new Uint8Array(buf);
+    } catch (e: unknown) {
+      const err = e as { code?: string };
+      if (err?.code === "ENOENT" || err?.code === "EISDIR") return undefined;
+      console.error("[funds-zarr] local read failed");
+      throw new Error("Zarr read failed");
+    }
+  }
+}
+
 function parseFundsZarrPrefix(): { bucket: string; basePath: string } {
   const raw = (process.env.ZARR_FUNDS_GCS_PREFIX ?? "rm_api_data/ERM3_Funds").trim();
   const i = raw.indexOf("/");
@@ -166,13 +190,18 @@ function parseFundsZarrPrefix(): { bucket: string; basePath: string } {
 async function openZarrGroupAt(
   relativePath: string,
 ): Promise<Group<Readable> | null> {
-  const { bucket: bucketName, basePath } = parseFundsZarrPrefix();
-  const fullPrefix = `${basePath}/${relativePath}`
-    .replace(/\/+/g, "/")
-    .replace(/^\//, "");
   try {
-    const bucket = getGcs().bucket(bucketName);
-    const raw = new GcsZarrStore(bucket, fullPrefix);
+    let raw: FsZarrStore | GcsZarrStore;
+    const localRoot = process.env.ZARR_FUNDS_LOCAL_ROOT?.trim();
+    if (localRoot) {
+      raw = new FsZarrStore(`${localRoot}/${relativePath}`.replace(/\/+/g, "/"));
+    } else {
+      const { bucket: bucketName, basePath } = parseFundsZarrPrefix();
+      const fullPrefix = `${basePath}/${relativePath}`
+        .replace(/\/+/g, "/")
+        .replace(/^\//, "");
+      raw = new GcsZarrStore(getGcs().bucket(bucketName), fullPrefix);
+    }
     const consolidated = await tryWithConsolidated(raw);
     const store = consolidated as unknown as Readable;
     return (await open.v2(root(store), { kind: "group" })) as Group<Readable>;
@@ -189,11 +218,21 @@ async function openFundZarrGroup(
   return openZarrGroupAt(`bw_fund_id/${bwFundId}/${basename}`);
 }
 
+/**
+ * Synthetic composite entities (`BW-SYNTH-*`) live under `bw_synth_id/` with
+ * the same per-entity dataset schemas as filers. The filer readers below are
+ * polymorphic over both families via this id-prefix dispatch.
+ */
+export function isSyntheticEntityId(id: string): boolean {
+  return id.startsWith("BW-SYNTH-");
+}
+
 async function openFilerZarrGroup(
   bwFilerId: string,
   basename: string,
 ): Promise<Group<Readable> | null> {
-  return openZarrGroupAt(`bw_filer_id/${bwFilerId}/${basename}`);
+  const family = isSyntheticEntityId(bwFilerId) ? "bw_synth_id" : "bw_filer_id";
+  return openZarrGroupAt(`${family}/${bwFilerId}/${basename}`);
 }
 
 /** Per-cell stores: portfolio_style/{Cell_Name}/... and equity_style_9box/{Cell_Name}/... */
@@ -1779,6 +1818,110 @@ async function computeFilerHedgeLatest(
     return null;
   }
   return out;
+}
+
+// ---------------------------------------------------------------------------
+// Synthetic composite entities — bw_synth_id/{BW-SYNTH-*}/ds_ph.zarr
+//
+// Same holdings schema as filers (coords symbol = bw_sym_id, teo; data_var
+// adj_mv) plus self-describing group attrs (recipe JSON, recipe_hash,
+// weight_basis, ontology_version, layer_depth) and per-teo composition
+// coverage vars. No registry row exists — the zarr is the source of truth.
+// ---------------------------------------------------------------------------
+
+/** Composition coverage at one teo — how much of the recipe is materialized. */
+export interface SyntheticEntityCoverage {
+  mapped_weight_frac: number | null;
+  child_coverage: number | null;
+  effective_coverage: number | null;
+  n_children: number | null;
+}
+
+export interface SyntheticEntityMeta {
+  /** Latest teo in the holdings panel (YYYY-MM-DD). */
+  teo: string;
+  /** Display handle from the zarr attrs (`plan_id`). */
+  name: string | null;
+  /** Parsed `recipe` attr — self-describing composition spec. */
+  recipe: Record<string, unknown> | null;
+  recipe_hash: string | null;
+  weight_basis: string | null;
+  ontology_version: string | null;
+  layer_depth: number | null;
+  /** Coverage vars at the latest teo. */
+  coverage: SyntheticEntityCoverage;
+}
+
+/**
+ * Entity metadata for a synthetic composite, read from its `ds_ph.zarr`
+ * group attrs + latest-teo coverage vars. Null when the id is not a
+ * synthetic id or the store is missing/empty.
+ */
+export async function readSyntheticEntityMeta(
+  bwSynthId: string,
+): Promise<SyntheticEntityMeta | null> {
+  if (!isSyntheticEntityId(bwSynthId)) return null;
+  const ck = generateCacheKey("funds_zarr", "synth_entity_meta", {
+    id: bwSynthId,
+  });
+  return withZarrCache(ck, () => computeSyntheticEntityMeta(bwSynthId), {
+    emptyValue: null,
+  });
+}
+
+async function computeSyntheticEntityMeta(
+  bwSynthId: string,
+): Promise<SyntheticEntityMeta | null> {
+  const grp = await openFilerZarrGroup(bwSynthId, "ds_ph.zarr");
+  if (!grp) return null;
+
+  const teos = await readTeoStrings(grp);
+  if (!teos || teos.length === 0) return null;
+  const teoIdx = teos.length - 1;
+
+  const attrs = (grp.attrs ?? {}) as Record<string, unknown>;
+  const str = (k: string): string | null =>
+    typeof attrs[k] === "string" ? (attrs[k] as string) : null;
+  const num = (k: string): number | null =>
+    typeof attrs[k] === "number" && Number.isFinite(attrs[k] as number)
+      ? (attrs[k] as number)
+      : null;
+
+  let recipe: Record<string, unknown> | null = null;
+  const rawRecipe = str("recipe");
+  if (rawRecipe) {
+    try {
+      const parsed: unknown = JSON.parse(rawRecipe);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        recipe = parsed as Record<string, unknown>;
+      }
+    } catch {
+      // malformed recipe attr → surface null rather than fail the read
+    }
+  }
+
+  const [mapped, child, effective, nChildren] = await Promise.all([
+    readFloatSlice1d(grp, "mapped_weight_frac", teoIdx, teoIdx + 1),
+    readFloatSlice1d(grp, "child_coverage", teoIdx, teoIdx + 1),
+    readFloatSlice1d(grp, "effective_coverage", teoIdx, teoIdx + 1),
+    readFloatSlice1d(grp, "n_children", teoIdx, teoIdx + 1),
+  ]);
+
+  return {
+    teo: teos[teoIdx]!,
+    name: str("plan_id"),
+    recipe,
+    recipe_hash: str("recipe_hash"),
+    weight_basis: str("weight_basis"),
+    ontology_version: str("ontology_version"),
+    layer_depth: num("layer_depth"),
+    coverage: {
+      mapped_weight_frac: mapped?.[0] ?? null,
+      child_coverage: child?.[0] ?? null,
+      effective_coverage: effective?.[0] ?? null,
+      n_children: nChildren?.[0] ?? null,
+    },
+  };
 }
 
 // ===========================================================================

--- a/lib/mcp/tools/riskmodels-tools.ts
+++ b/lib/mcp/tools/riskmodels-tools.ts
@@ -791,9 +791,9 @@ export function registerRiskModelsTools(
       title: "RiskModels 13F Filer Snapshot",
       annotations: { readOnlyHint: true },
       description:
-        "Composed JSON snapshot for one 13F filer (GET /13f/filers/{bw_filer_id}/snapshot): registry + latest metrics + concentration. Resolve bw_filer_id via riskmodels_search_filers first.",
+        "Composed JSON snapshot for one 13F filer (GET /13f/filers/{bw_filer_id}/snapshot): registry + latest metrics + concentration. Resolve bw_filer_id via riskmodels_search_filers first. Composite entities (BW-SYNTH-*) are served by the same route.",
       inputSchema: {
-        bw_filer_id: z.string().min(1).describe("Filer id from riskmodels_search_filers"),
+        bw_filer_id: z.string().min(1).describe("Filer id from riskmodels_search_filers, or a composite entity id (BW-SYNTH-*)"),
       },
     },
     async ({ bw_filer_id }) => {
@@ -813,9 +813,9 @@ export function registerRiskModelsTools(
       title: "RiskModels 13F Filer Holdings",
       annotations: { readOnlyHint: true },
       description:
-        "Top-N current holdings of a 13F filer (GET /13f/filers/{bw_filer_id}/holdings). Resolve bw_filer_id via riskmodels_search_filers first.",
+        "Top-N current holdings of a 13F filer (GET /13f/filers/{bw_filer_id}/holdings). Resolve bw_filer_id via riskmodels_search_filers first. Composite entities (BW-SYNTH-*) are served by the same route.",
       inputSchema: {
-        bw_filer_id: z.string().min(1).describe("Filer id from riskmodels_search_filers"),
+        bw_filer_id: z.string().min(1).describe("Filer id from riskmodels_search_filers, or a composite entity id (BW-SYNTH-*)"),
         top: z.number().int().min(1).max(200).optional().describe("Number of holdings (default 25)"),
       },
     },

--- a/tests/filer-bitemporal-routes.test.ts
+++ b/tests/filer-bitemporal-routes.test.ts
@@ -10,6 +10,8 @@ vi.mock("@/lib/dal/filers-engine", () => ({
 }));
 
 vi.mock("@/lib/dal/funds-zarr-reader", () => ({
+  isSyntheticEntityId: (id: string) => id.startsWith("BW-SYNTH-"),
+  readSyntheticEntityMeta: vi.fn(),
   readFilerHoldingsTopN: vi.fn(),
   readFilerPortfolioSeries: vi.fn(),
 }));

--- a/tests/synthetic-entity-local-zarr.test.ts
+++ b/tests/synthetic-entity-local-zarr.test.ts
@@ -1,0 +1,104 @@
+import { existsSync } from "node:fs";
+import { describe, expect, it, vi } from "vitest";
+
+/**
+ * Local-zarr integration test for synthetic composite entities. Opt-in
+ * (requires a local mirror of the funds zarr tree and a materialized
+ * composite):
+ *
+ *   ZARR_FUNDS_LOCAL_ROOT=/path/to/zarr \
+ *   SYNTH_ZARR_TEST_ID=BW-SYNTH-xxxxxxxx-slug \
+ *   npx vitest run tests/synthetic-entity-local-zarr.test.ts
+ *
+ * Reads the real per-entity store (no fixtures). Supabase-backed
+ * enrichment/scrub is identity-mocked so the test exercises the zarr
+ * adapter offline.
+ */
+
+vi.mock("@/lib/dal/symbols-batch", () => ({
+  applyScrubToHoldings: vi.fn(async (h: unknown) => h),
+  applyScrubToFilerHoldings: vi.fn(async (h: unknown) => h),
+}));
+
+vi.mock("@/lib/13f/enrich-filer-holdings", () => ({
+  enrichFilerHoldingsWithL3: vi.fn(async (snap: unknown) => snap),
+}));
+
+import {
+  readFilerHoldingsTopN,
+  readFilerPortfolioSeries,
+  readSyntheticEntityMeta,
+} from "@/lib/dal/funds-zarr-reader";
+import { loadFilerSnapshot } from "@/lib/13f/filer-snapshot-loader";
+
+const ROOT = process.env.ZARR_FUNDS_LOCAL_ROOT?.trim();
+const SYNTH_ID = process.env.SYNTH_ZARR_TEST_ID?.trim();
+const AVAILABLE =
+  !!ROOT &&
+  !!SYNTH_ID &&
+  existsSync(`${ROOT}/bw_synth_id/${SYNTH_ID}/ds_ph.zarr/.zgroup`);
+
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+
+describe.skipIf(!AVAILABLE)("synthetic composite — local zarr", () => {
+  it("reads self-describing entity meta from ds_ph.zarr attrs", async () => {
+    const meta = await readSyntheticEntityMeta(SYNTH_ID!);
+    expect(meta).not.toBeNull();
+    expect(meta!.teo).toMatch(ISO_DATE);
+    expect(meta!.recipe).not.toBeNull();
+    expect(typeof meta!.recipe).toBe("object");
+    expect(meta!.recipe_hash).toBeTruthy();
+    // recipe_hash is the hash8 component of the id
+    expect(SYNTH_ID).toContain(meta!.recipe_hash!);
+    expect(meta!.weight_basis).toBeTruthy();
+    expect(meta!.ontology_version).toBeTruthy();
+    const cov = meta!.coverage;
+    expect(cov.effective_coverage).toBeGreaterThan(0);
+    expect(cov.effective_coverage).toBeLessThanOrEqual(1);
+    expect(cov.mapped_weight_frac).toBeGreaterThan(0);
+    expect(cov.n_children).toBeGreaterThanOrEqual(1);
+  });
+
+  it("serves top-N holdings by adj_mv through the shared filer reader", async () => {
+    const snap = await readFilerHoldingsTopN(SYNTH_ID!, 10);
+    expect(snap).not.toBeNull();
+    expect(snap!.teo).toMatch(ISO_DATE);
+    expect(snap!.holdings.length).toBeGreaterThan(0);
+    expect(snap!.holdings.length).toBeLessThanOrEqual(10);
+    for (let i = 1; i < snap!.holdings.length; i++) {
+      expect(snap!.holdings[i - 1]!.adj_mv).toBeGreaterThanOrEqual(
+        snap!.holdings[i]!.adj_mv,
+      );
+    }
+    for (const h of snap!.holdings) {
+      expect(h.adj_mv).toBeGreaterThan(0);
+      expect(h.security_id).toBeTruthy();
+      expect(h.weight).toBeGreaterThan(0);
+    }
+  });
+
+  it("serves the portfolio series through the shared filer reader", async () => {
+    const rows = await readFilerPortfolioSeries(SYNTH_ID!);
+    expect(rows.length).toBeGreaterThan(0);
+    for (const row of rows) {
+      expect(row.teo).toMatch(ISO_DATE);
+    }
+  });
+
+  it("composes the full snapshot with additive synthetic fields", async () => {
+    const result = await loadFilerSnapshot(SYNTH_ID!);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const s = result.snapshot;
+    expect(s.entity_kind).toBe("synthetic_composite");
+    expect(s.evidence_class).toBe("reconstructed");
+    expect(s.recipe).not.toBeNull();
+    expect(s.cik).toBeNull();
+    expect(s.filer_type).toBeNull();
+    expect(s.aum_tier).toBeNull();
+    expect(s.coverage.effective_coverage).toBeGreaterThan(0);
+    expect(s.coverage.n_children).toBeGreaterThanOrEqual(1);
+    expect(s.holdings?.top.length).toBeGreaterThan(0);
+    expect(result.reportDate).toMatch(ISO_DATE);
+  });
+});

--- a/tests/synthetic-entity-routes.test.ts
+++ b/tests/synthetic-entity-routes.test.ts
@@ -1,0 +1,267 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest, type NextResponse } from "next/server";
+
+vi.mock("@/lib/agent/billing-middleware", () => ({
+  withBilling: <T extends (...args: unknown[]) => unknown>(handler: T) => handler,
+}));
+
+vi.mock("@/lib/dal/filers-engine", () => ({
+  fetchFiler: vi.fn(),
+  resolveFilerById: vi.fn(),
+  fetchFilerRanks: vi.fn(),
+}));
+
+vi.mock("@/lib/dal/funds-zarr-reader", () => ({
+  isSyntheticEntityId: (id: string) => id.startsWith("BW-SYNTH-"),
+  readSyntheticEntityMeta: vi.fn(),
+  readFilerHoldingsTopN: vi.fn(),
+  readFilerPortfolioSeries: vi.fn(),
+  readFilerReturnsDecomposition: vi.fn(),
+  readFilerHedgeLatest: vi.fn(),
+}));
+
+vi.mock("@/lib/13f/enrich-filer-holdings", () => ({
+  enrichFilerHoldingsWithL3: vi.fn(async (snap: unknown) => snap),
+}));
+
+import { fetchFiler, resolveFilerById, fetchFilerRanks } from "@/lib/dal/filers-engine";
+import {
+  readFilerHedgeLatest,
+  readFilerHoldingsTopN,
+  readFilerPortfolioSeries,
+  readFilerReturnsDecomposition,
+  readSyntheticEntityMeta,
+  type SyntheticEntityMeta,
+} from "@/lib/dal/funds-zarr-reader";
+import type { BillingContext } from "@/lib/agent/billing-middleware";
+import { loadFilerSnapshot } from "@/lib/13f/filer-snapshot-loader";
+import { GET as holdingsGETWrapped } from "@/app/api/13f/filers/[bw_filer_id]/holdings/route";
+
+type RouteGET = (
+  req: NextRequest,
+  ctx: BillingContext,
+) => Promise<NextResponse>;
+const holdingsGET = holdingsGETWrapped as unknown as RouteGET;
+
+const SYNTH_ID = "BW-SYNTH-00000000-test";
+
+const META: SyntheticEntityMeta = {
+  teo: "2025-12-31",
+  name: "test",
+  recipe: {
+    schema: "layered_portfolio_recipe/1",
+    plan_id: "test",
+    edges: [{ child_id: "BW-FILER-CIK0000000000", self_scaled: true }],
+  },
+  recipe_hash: "00000000",
+  weight_basis: "static_mix/mandate_usd_as_disclosed",
+  ontology_version: "2.0",
+  layer_depth: 1,
+  coverage: {
+    mapped_weight_frac: 0.97,
+    child_coverage: 1,
+    effective_coverage: 0.9,
+    n_children: 1,
+  },
+};
+
+const HOLDINGS_SNAPSHOT = {
+  teo: "2025-12-31",
+  report_date: "2025-12-31",
+  filing_date: null,
+  as_of_basis: "report_date" as const,
+  total_aum_usd: null,
+  aum_in_erm3: null,
+  n_holdings_returned: 2,
+  n_total_holdings: 42,
+  holdings: [
+    { security_id: "BW-A", adj_mv: 600, weight: 0.6 },
+    { security_id: "BW-B", adj_mv: 400, weight: 0.4 },
+  ],
+};
+
+function request(path: string): NextRequest {
+  return new NextRequest(new URL(`http://localhost${path}`));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("holdings route — synthetic composite ids", () => {
+  it("serves BW-SYNTH-* from the same route with additive fields and null registry fields", async () => {
+    vi.mocked(readSyntheticEntityMeta).mockResolvedValue(META);
+    vi.mocked(readFilerHoldingsTopN).mockResolvedValue(HOLDINGS_SNAPSHOT);
+
+    const res = await holdingsGET(
+      request(`/api/13f/filers/${SYNTH_ID}/holdings`),
+      {} as BillingContext,
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.bw_filer_id).toBe(SYNTH_ID);
+    expect(body.entity_kind).toBe("synthetic_composite");
+    expect(body.evidence_class).toBe("reconstructed");
+    expect(body.cik).toBeNull();
+    expect(body.filer_type).toBeNull();
+    expect(body.aum_tier).toBeNull();
+    expect(body.name).toBe("test");
+    expect(body.holdings).toHaveLength(2);
+    expect(body.holdings[0].adj_mv).toBeGreaterThan(body.holdings[1].adj_mv);
+    // registry is never consulted for synthetic ids
+    expect(fetchFiler).not.toHaveBeenCalled();
+  });
+
+  it("404s an unknown synthetic id without touching the registry", async () => {
+    vi.mocked(readSyntheticEntityMeta).mockResolvedValue(null);
+    const res = await holdingsGET(
+      request(`/api/13f/filers/BW-SYNTH-ffffffff-none/holdings`),
+      {} as BillingContext,
+    );
+    expect(res.status).toBe(404);
+    expect(fetchFiler).not.toHaveBeenCalled();
+    expect(readFilerHoldingsTopN).not.toHaveBeenCalled();
+  });
+
+  it("keeps the BW-FILER response shape unchanged (no synthetic keys)", async () => {
+    vi.mocked(fetchFiler).mockResolvedValue({
+      bw_filer_id: "BW-FILER-CIK0000123456",
+      cik: "0000123456",
+      name: "Test Capital LP",
+      filer_type: "hedge_fund",
+      aum_tier: "large",
+      latest_filing_date: "2026-05-14",
+    } as never);
+    vi.mocked(readFilerHoldingsTopN).mockResolvedValue({
+      ...HOLDINGS_SNAPSHOT,
+      filing_date: "2026-05-14",
+      as_of_basis: "filing_date",
+    });
+
+    const res = await holdingsGET(
+      request(`/api/13f/filers/BW-FILER-CIK0000123456/holdings`),
+      {} as BillingContext,
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).not.toHaveProperty("entity_kind");
+    expect(body).not.toHaveProperty("evidence_class");
+    expect(body.cik).toBe("0000123456");
+    expect(body.filer_type).toBe("hedge_fund");
+    expect(body.aum_tier).toBe("large");
+    expect(readSyntheticEntityMeta).not.toHaveBeenCalled();
+  });
+});
+
+describe("snapshot loader — synthetic composite ids", () => {
+  it("composes the same snapshot shape with additive synthetic fields", async () => {
+    vi.mocked(readSyntheticEntityMeta).mockResolvedValue(META);
+    vi.mocked(readFilerHoldingsTopN).mockResolvedValue(HOLDINGS_SNAPSHOT);
+    vi.mocked(readFilerPortfolioSeries).mockResolvedValue([
+      {
+        teo: "2025-12-31",
+        filing_date: null,
+        weight_sum: 1,
+        n_holdings_active: 42,
+        effective_n: 12,
+        top5_weight_sum: null,
+        top10_weight_sum: 0.5,
+        weight_hhi: null,
+        total_aum_usd: null,
+        aum_in_erm3: null,
+        n_holdings_in_erm3: null,
+        effective_n_in_erm3: null,
+        coverage_in_erm3: null,
+        portfolio_style_hhi: null,
+        effective_n_styles: null,
+        portfolio_gross_return: 0.01,
+        portfolio_market_return: 0.008,
+        portfolio_sector_return: 0.001,
+        portfolio_subsector_return: 0.0005,
+        portfolio_idiosyncratic_return: 0.0005,
+        identity_residual: 0,
+      },
+    ]);
+    vi.mocked(readFilerReturnsDecomposition).mockResolvedValue(null);
+    vi.mocked(readFilerHedgeLatest).mockResolvedValue(null);
+
+    const result = await loadFilerSnapshot(SYNTH_ID);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const s = result.snapshot;
+    expect(s.entity_kind).toBe("synthetic_composite");
+    expect(s.evidence_class).toBe("reconstructed");
+    expect(s.recipe).toEqual(META.recipe);
+    expect(s.bw_filer_id).toBe(SYNTH_ID);
+    // registry-only fields are null
+    expect(s.cik).toBeNull();
+    expect(s.filer_type).toBeNull();
+    expect(s.aum_tier).toBeNull();
+    expect(s.cohort_context).toBeNull();
+    // composition coverage merged into the coverage block (erm3 keys retained)
+    expect(s.coverage.effective_coverage).toBeCloseTo(0.9);
+    expect(s.coverage.mapped_weight_frac).toBeCloseTo(0.97);
+    expect(s.coverage.n_children).toBe(1);
+    expect(s.coverage.coverage_in_erm3).toBeNull();
+    // panel data flows through the shared readers
+    expect(s.holdings?.top).toHaveLength(2);
+    expect(s.portfolio_history.n_periods).toBe(1);
+    expect(result.reportDate).toBe("2025-12-31");
+    expect(result.filingDate).toBeNull();
+    // no database dependency on the synthetic path
+    expect(resolveFilerById).not.toHaveBeenCalled();
+    expect(fetchFilerRanks).not.toHaveBeenCalled();
+  });
+
+  it("404s an unknown synthetic id", async () => {
+    vi.mocked(readSyntheticEntityMeta).mockResolvedValue(null);
+    const result = await loadFilerSnapshot("BW-SYNTH-ffffffff-none");
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.status).toBe(404);
+    expect(resolveFilerById).not.toHaveBeenCalled();
+  });
+
+  it("leaves the BW-FILER snapshot free of synthetic keys", async () => {
+    vi.mocked(resolveFilerById).mockResolvedValue({
+      filer: {
+        bw_filer_id: "BW-FILER-CIK0000123456",
+        cik: "0000123456",
+        lei: null,
+        name: "Test Capital LP",
+        filer_type: "hedge_fund",
+        filer_subtype: null,
+        country: "US",
+        status: "active",
+        style_label: null,
+        factset_entity_id: null,
+        latest_report_date: "2026-03-31",
+        latest_filing_date: "2026-05-14",
+        latest_extracted_at: null,
+        latest_aum_usd: 1_000_000_000,
+        aum_tier: "large",
+        latest_n_holdings: 42,
+        last_in_eligible_universe_at: null,
+        n_funds_managed: null,
+        metadata: null,
+      },
+      latest: null,
+    });
+    vi.mocked(fetchFilerRanks).mockResolvedValue([]);
+    vi.mocked(readFilerHoldingsTopN).mockResolvedValue(null);
+    vi.mocked(readFilerPortfolioSeries).mockResolvedValue([]);
+    vi.mocked(readFilerReturnsDecomposition).mockResolvedValue(null);
+    vi.mocked(readFilerHedgeLatest).mockResolvedValue(null);
+
+    const result = await loadFilerSnapshot("BW-FILER-CIK0000123456");
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.snapshot.entity_kind).toBe("13f_filer");
+    expect(result.snapshot).not.toHaveProperty("evidence_class");
+    expect(result.snapshot).not.toHaveProperty("recipe");
+    expect(result.snapshot.coverage).not.toHaveProperty("effective_coverage");
+    expect(readSyntheticEntityMeta).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
The existing `/13f/filers/{id}/snapshot` and `/holdings` routes now serve composite entities (`BW-SYNTH-*`) polymorphically — no parallel route tree. Dispatch happens once in the zarr reader (synthetic ids resolve to the `bw_synth_id/` family), so every existing filer reader works unchanged; composite responses add `entity_kind: "synthetic_composite"`, `evidence_class: "reconstructed"`, a self-describing `recipe` from zarr attrs (no registry/database dependency), and composition-coverage fields in the existing `coverage` block. Registry-only fields are null. Filer output is byte-identical (live-verified on a real filer before/after).

Also: env-gated local zarr root for dev/tests (unset in prod → identical GCS behavior); discovery one-liners on the two routes in OpenAPI/capabilities/MCP descriptions.

Tests: vitest 508 passed / 9 skipped (6 new mocked route tests + an opt-in data-gated local-zarr test, skip-if-absent). Composite ids 404 cleanly until the data family syncs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)