### PR TITLE
feat(snapshot): panel drill-down API + stock O.6 render-svc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to the RiskModels API surface and public assets.
 
 
+## [Unreleased]
+
+### Added
+
+- **`GET /api/snapshot/{entity_kind}/{id}/panels/{slug}`** — Stock panel drill-down (O.6): `l3_explained_risk_hbar`, `hedge_notionals_hbar`, `hedge_depth_retained`, `watchlist_er_stacked`, and `_full` (composed DD page). Thin alias onto Artifact Registry / render-svc. ADR: BWMACRO `docs/architecture/SNAPSHOT_CANONICAL_PROCESS_ADR.md`.
+- **Python SDK — `snapshot_panel()`** — Fetches a single panel PNG/JSON/SVG via the product panel route.
+- **render-svc** — Live stock `POST /decompose` loader for O.6 panels (`BW-STOCK-*` / watchlist).
+
+### Changed
+
+- **`GET /api/snapshot/{ticker}`** — Implemented under `[entity_kind]/route.ts` (same dynamic segment as panels) so Next.js does not reject sibling `[ticker]` vs `[entity_kind]` folders. Reserved kinds (`stock`, `fund`, …) return 400 with the panel URL shape. Deprecation header still prefers `…/panels/_full`.
+
 ## [0.6.2] — 2026-06-30
 
 ### Added

--- a/OPENAPI_SPEC.yaml
+++ b/OPENAPI_SPEC.yaml
@@ -6752,6 +6752,100 @@ paths:
               schema:
                 $ref: "#/components/schemas/InsufficientBalance"
 
+  /snapshot/{entity_kind}/{id}/panels/{slug}:
+    get:
+      summary: Snapshot panel drill-down (artifact PNG/JSON)
+      description: >
+        Addressable panel from the Artifact Registry (O.6). Product alias onto
+        render-svc `POST /artifacts/render`. Stock panels:
+        `l3_explained_risk_hbar`, `hedge_notionals_hbar`, `hedge_depth_retained`,
+        `watchlist_er_stacked` (pass `tickers=CRM,MSFT,NVDA`), and `_full` (composed
+        DD page from GCS). See BWMACRO `docs/architecture/SNAPSHOT_CANONICAL_PROCESS_ADR.md`.
+
+        **Billing:** `portfolio-risk-snapshot` ($0.25; cache hits may be $0).
+      operationId: getSnapshotPanel
+      tags: [Risk Metrics]
+      x-pricing:
+        capability_id: portfolio-risk-snapshot
+        tier: premium
+        model: per_request
+        cost_usd: 0.25
+        currency: USD
+        billing_code: risk_snapshot_pdf_v1
+      security:
+        - BearerAuth: []
+        - OAuth2ClientCredentials: ["*"]
+      parameters:
+        - name: entity_kind
+          in: path
+          required: true
+          schema:
+            type: string
+            enum: [stock, fund, filer_13f, client_portfolio, cohort]
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Ticker (CRM), BW-STOCK-CRM, fund/filer id, or WATCHLIST.
+        - name: slug
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Panel artifact slug or `_full`.
+        - name: format
+          in: query
+          schema:
+            type: string
+            enum: [png, json, svg, pdf]
+            default: png
+        - name: version
+          in: query
+          schema:
+            type: string
+            default: v1
+        - name: as_of
+          in: query
+          schema:
+            type: string
+            default: latest
+        - name: tickers
+          in: query
+          schema:
+            type: string
+          description: Comma-separated tickers for watchlist_er_stacked.
+      responses:
+        "200":
+          description: Panel PNG/SVG bytes or JSON contract.
+          content:
+            image/png:
+              schema:
+                type: string
+                format: binary
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+        "401":
+          description: Unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Unknown panel or missing DD asset.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "501":
+          description: render-svc not configured or panel not live-renderable.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
   /metrics/{ticker}/snapshot.pdf:
     get:
       summary: Single-ticker risk snapshot PDF

--- a/app/api/snapshot/[entity_kind]/[id]/panels/[slug]/route.ts
+++ b/app/api/snapshot/[entity_kind]/[id]/panels/[slug]/route.ts
@@ -1,0 +1,279 @@
+/**
+ * GET /api/snapshot/{entity_kind}/{id}/panels/{slug}
+ *
+ * Stock (and later fund/filer) panel drill-down — thin alias onto Artifact
+ * Registry render-svc. See BWMACRO docs/architecture/SNAPSHOT_CANONICAL_PROCESS_ADR.md.
+ *
+ * Examples:
+ *   GET /api/snapshot/stock/CRM/panels/l3_explained_risk_hbar?format=png
+ *   GET /api/snapshot/stock/WATCHLIST/panels/watchlist_er_stacked?tickers=CRM,MSFT,NVDA&format=png
+ *   GET /api/snapshot/stock/NVDA/panels/_full?format=png  → full DD page (GCS)
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { withBilling, type BillingContext } from "@/lib/agent/billing-middleware";
+import { getBillingUserId } from "@/lib/agent/billing-user";
+import { renderArtifact } from "@/lib/artifacts/render-client";
+import { getCorsHeaders } from "@/lib/cors";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+const ENTITY_KINDS = new Set([
+  "stock",
+  "fund",
+  "filer_13f",
+  "client_portfolio",
+  "cohort",
+]);
+
+const STOCK_PANEL_SLUGS = new Set([
+  "l3_explained_risk_hbar",
+  "hedge_notionals_hbar",
+  "hedge_depth_retained",
+  "watchlist_er_stacked",
+  "_full",
+]);
+
+const GCS_DD_BASE = "https://storage.googleapis.com/rm_api_public/snapshot";
+
+type SnapshotFormat = "png" | "json" | "svg" | "pdf";
+
+function subjectIdFor(entityKind: string, id: string): string {
+  const upper = id.trim().toUpperCase();
+  if (entityKind === "stock") {
+    if (upper.startsWith("BW-STOCK-")) return upper;
+    return `BW-STOCK-${upper}`;
+  }
+  if (entityKind === "fund" && !upper.startsWith("BW-FUND-")) {
+    return `BW-FUND-${upper}`;
+  }
+  if (entityKind === "filer_13f" && !upper.startsWith("BW-FILER-")) {
+    return `BW-FILER-${upper}`;
+  }
+  return upper;
+}
+
+async function fetchFullDd(
+  ticker: string,
+  format: "png" | "pdf",
+  origin: string | null,
+): Promise<NextResponse> {
+  const upper = ticker.toUpperCase();
+  const url = `${GCS_DD_BASE}/${upper}/${upper}_DD_latest.${format}`;
+  const upstream = await fetch(url, { cache: "no-store" });
+  if (upstream.status === 404) {
+    return NextResponse.json(
+      {
+        error: "Snapshot not found",
+        message: `No precomputed DD snapshot for ${upper}`,
+      },
+      { status: 404, headers: getCorsHeaders(origin) },
+    );
+  }
+  if (!upstream.ok) {
+    return NextResponse.json(
+      { error: "Upstream error", message: `GCS returned ${upstream.status}` },
+      { status: 502, headers: getCorsHeaders(origin) },
+    );
+  }
+  const buf = Buffer.from(await upstream.arrayBuffer());
+  const contentType = format === "pdf" ? "application/pdf" : "image/png";
+  return new NextResponse(buf, {
+    status: 200,
+    headers: {
+      ...getCorsHeaders(origin),
+      "Content-Type": contentType,
+      "Content-Disposition": `inline; filename="${upper}_DD_latest.${format}"`,
+      "Cache-Control": "public, max-age=300, s-maxage=300",
+      "X-Snapshot-Panel": "_full",
+      "X-Deprecated-Alias-Of": `/api/snapshot/${upper}`,
+    },
+  });
+}
+
+async function buildPanelResponse(
+  request: NextRequest,
+  _ctx: BillingContext,
+  entityKind: string,
+  id: string,
+  slug: string,
+): Promise<NextResponse> {
+  const origin = request.headers.get("origin");
+  const url = new URL(request.url);
+  const formatParam = (url.searchParams.get("format") ?? "png").toLowerCase();
+  if (!["png", "json", "svg", "pdf"].includes(formatParam)) {
+    return NextResponse.json(
+      { error: "Invalid format", message: "format must be png|json|svg|pdf" },
+      { status: 400, headers: getCorsHeaders(origin) },
+    );
+  }
+  const format = formatParam as SnapshotFormat;
+  const version = url.searchParams.get("version") ?? "v1";
+  const asOf = url.searchParams.get("as_of") ?? "latest";
+
+  if (slug === "_full") {
+    if (entityKind !== "stock") {
+      return NextResponse.json(
+        {
+          error: "Not supported",
+          message: "_full panel is stock-only (dd_stock template / GCS DD)",
+        },
+        { status: 400, headers: getCorsHeaders(origin) },
+      );
+    }
+    if (format !== "png" && format !== "pdf") {
+      return NextResponse.json(
+        { error: "Invalid format", message: "_full supports png|pdf only" },
+        { status: 400, headers: getCorsHeaders(origin) },
+      );
+    }
+    const ticker = id.replace(/^BW-STOCK-/i, "").toUpperCase();
+    return fetchFullDd(ticker, format, origin);
+  }
+
+  if (entityKind === "stock" && !STOCK_PANEL_SLUGS.has(slug)) {
+    return NextResponse.json(
+      {
+        error: "Unknown panel",
+        message: `Known stock panels: ${[...STOCK_PANEL_SLUGS]
+          .filter((s) => s !== "_full")
+          .join(", ")}`,
+      },
+      { status: 404, headers: getCorsHeaders(origin) },
+    );
+  }
+
+  if (format === "pdf") {
+    return NextResponse.json(
+      {
+        error: "Not implemented",
+        message: "Panel PDF not yet supported; use format=png or _full?format=pdf",
+      },
+      { status: 501, headers: getCorsHeaders(origin) },
+    );
+  }
+
+  let subjectId = subjectIdFor(entityKind, id);
+  let subjectPayload: Record<string, unknown> | undefined;
+
+  if (slug === "watchlist_er_stacked") {
+    const tickersParam = url.searchParams.get("tickers");
+    const tickers = tickersParam
+      ? tickersParam.split(/[\s,;]+/).filter(Boolean)
+      : id.toUpperCase() === "WATCHLIST"
+        ? []
+        : [id.replace(/^BW-STOCK-/i, "")];
+    if (!tickers.length) {
+      return NextResponse.json(
+        {
+          error: "Missing tickers",
+          message:
+            "Pass ?tickers=CRM,MSFT,NVDA for watchlist_er_stacked (or use id=WATCHLIST with tickers query)",
+        },
+        { status: 400, headers: getCorsHeaders(origin) },
+      );
+    }
+    subjectId = "BW-STOCK-WATCHLIST";
+    subjectPayload = { tickers: tickers.map((t) => t.toUpperCase()) };
+  }
+
+  const result = await renderArtifact({
+    slug,
+    version,
+    subject_id: subjectId,
+    as_of: asOf,
+    format: format as "png" | "json" | "svg",
+    subject_payload: subjectPayload,
+  });
+
+  if (!result.ok) {
+    return NextResponse.json(
+      { error: result.error, detail: result.detail },
+      { status: result.status, headers: getCorsHeaders(origin) },
+    );
+  }
+
+  const headers: Record<string, string> = {
+    ...getCorsHeaders(origin),
+    "X-Snapshot-Panel": slug,
+    "X-Artifact-Resolved-As-Of": result.resolved_as_of,
+    "X-Artifact-Gcs-Path": result.gcs_path,
+    "Cache-Control":
+      asOf === "latest"
+        ? "public, max-age=3600"
+        : "public, max-age=31536000, immutable",
+  };
+  if (result.receipt_id) {
+    headers["X-Artifact-Receipt-Id"] = result.receipt_id;
+  }
+
+  if (format === "json") {
+    headers["Content-Type"] = "application/json";
+    return NextResponse.json(result.data, { status: 200, headers });
+  }
+
+  const bin = result.data as {
+    base64: string;
+    content_type: string;
+  };
+  headers["Content-Type"] = bin.content_type;
+  headers["Content-Disposition"] =
+    `inline; filename="${subjectId}_${slug}.${format}"`;
+  return new NextResponse(Buffer.from(bin.base64, "base64"), {
+    status: 200,
+    headers,
+  });
+}
+
+export async function GET(
+  request: NextRequest,
+  segmentData: {
+    params: Promise<{ entity_kind: string; id: string; slug: string }>;
+  },
+) {
+  const origin = request.headers.get("origin");
+  const { entity_kind, id, slug } = await segmentData.params;
+  const entityKind = entity_kind.toLowerCase();
+
+  if (!ENTITY_KINDS.has(entityKind)) {
+    return NextResponse.json(
+      {
+        error: "Invalid entity_kind",
+        message: `entity_kind must be one of: ${[...ENTITY_KINDS].join(", ")}`,
+      },
+      { status: 400, headers: getCorsHeaders(origin) },
+    );
+  }
+
+  const auth = await getBillingUserId(request);
+  if (!auth) {
+    return NextResponse.json(
+      {
+        error: "Unauthorized",
+        message: "Valid API key or authentication required",
+      },
+      { status: 401, headers: getCorsHeaders(origin) },
+    );
+  }
+
+  const url = new URL(request.url);
+  const req2 = new NextRequest(url.toString(), {
+    method: "GET",
+    headers: request.headers,
+  });
+
+  return withBilling(
+    async (req, context) =>
+      buildPanelResponse(req, context, entityKind, id, slug),
+    { capabilityId: "portfolio-risk-snapshot" },
+  )(req2);
+}
+
+export async function OPTIONS(request: NextRequest) {
+  const origin = request.headers.get("origin");
+  return new NextResponse(null, {
+    status: 204,
+    headers: getCorsHeaders(origin),
+  });
+}

--- a/app/api/snapshot/[entity_kind]/route.ts
+++ b/app/api/snapshot/[entity_kind]/route.ts
@@ -1,19 +1,19 @@
 /**
  * Stock Deep Dive (DD) snapshot — served from precomputed GCS objects.
  *
- * The DD snapshots are generated offline by the Python pipeline in
- * `sdk/riskmodels/snapshots/stock_deep_dive.py` and uploaded to
- * `gs://rm_api_public/snapshot/{TICKER}/{TICKER}_DD_latest.{png,pdf}`.
- *
- * This endpoint adds an authenticated, branded API URL on top of the
- * public bucket, enforcing API-key auth, billing, CORS, and a Redis cache
- * layer. The Python generation code stays proprietary on the offline
- * batch infrastructure — only the rendered bytes ever leave that
- * environment.
- *
  *   GET /api/snapshot/{ticker}              → image/png
  *   GET /api/snapshot/{ticker}?format=pdf   → application/pdf
- *   GET /api/snapshot/{ticker}?format=png   → image/png
+ *
+ * Route param is named `entity_kind` so this folder can nest
+ * `[entity_kind]/[id]/panels/[slug]` without a Next.js sibling-dynamic
+ * conflict against a separate `[ticker]` segment.
+ *
+ * Reserved kinds (`stock`, `fund`, …) are not tickers — hitting
+ * `/api/snapshot/stock` alone returns 400 with the panel URL shape.
+ *
+ * Preferred panel drill-down (O.6):
+ *   GET /api/snapshot/stock/{ticker}/panels/{slug}?format=png
+ *   GET /api/snapshot/stock/{ticker}/panels/_full?format=png
  */
 
 import { createHash } from "crypto";
@@ -32,8 +32,15 @@ import { getCorsHeaders } from "@/lib/cors";
 
 export const dynamic = "force-dynamic";
 
-// Public GCS bucket where the offline pipeline uploads the rendered DD files.
 const GCS_BASE = "https://storage.googleapis.com/rm_api_public/snapshot";
+
+const RESERVED_ENTITY_KINDS = new Set([
+  "stock",
+  "fund",
+  "filer_13f",
+  "client_portfolio",
+  "cohort",
+]);
 
 const ALLOWED_FORMATS = ["png", "pdf"] as const;
 type SnapshotFormat = (typeof ALLOWED_FORMATS)[number];
@@ -45,19 +52,17 @@ type SnapshotCache = {
   etag?: string;
 };
 
-// Bumped during PR 3 (snapshot canonicalization, 2026-05) to invalidate cached
-// PNG/PDF bytes after the subsector slate→violet color cutover and the move to
-// the canonical reference renderer. Bump again whenever the rendered output
-// changes deterministically and old hashes would otherwise still match.
 const SNAPSHOT_CACHE_VERSION = "v2";
 
 function snapshotCacheKey(ticker: string, format: SnapshotFormat) {
   const h = createHash("sha256")
-    .update(JSON.stringify({
-      ticker: ticker.toUpperCase(),
-      format,
-      v: SNAPSHOT_CACHE_VERSION,
-    }))
+    .update(
+      JSON.stringify({
+        ticker: ticker.toUpperCase(),
+        format,
+        v: SNAPSHOT_CACHE_VERSION,
+      }),
+    )
     .digest("hex");
   return generateCacheKey("dd_snapshot", h);
 }
@@ -120,12 +125,12 @@ async function fetchFromGcs(
     "Content-Type": contentType,
     "Content-Disposition": `inline; filename="${ticker.toUpperCase()}_DD_latest.${format}"`,
     "Cache-Control": "public, max-age=300, s-maxage=300",
+    "X-Deprecated-Prefer": `/api/snapshot/stock/${ticker.toUpperCase()}/panels/_full?format=${format}`,
   };
   if (lastModified) headers["Last-Modified"] = lastModified;
   if (etag) headers["ETag"] = etag;
 
   const res = new NextResponse(buf, { status: 200, headers });
-  // Stash on the response so the caller can write it to Redis after billing succeeds.
   (res as NextResponse & { __cachePayload?: SnapshotCache }).__cachePayload = {
     base64: buf.toString("base64"),
     contentType,
@@ -137,12 +142,26 @@ async function fetchFromGcs(
 
 export async function GET(
   request: NextRequest,
-  segmentData: { params: Promise<{ ticker: string }> },
+  segmentData: { params: Promise<{ entity_kind: string }> },
 ) {
   const origin = request.headers.get("origin");
-  const { ticker: rawTicker } = await segmentData.params;
+  const { entity_kind: raw } = await segmentData.params;
+  const kindLower = raw.trim().toLowerCase();
 
-  const parsed = TickerSchema.safeParse(rawTicker);
+  if (RESERVED_ENTITY_KINDS.has(kindLower)) {
+    return NextResponse.json(
+      {
+        error: "Use panel path",
+        message:
+          `GET /api/snapshot/${kindLower}/{id}/panels/{slug} — ` +
+          `e.g. /api/snapshot/stock/CRM/panels/l3_explained_risk_hbar?format=png ` +
+          `or /api/snapshot/stock/CRM/panels/_full?format=png`,
+      },
+      { status: 400, headers: getCorsHeaders(origin) },
+    );
+  }
+
+  const parsed = TickerSchema.safeParse(raw);
   if (!parsed.success) {
     return NextResponse.json(
       { error: "Invalid ticker", message: parsed.error.issues[0].message },
@@ -164,7 +183,6 @@ export async function GET(
   }
   const format = formatParam as SnapshotFormat;
 
-  // Auth gate (mirrors snapshot.png/snapshot.pdf routes).
   const auth = await getBillingUserId(request);
   if (!auth) {
     return NextResponse.json(
@@ -176,9 +194,6 @@ export async function GET(
     );
   }
 
-  // Redis hot cache: keyed on (ticker, format), shared across users since the
-  // file is identical for everyone. Short TTL because the offline pipeline
-  // updates GCS daily.
   const key = snapshotCacheKey(ticker, format);
   const hit = await getCache<SnapshotCache>(key);
   if (isDdSnapshotCacheHit(hit)) {
@@ -197,7 +212,6 @@ export async function GET(
     });
   }
 
-  // Cache miss → bill the request, fetch from GCS, populate cache.
   const req2 = new NextRequest(url.toString(), {
     method: "GET",
     headers: request.headers,
@@ -207,15 +221,12 @@ export async function GET(
     async (req, _ctx: BillingContext) => {
       const res = await fetchFromGcs(ticker, format, req.headers.get("origin"));
       if (res.status === 200) {
-        const payload = (res as NextResponse & {
-          __cachePayload?: SnapshotCache;
-        }).__cachePayload;
+        const payload = (
+          res as NextResponse & {
+            __cachePayload?: SnapshotCache;
+          }
+        ).__cachePayload;
         if (payload) {
-          // 1h TTL matches the offline pipeline's daily refresh cadence — long
-          // enough to absorb traffic bursts, short enough that a fresh GCS
-          // upload propagates to end users in under an hour. Previously this
-          // was HISTORICAL (24h), which meant a same-day refresh of GCS could
-          // be invisible to website users for almost a full day.
           await setCache(key, payload, CACHE_TTL.DAILY);
         }
       }

--- a/lib/agent/capabilities.ts
+++ b/lib/agent/capabilities.ts
@@ -1400,16 +1400,17 @@ export const CAPABILITIES: Capability[] = [
     id: "artifact-render",
     name: "Artifact registry render",
     description:
-      "Deterministic render-once artifact from the intelligence registry (fund / filer / client_portfolio subjects). " +
-      "Invokes render-svc `POST /artifacts/render` — same contract as riskmodels.net workspace `fetchArtifact`. " +
-      "Returns JSON chart/table/narrative payloads or PNG/SVG bytes (base64). Chat tool: `render_artifact`; MCP: `riskmodels_render_artifact`.",
+      "Deterministic render-once artifact from the intelligence registry (stock / fund / filer / client_portfolio). " +
+      "Invokes render-svc `POST /artifacts/render`; product alias `GET /api/snapshot/{entity_kind}/{id}/panels/{slug}`. " +
+      "Stock O.6: l3_explained_risk_hbar, hedge_notionals_hbar, hedge_depth_retained, watchlist_er_stacked. " +
+      "Returns JSON or PNG/SVG (base64). Chat: `render_artifact`; MCP: `riskmodels_render_artifact`.",
     endpoint: "/artifacts/render",
     method: "POST",
     parameters: {
       slug: {
         type: "string",
         required: true,
-        description: "Artifact slug (e.g. top_holdings_erm_stacked, narrative_profile)",
+        description: "Artifact slug (e.g. l3_explained_risk_hbar, top_holdings_erm_stacked)",
       },
       version: {
         type: "string",
@@ -1420,7 +1421,7 @@ export const CAPABILITIES: Capability[] = [
       subject_id: {
         type: "string",
         required: true,
-        description: "BW-FUND-…, BW-FILER-…, or BW-PORTFOLIO-…",
+        description: "BW-STOCK-…, BW-FUND-…, BW-FILER-…, BW-PORTFOLIO-…, or BW-STOCK-WATCHLIST",
       },
       as_of: {
         type: "string",

--- a/lib/artifacts/render-client.ts
+++ b/lib/artifacts/render-client.ts
@@ -53,6 +53,14 @@ export const WIRED_ARTIFACT_RENDER_MATRIX: Record<
   return_composition_bars: { subject_kinds: ["filer_13f"] },
   active_risk_composition: { subject_kinds: ["filer_13f"] },
   risk_summary_panel: { subject_kinds: ["filer_13f"] },
+  // O.6 stock panels (2026-07-14) — live decompose loader on render-svc
+  l3_explained_risk_hbar: { subject_kinds: ["stock"] },
+  hedge_notionals_hbar: { subject_kinds: ["stock"] },
+  hedge_depth_retained: { subject_kinds: ["stock"] },
+  watchlist_er_stacked: {
+    subject_kinds: ["stock"],
+    notes: "Requires subject_payload.tickers; subject_id BW-STOCK-WATCHLIST.",
+  },
 };
 
 function renderSvcUrl(): string | null {

--- a/mcp/data/capabilities.json
+++ b/mcp/data/capabilities.json
@@ -1571,14 +1571,14 @@
   {
     "id": "artifact-render",
     "name": "Artifact registry render",
-    "description": "Deterministic render-once artifact from the intelligence registry (fund / filer / client_portfolio subjects). Invokes render-svc `POST /artifacts/render` — same contract as riskmodels.net workspace `fetchArtifact`. Returns JSON chart/table/narrative payloads or PNG/SVG bytes (base64). Chat tool: `render_artifact`; MCP: `riskmodels_render_artifact`.",
+    "description": "Deterministic render-once artifact from the intelligence registry (stock / fund / filer / client_portfolio subjects). Invokes render-svc `POST /artifacts/render` — same contract as riskmodels.net workspace `fetchArtifact` and product alias `GET /api/snapshot/{entity_kind}/{id}/panels/{slug}`. Stock O.6 panels: l3_explained_risk_hbar, hedge_notionals_hbar, hedge_depth_retained, watchlist_er_stacked. Returns JSON chart/table/narrative payloads or PNG/SVG bytes (base64). Chat tool: `render_artifact`; MCP: `riskmodels_render_artifact`.",
     "endpoint": "/artifacts/render",
     "method": "POST",
     "parameters": {
       "slug": {
         "type": "string",
         "required": true,
-        "description": "Artifact slug (e.g. top_holdings_erm_stacked, narrative_profile)"
+        "description": "Artifact slug (e.g. l3_explained_risk_hbar, top_holdings_erm_stacked, narrative_profile)"
       },
       "version": {
         "type": "string",
@@ -1589,7 +1589,7 @@
       "subject_id": {
         "type": "string",
         "required": true,
-        "description": "BW-FUND-…, BW-FILER-…, or BW-PORTFOLIO-…"
+        "description": "BW-STOCK-…, BW-FUND-…, BW-FILER-…, BW-PORTFOLIO-…, or BW-STOCK-WATCHLIST"
       },
       "as_of": {
         "type": "string",

--- a/mcp/data/openapi.json
+++ b/mcp/data/openapi.json
@@ -9719,6 +9719,156 @@
         }
       }
     },
+    "/snapshot/{entity_kind}/{id}/panels/{slug}": {
+      "get": {
+        "summary": "Snapshot panel drill-down (artifact PNG/JSON)",
+        "description": "Addressable panel from the Artifact Registry (O.6). Product alias onto render-svc `POST /artifacts/render`. Stock panels: `l3_explained_risk_hbar`, `hedge_notionals_hbar`, `hedge_depth_retained`, `watchlist_er_stacked` (pass `tickers=CRM,MSFT,NVDA`), and `_full` (composed DD page from GCS). See BWMACRO `docs/architecture/SNAPSHOT_CANONICAL_PROCESS_ADR.md`.\n**Billing:** `portfolio-risk-snapshot` ($0.25; cache hits may be $0).\n",
+        "operationId": "getSnapshotPanel",
+        "tags": [
+          "Risk Metrics"
+        ],
+        "x-pricing": {
+          "capability_id": "portfolio-risk-snapshot",
+          "tier": "premium",
+          "model": "per_request",
+          "cost_usd": 0.25,
+          "currency": "USD",
+          "billing_code": "risk_snapshot_pdf_v1"
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "OAuth2ClientCredentials": [
+              "*"
+            ]
+          }
+        ],
+        "parameters": [
+          {
+            "name": "entity_kind",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "stock",
+                "fund",
+                "filer_13f",
+                "client_portfolio",
+                "cohort"
+              ]
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Ticker (CRM), BW-STOCK-CRM, fund/filer id, or WATCHLIST."
+          },
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Panel artifact slug or `_full`."
+          },
+          {
+            "name": "format",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "png",
+                "json",
+                "svg",
+                "pdf"
+              ],
+              "default": "png"
+            }
+          },
+          {
+            "name": "version",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "default": "v1"
+            }
+          },
+          {
+            "name": "as_of",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "default": "latest"
+            }
+          },
+          {
+            "name": "tickers",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Comma-separated tickers for watchlist_er_stacked."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Panel PNG/SVG bytes or JSON contract.",
+            "content": {
+              "image/png": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Unknown panel or missing DD asset.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "render-svc not configured or panel not live-renderable.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/metrics/{ticker}/snapshot.pdf": {
       "get": {
         "summary": "Single-ticker risk snapshot PDF",
@@ -14441,7 +14591,8 @@
             "required": true,
             "schema": {
               "type": "string"
-            }
+            },
+            "description": "Canonical filer id (BW-FILER-CIK{cik}). Composite entities (BW-SYNTH-*) are served by the same route; registry-only fields (cik, filer_type, aum_tier) return null.\n"
           },
           {
             "name": "limit",
@@ -14690,7 +14841,8 @@
             "required": true,
             "schema": {
               "type": "string"
-            }
+            },
+            "description": "Canonical filer id (BW-FILER-CIK{cik}). Composite entities (BW-SYNTH-*) are served by the same route; the snapshot adds entity_kind: synthetic_composite, evidence_class: reconstructed, recipe, and composition coverage; registry-only fields return null.\n"
           }
         ],
         "responses": {

--- a/sdk/riskmodels/client.py
+++ b/sdk/riskmodels/client.py
@@ -1962,6 +1962,59 @@ class RiskModelsClient:
         )
         return data, lineage
 
+    def snapshot_panel(
+        self,
+        entity_kind: str,
+        subject_id: str,
+        slug: str,
+        *,
+        format: Literal["png", "json", "svg"] = "png",
+        version: str = "v1",
+        as_of: str = "latest",
+        tickers: list[str] | None = None,
+    ) -> tuple[bytes | dict, RiskLineage]:
+        """Fetch one snapshot panel via ``GET /api/snapshot/{kind}/{id}/panels/{slug}``.
+
+        Stock panels (O.6): ``l3_explained_risk_hbar``, ``hedge_notionals_hbar``,
+        ``hedge_depth_retained``, ``watchlist_er_stacked``, ``_full`` (DD page).
+
+        Args:
+            entity_kind: ``stock`` | ``fund`` | ``filer_13f`` | …
+            subject_id: Ticker (``CRM``) or ``BW-STOCK-CRM``; use ``WATCHLIST``
+                with ``tickers=`` for ``watchlist_er_stacked``.
+            slug: Panel artifact slug (or ``_full`` for the composed DD page).
+            format: ``png`` (default), ``json``, or ``svg``.
+            version: Artifact version (default ``v1``).
+            as_of: ``latest`` or ISO date.
+            tickers: Optional watchlist tickers for ``watchlist_er_stacked``.
+
+        Returns:
+            ``(png_bytes, lineage)`` for binary formats, or ``(dict, lineage)``
+            when ``format="json"``.
+        """
+        from urllib.parse import quote, urlencode
+
+        kind = entity_kind.strip().lower()
+        sid = subject_id.strip()
+        path = (
+            f"/snapshot/{quote(kind, safe='')}/"
+            f"{quote(sid, safe='')}/panels/{quote(slug, safe='')}"
+        )
+        q: dict[str, str] = {
+            "format": format,
+            "version": version,
+            "as_of": as_of,
+        }
+        if tickers:
+            q["tickers"] = ",".join(t.strip().upper() for t in tickers)
+        qs = urlencode(q)
+        data, lineage, _r = self._transport.request(
+            "GET",
+            f"{path}?{qs}",
+            expect_json=(format == "json"),
+        )
+        return data, lineage
+
     def snapshot_ticker(
         self,
         ticker: str,

--- a/services/render-svc/Dockerfile
+++ b/services/render-svc/Dockerfile
@@ -91,6 +91,10 @@ RUN python -c "import sys; \
 import bwmacro.snapshots.artifacts; \
 import bwmacro.snapshots.artifacts.top_holdings_erm_stacked.v1; \
 import bwmacro.snapshots.artifacts.cumulative_return_strip.v1; \
+import bwmacro.snapshots.artifacts.l3_explained_risk_hbar.v1; \
+import bwmacro.snapshots.artifacts.hedge_notionals_hbar.v1; \
+import bwmacro.snapshots.artifacts.hedge_depth_retained.v1; \
+import bwmacro.snapshots.artifacts.watchlist_er_stacked.v1; \
 forbidden = ['bwmacro.snapshots.funds._ai_insight', 'bwmacro.snapshots.funds._data', 'supabase']; \
 hit = [m for m in forbidden if m in sys.modules]; \
 assert not hit, f'forbidden modules imported at artifact import: {hit}'; \

--- a/services/render-svc/render_svc/artifacts.py
+++ b/services/render-svc/render_svc/artifacts.py
@@ -186,6 +186,24 @@ def _adapter_for(slug: str, subject_kind: str) -> Callable[[Any], Any]:
             ),
         )
 
+    if subject_kind == "stock":
+        if slug == "l3_explained_risk_hbar":
+            return adapters.stock_l3_exposure_from_decompose
+        if slug == "hedge_notionals_hbar":
+            return adapters.stock_hedge_notionals_from_decompose
+        if slug == "hedge_depth_retained":
+            return adapters.stock_l3_exposure_from_decompose
+        if slug == "watchlist_er_stacked":
+            return adapters.watchlist_er_stacked_from_decomposes
+        raise HTTPException(
+            status_code=501,
+            detail=(
+                f"No stock adapter wired for slug={slug!r} "
+                f"(O.6 panels: l3_explained_risk_hbar, hedge_notionals_hbar, "
+                f"hedge_depth_retained, watchlist_er_stacked)"
+            ),
+        )
+
     raise HTTPException(
         status_code=501,
         detail=(
@@ -252,9 +270,10 @@ def _resolve_client_portfolio(
 # Subject kinds with no SDK loader inside render-svc. Pre-rendered artifacts
 # (explicit as_of, bytes already in GCS) serve via the cache-hit path; cache
 # miss raises 501. filer_13f data lives behind the private BWMACRO surface;
-# cohort/stock cover the research artifact registry (BW-COHORT-RES-*,
-# BW-STOCK-* — published by BWMACRO research/papers/build_artifacts.py).
-_PRERENDERED_SUBJECT_KINDS: tuple[str, ...] = ("filer_13f", "cohort", "stock")
+# cohort covers research artifacts (BW-COHORT-RES-* — published by
+# BWMACRO research/papers/build_artifacts.py).
+# ``stock`` was removed from this set 2026-07-14 (O.6): live decompose loader.
+_PRERENDERED_SUBJECT_KINDS: tuple[str, ...] = ("filer_13f", "cohort")
 
 
 def _resolve_prerendered_subject(
@@ -295,12 +314,13 @@ def _resolve_prerendered_subject(
 def _load_subject_data(subject_id: str, subject_kind: str, as_of: str) -> Any:
     """Load subject data + verify the loader's resolved as_of.
 
-    Phase 1B: only ``subject_kind == "fund"`` is wired, and only
-    ``as_of == "latest"`` (or an as_of matching the loader's resolved
-    latest_report_date) is supported. Arbitrary historical as_of is a
-    Phase 2 task (the SDK ``get_data_for_f1`` doesn't yet accept an
-    ``as_of`` parameter).
+    Wired today:
+      - ``fund`` via ``get_data_for_f1`` (as_of=latest or matching teo)
+      - ``stock`` via live ``POST /api/decompose`` (as_of=latest or matching data_as_of)
     """
+    if subject_kind == "stock":
+        return _load_stock_decompose(subject_id, as_of)
+
     if subject_kind != "fund":
         raise HTTPException(
             status_code=501,
@@ -336,6 +356,126 @@ def _load_subject_data(subject_id: str, subject_kind: str, as_of: str) -> Any:
         )
 
     return fd, resolved
+
+
+def _ticker_from_stock_subject_id(subject_id: str) -> str:
+    """BW-STOCK-CRM → CRM."""
+    prefix = "BW-STOCK-"
+    if not subject_id.startswith(prefix):
+        raise HTTPException(
+            status_code=422,
+            detail=f"stock subject_id must start with {prefix!r}",
+        )
+    ticker = subject_id[len(prefix) :].strip().upper()
+    if not ticker or ticker == "WATCHLIST":
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                "BW-STOCK-WATCHLIST requires subject_payload.tickers; "
+                "single-name panels use BW-STOCK-{TICKER}"
+            ),
+        )
+    return ticker
+
+
+def _fetch_decompose(ticker: str) -> dict[str, Any]:
+    """Call RiskModels ``POST /api/decompose`` with service credentials."""
+    import os
+
+    import requests
+
+    api_key = (
+        os.environ.get("RISKMODELS_API_KEY")
+        or os.environ.get("RENDER_SVC_RISKMODELS_API_KEY")
+        or ""
+    ).strip()
+    if not api_key:
+        raise HTTPException(
+            status_code=503,
+            detail="RISKMODELS_API_KEY not configured on render-svc for stock panels",
+        )
+    base = os.environ.get("RISKMODELS_BASE_URL", "https://riskmodels.app/api").rstrip("/")
+    try:
+        resp = requests.post(
+            f"{base}/decompose",
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/json",
+            },
+            json={"ticker": ticker},
+            timeout=45,
+        )
+        resp.raise_for_status()
+        payload = resp.json()
+    except Exception as exc:  # noqa: BLE001
+        log.exception("decompose failed for %s", ticker)
+        raise HTTPException(
+            status_code=502,
+            detail=f"decompose failed for {ticker!r}: {exc}",
+        ) from exc
+    if "ticker" not in payload:
+        payload = {**payload, "ticker": ticker}
+    return payload
+
+
+def _load_stock_decompose(
+    subject_id: str, as_of: str
+) -> tuple[dict[str, Any], str]:
+    """Load a single-name decompose payload for stock panel artifacts."""
+    ticker = _ticker_from_stock_subject_id(subject_id)
+    payload = _fetch_decompose(ticker)
+    resolved = str(payload.get("data_as_of") or "").strip()
+    if not resolved:
+        resolved = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    if as_of != "latest" and as_of != resolved:
+        # Decompose is latest-only today; refuse mismatched historical pins.
+        raise HTTPException(
+            status_code=501,
+            detail=(
+                f"as_of={as_of!r} differs from decompose data_as_of={resolved!r}; "
+                f"historical stock panel as_of is not yet supported. "
+                f"Use as_of='latest' or as_of={resolved!r}."
+            ),
+        )
+    return payload, resolved
+
+
+def _resolve_stock_watchlist(
+    req: "ArtifactRenderRequest",
+) -> tuple[list[dict[str, Any]], str, str]:
+    """Inline watchlist: subject_payload.tickers → list of decompose payloads."""
+    if req.subject_payload is None:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "watchlist_er_stacked requires subject_payload.tickers "
+                "(list of US equity tickers)"
+            ),
+        )
+    tickers = req.subject_payload.get("tickers")
+    if not isinstance(tickers, list) or not tickers:
+        raise HTTPException(
+            status_code=400,
+            detail="subject_payload.tickers must be a non-empty list",
+        )
+    if len(tickers) > 12:
+        raise HTTPException(status_code=400, detail="at most 12 watchlist tickers")
+    payloads = [_fetch_decompose(str(t).strip().upper()) for t in tickers]
+    as_ofs = {str(p.get("data_as_of") or "") for p in payloads}
+    as_ofs.discard("")
+    if req.as_of == "latest":
+        resolved_as_of = (
+            next(iter(as_ofs))
+            if len(as_ofs) == 1
+            else datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        )
+    else:
+        resolved_as_of = req.as_of
+    # Stable subject id from ticker set
+    key = ",".join(sorted(str(t).strip().upper() for t in tickers))
+    digest = hashlib.sha256(key.encode("utf-8")).hexdigest()[:16]
+    resolved_subject_id = f"BW-STOCK-WATCHLIST-{digest}"
+    return payloads, resolved_subject_id, resolved_as_of
 
 
 def _render_bytes(mod: Any, data: Any, fmt: str) -> bytes:
@@ -398,6 +538,8 @@ def render_artifact(
     if subject_kind == "client_portfolio":
         # Subject data is supplied inline; cache key is payload-hash-derived.
         subject_data, resolved_subject_id, resolved_as_of = _resolve_client_portfolio(req)
+    elif subject_kind == "stock" and req.slug == "watchlist_er_stacked":
+        subject_data, resolved_subject_id, resolved_as_of = _resolve_stock_watchlist(req)
     elif subject_kind in _PRERENDERED_SUBJECT_KINDS:
         # No SDK loader in render-svc — cache-hit path works for pre-rendered
         # artifacts; cache miss raises 501 (live-render is Phase 2 follow-on).
@@ -405,7 +547,7 @@ def render_artifact(
             req, subject_kind
         )
     else:
-        # Loader-resolved path (fund today; etf to follow).
+        # Loader-resolved path (fund + stock today; etf to follow).
         subject_data, resolved_as_of = _load_subject_data(
             req.subject_id, subject_kind, req.as_of
         )


### PR DESCRIPTION
## Summary
- `GET /api/snapshot/{entity_kind}/{id}/panels/{slug}` (stock O.6 panels + `_full` GCS DD)
- SDK `snapshot_panel()`, OpenAPI, capabilities updates
- render-svc live stock `/decompose` loader
- Fix Next.js conflict: legacy DD lives under `[entity_kind]/route.ts` (not sibling `[ticker]`)

Depends on BWMACRO O.6 artifact PR (render-svc clones BWMACRO at image build).

## Test plan
- [ ] Vercel preview: `GET /api/snapshot/stock/CRM/panels/_full?format=png` (auth) → 200
- [ ] After render-svc redeploy: `…/panels/l3_explained_risk_hbar?format=png` → 200 PNG
- [ ] Legacy `GET /api/snapshot/CRM` still works
- [ ] `GET /api/snapshot/stock` alone → 400 with panel URL hint


Made with [Cursor](https://cursor.com)