### PR TITLE
feat(o6): dd_peer_dna@v1 Tier-1 prerender — bulk_dd_render --panels + dd_ route branch

### DIFF
--- a/OPENAPI_SPEC.yaml
+++ b/OPENAPI_SPEC.yaml
@@ -6760,7 +6760,11 @@ paths:
         render-svc `POST /artifacts/render`. Stock panels:
         `l3_explained_risk_hbar`, `hedge_notionals_hbar`, `hedge_depth_retained`,
         `watchlist_er_stacked` (pass `tickers=CRM,MSFT,NVDA`), and `_full` (composed
-        DD page from GCS). See BWMACRO `docs/architecture/SNAPSHOT_CANONICAL_PROCESS_ADR.md`.
+        DD page from GCS). Institutional DD figure units (`dd_peer_dna`, more to
+        follow) are batch pre-rendered for a hot ticker cohort — same pixels as the
+        institutional letter page; outside the cohort the route returns 501 with a
+        pointer to `_full` and a request path (email service@riskmodels.app to have
+        a ticker added). See BWMACRO `docs/architecture/SNAPSHOT_CANONICAL_PROCESS_ADR.md`.
 
         **Billing:** `portfolio-risk-snapshot` ($0.25; cache hits may be $0).
       operationId: getSnapshotPanel

--- a/app/api/snapshot/[entity_kind]/[id]/panels/[slug]/route.ts
+++ b/app/api/snapshot/[entity_kind]/[id]/panels/[slug]/route.ts
@@ -32,6 +32,10 @@ const STOCK_PANEL_SLUGS = new Set([
   "hedge_notionals_hbar",
   "hedge_depth_retained",
   "watchlist_er_stacked",
+  // Institutional DD figure units — Tier-1 batch pre-rendered
+  // (bulk_dd_render --panels); render-svc serves the GCS cache and returns
+  // an actionable 501 for tickers outside the hot cohort.
+  "dd_peer_dna",
   "_full",
 ]);
 

--- a/mcp/data/openapi.json
+++ b/mcp/data/openapi.json
@@ -9722,7 +9722,7 @@
     "/snapshot/{entity_kind}/{id}/panels/{slug}": {
       "get": {
         "summary": "Snapshot panel drill-down (artifact PNG/JSON)",
-        "description": "Addressable panel from the Artifact Registry (O.6). Product alias onto render-svc `POST /artifacts/render`. Stock panels: `l3_explained_risk_hbar`, `hedge_notionals_hbar`, `hedge_depth_retained`, `watchlist_er_stacked` (pass `tickers=CRM,MSFT,NVDA`), and `_full` (composed DD page from GCS). See BWMACRO `docs/architecture/SNAPSHOT_CANONICAL_PROCESS_ADR.md`.\n**Billing:** `portfolio-risk-snapshot` ($0.25; cache hits may be $0).\n",
+        "description": "Addressable panel from the Artifact Registry (O.6). Product alias onto render-svc `POST /artifacts/render`. Stock panels: `l3_explained_risk_hbar`, `hedge_notionals_hbar`, `hedge_depth_retained`, `watchlist_er_stacked` (pass `tickers=CRM,MSFT,NVDA`), and `_full` (composed DD page from GCS). Institutional DD figure units (`dd_peer_dna`, more to follow) are batch pre-rendered for a hot ticker cohort — same pixels as the institutional letter page; outside the cohort the route returns 501 with a pointer to `_full` and a request path (email service@riskmodels.app to have a ticker added). See BWMACRO `docs/architecture/SNAPSHOT_CANONICAL_PROCESS_ADR.md`.\n**Billing:** `portfolio-risk-snapshot` ($0.25; cache hits may be $0).\n",
         "operationId": "getSnapshotPanel",
         "tags": [
           "Risk Metrics"

--- a/sdk/riskmodels/client.py
+++ b/sdk/riskmodels/client.py
@@ -1977,6 +1977,9 @@ class RiskModelsClient:
 
         Stock panels (O.6): ``l3_explained_risk_hbar``, ``hedge_notionals_hbar``,
         ``hedge_depth_retained``, ``watchlist_er_stacked``, ``_full`` (DD page).
+        Institutional DD figure units (``dd_peer_dna``, …) are batch
+        pre-rendered for a hot ticker cohort; outside it the route returns
+        501 with a request path (service@riskmodels.app).
 
         Args:
             entity_kind: ``stock`` | ``fund`` | ``filer_13f`` | …

--- a/sdk/scripts/bulk_dd_render.py
+++ b/sdk/scripts/bulk_dd_render.py
@@ -236,6 +236,8 @@ def _render_one(
     resume: bool,
     force: bool = False,
     renderer: str = "public",
+    panels: bool = False,
+    panels_gcs_root: str | None = None,
 ) -> dict:
     """Render one ticker's DD to PNG + PDF. Returns a status dict for the log.
 
@@ -309,6 +311,7 @@ def _render_one(
                 )
 
         tdir.mkdir(parents=True, exist_ok=True)
+        panel_status: dict | None = None
         with _MATPLOTLIB_RENDER_LOCK:
             if renderer == "institutional":
                 dd = DDData(
@@ -326,6 +329,9 @@ def _render_one(
                     judgment = None
                 render_dd_to_png(dd, png, judgment=judgment)
                 render_dd_to_pdf(dd, pdf, judgment=judgment)
+                # Same DDData, same lock (matplotlib is not thread-safe) —
+                # panel pixels match the letter page by construction.
+                panel_status = _emit_dd_panels(dd, tdir, ticker, panels_gcs_root) if panels else None
             else:
                 snap = from_components(
                     p1,
@@ -369,6 +375,8 @@ def _render_one(
         }
         if peer_error:
             out["peer_error"] = peer_error
+        if panel_status is not None:
+            out["panels"] = panel_status
         return out
     except Exception as exc:
         return {
@@ -378,6 +386,63 @@ def _render_one(
             "error": str(exc),
             "traceback": traceback.format_exc().splitlines()[-3:],
         }
+
+
+# DD registry panels emitted per ticker when --panels is on (institutional
+# renderer only — they consume the same in-memory DDData as the letter page,
+# so panel pixels match the page by construction). Keys mirror render-svc's
+# artifact cache (`{root}/artifacts/{slug}@{version}/{subject_id}/{as_of}.{fmt}`)
+# plus a `latest.*` alias so `as_of=latest` resolves without a loader.
+# See BWMACRO docs/ceo/DD_PANEL_REGISTRY_EXPOSE_PROJECT.md (Tier-1 cohort).
+_DD_PANEL_SLUGS: tuple[tuple[str, str], ...] = (
+    ("dd_peer_dna", "v1"),
+)
+
+
+def _emit_dd_panels(
+    dd,
+    tdir: Path,
+    ticker: str,
+    panels_gcs_root: str | None,
+) -> dict:
+    """Render + upload registry DD panels from the in-memory ``DDData``.
+
+    Returns a status dict folded into the ticker row: per-slug ok/error,
+    upload state. Never raises — a panel failure must not fail the page
+    render that already succeeded.
+    """
+    import importlib
+    import json as _json
+
+    teo = dd.teo
+    subject_id = f"BW-STOCK-{ticker}"
+    status: dict = {"emitted": [], "errors": {}}
+    for slug, version in _DD_PANEL_SLUGS:
+        try:
+            mod = importlib.import_module(f"bwmacro.snapshots.artifacts.{slug}.{version}")
+            png = mod.render_png_bytes(dd)
+            data = _json.dumps(mod.render_data(dd), separators=(",", ":")).encode("utf-8")
+
+            local_dir = tdir / "panels" / f"{slug}@{version}"
+            local_dir.mkdir(parents=True, exist_ok=True)
+            (local_dir / f"{teo}.png").write_bytes(png)
+            (local_dir / f"{teo}.json").write_bytes(data)
+
+            if panels_gcs_root:
+                key_root = f"{panels_gcs_root.rstrip('/')}/artifacts/{slug}@{version}/{subject_id}"
+                for fmt in ("png", "json"):
+                    local = local_dir / f"{teo}.{fmt}"
+                    for key in (f"{teo}.{fmt}", f"latest.{fmt}"):
+                        subprocess.run(
+                            ["gcloud", "storage", "cp", str(local), f"{key_root}/{key}"],
+                            check=True, capture_output=True, text=True,
+                        )
+            status["emitted"].append(f"{slug}@{version}")
+        except subprocess.CalledProcessError as e:
+            status["errors"][f"{slug}@{version}"] = f"upload: {e.stderr}"[:300]
+        except Exception as exc:  # noqa: BLE001 — panel failure must not fail the page
+            status["errors"][f"{slug}@{version}"] = f"{type(exc).__name__}: {exc}"[:300]
+    return status
 
 
 def _rsync_out_dir_to_gcs(out_dir: Path, gcs_bucket: str) -> tuple[bool, str]:
@@ -503,9 +568,37 @@ def main() -> int:
             "DD_Snapshots code location)."
         ),
     )
+    ap.add_argument(
+        "--panels",
+        action="store_true",
+        help=(
+            "Also emit registry DD panels (dd_peer_dna@v1, …) per ticker from "
+            "the same in-memory DDData as the letter page, and upload them to "
+            "the render-svc artifact cache keys (+ a latest.* alias). "
+            "Institutional renderer only. Intended for the Tier-1 hot cohort "
+            "(~100 tickers, ~seconds/ticker marginal) — see BWMACRO "
+            "docs/ceo/DD_PANEL_REGISTRY_EXPOSE_PROJECT.md before running it "
+            "over a full universe."
+        ),
+    )
+    ap.add_argument(
+        "--panels-gcs-root",
+        default="gs://rm_api_data/snapshots",
+        help=(
+            "GCS root for panel artifact keys "
+            "({root}/artifacts/{slug}@{version}/BW-STOCK-{T}/{as_of}.{fmt}). "
+            "Must match render-svc RENDER_SVC_BUCKET/RENDER_SVC_PREFIX. "
+            "Pass an empty string to keep panels local-only."
+        ),
+    )
     ap.add_argument("--dry-run", action="store_true",
                     help="Resolve the ticker list, print the count + first 10, exit.")
     args = ap.parse_args()
+
+    if args.panels and args.renderer != "institutional":
+        print("FAIL: --panels requires --renderer institutional (panels wrap the "
+              "private DDData figure units)", file=sys.stderr)
+        return 2
 
     sys.path.insert(0, str(_SDK_ROOT))
 
@@ -648,6 +741,7 @@ def main() -> int:
                     ticker, args.out_dir, args.zarr_root,
                     upload_gcs=per_ticker_upload, gcs_bucket=args.gcs_bucket,
                     resume=args.resume, force=args.force, renderer=args.renderer,
+                    panels=args.panels, panels_gcs_root=args.panels_gcs_root or None,
                 )
                 _log_result(row, i, logf)
         else:
@@ -664,6 +758,7 @@ def main() -> int:
                         _render_one, t, args.out_dir, args.zarr_root,
                         upload_gcs=per_ticker_upload, gcs_bucket=args.gcs_bucket,
                         resume=args.resume, force=args.force, renderer=args.renderer,
+                        panels=args.panels, panels_gcs_root=args.panels_gcs_root or None,
                     ): (i, t)
                     for i, t in enumerate(tickers, start=1)
                 }

--- a/services/render-svc/RUNBOOK.md
+++ b/services/render-svc/RUNBOOK.md
@@ -209,6 +209,36 @@ file /tmp/nvda.png
 
 ---
 
+## Stock-panel API key (O.6 live decompose loader)
+
+The stock panel route (`GET /api/snapshot/stock/{id}/panels/{slug}`) needs
+`RISKMODELS_API_KEY` in the render-svc environment to make its internal
+`POST /api/decompose` call (`render_svc/artifacts.py::_fetch_decompose`).
+Without it the route 503s with "RISKMODELS_API_KEY not configured".
+
+Wired 2026-07-14 (revision `render-svc-00021-gkn`):
+
+- **SSOT:** Doppler `erm3/prd` → `RENDER_SVC_RISKMODELS_API_KEY`
+- **Runtime:** GCP Secret Manager secret `render-svc-riskmodels-api-key`,
+  mounted on the service as env var `RISKMODELS_API_KEY`
+  (`--update-secrets RISKMODELS_API_KEY=render-svc-riskmodels-api-key:latest`);
+  `render-svc@` SA has `secretmanager.secretAccessor` on it.
+
+**Rotation:**
+
+```bash
+doppler secrets set RENDER_SVC_RISKMODELS_API_KEY --project erm3 --config prd   # update SSOT
+doppler secrets get RENDER_SVC_RISKMODELS_API_KEY --project erm3 --config prd --plain \
+  | gcloud secrets versions add render-svc-riskmodels-api-key --data-file=-
+gcloud run services update render-svc --region us-central1 \
+  --update-secrets RISKMODELS_API_KEY=render-svc-riskmodels-api-key:latest      # new revision picks up :latest
+```
+
+Current value is an operator key; replace with a dedicated service key when
+one is minted (tracked under MASTER_BACKLOG O.6).
+
+---
+
 ## Monitoring + rollback
 
 - **Logs:** Cloud Run console → Logs (or `gcloud run services logs tail render-svc`)

--- a/services/render-svc/render_svc/artifacts.py
+++ b/services/render-svc/render_svc/artifacts.py
@@ -534,12 +534,22 @@ def render_artifact(
     rationale.
     """
     subject_kind = _resolve_subject_kind(req.subject_id)
+    is_dd_panel = subject_kind == "stock" and req.slug.startswith("dd_")
 
     if subject_kind == "client_portfolio":
         # Subject data is supplied inline; cache key is payload-hash-derived.
         subject_data, resolved_subject_id, resolved_as_of = _resolve_client_portfolio(req)
     elif subject_kind == "stock" and req.slug == "watchlist_er_stacked":
         subject_data, resolved_subject_id, resolved_as_of = _resolve_stock_watchlist(req)
+    elif is_dd_panel:
+        # Institutional DD figure units (dd_peer_dna@v1, …) — Tier-1 batch
+        # pre-rendered by `bulk_dd_render --panels` (same in-memory DDData as
+        # the letter page); no live loader here (DDData needs the private
+        # zarr path). `as_of=latest` resolves via the batch-written
+        # `latest.{fmt}` alias key, refreshed each batch run — so unlike
+        # the loaderless subject kinds below, `latest` is allowed.
+        # See BWMACRO docs/ceo/DD_PANEL_REGISTRY_EXPOSE_PROJECT.md.
+        subject_data, resolved_subject_id, resolved_as_of = None, req.subject_id, req.as_of
     elif subject_kind in _PRERENDERED_SUBJECT_KINDS:
         # No SDK loader in render-svc — cache-hit path works for pre-rendered
         # artifacts; cache miss raises 501 (live-render is Phase 2 follow-on).
@@ -570,6 +580,22 @@ def render_artifact(
         )
 
     # Cache miss → live render.
+    if is_dd_panel:
+        # Tier-2 contract: not pre-rendered → explicit error with the full-page
+        # pointer AND the request path. Misses are the demand signal for
+        # widening the Tier-1 cohort.
+        ticker = _ticker_from_stock_subject_id(req.subject_id)
+        raise HTTPException(
+            status_code=501,
+            detail=(
+                f"{req.slug}@{req.version} is not pre-rendered for {ticker} "
+                f"(institutional DD panels are batch-rendered for a hot ticker "
+                f"cohort only). The full institutional page is at "
+                f"https://www.riskmodels.org/snapshots/{ticker.lower()}_dd_latest.png. "
+                f"To have {ticker} added to the panel cohort, email "
+                f"service@riskmodels.app."
+            ),
+        )
     if subject_kind in _PRERENDERED_SUBJECT_KINDS:
         # No SDK loader inside render-svc means the adapter has no subject
         # data to consume. Pre-render the artifact (LANDING daily refresh for

--- a/services/render-svc/tests/test_artifacts.py
+++ b/services/render-svc/tests/test_artifacts.py
@@ -718,3 +718,73 @@ class TestFilerAdapterRouting:
             _adapter_for("not_yet_widened_slug", "filer_13f")
         assert exc.value.status_code == 501
         assert "BWMACRO adapters.py" in str(exc.value.detail)
+
+
+class TestDdPanelPrerendered:
+    """Institutional DD figure units (dd_* stock slugs) — Tier-1 batch
+    pre-rendered by ``bulk_dd_render --panels``; render-svc has no DDData
+    loader, so cache-hit serves and cache-miss returns the actionable 501
+    (full-page pointer + service@riskmodels.app request path)."""
+
+    def _dd_req(self, **overrides):
+        base = dict(
+            slug="dd_peer_dna",
+            version="v1",
+            subject_id="BW-STOCK-NVDA",
+            as_of="latest",
+            format="png",
+        )
+        base.update(overrides)
+        return ArtifactRenderRequest(**base)
+
+    def test_latest_alias_cache_hit(self, store):
+        """`as_of=latest` reads the batch-written latest.png alias key —
+        no stock decompose loader call, no bwmacro import."""
+        path = _artifact_gcs_path(
+            PREFIX, "dd_peer_dna", "v1", "BW-STOCK-NVDA", "latest", "png"
+        )
+        store.write(path, b"\x89PNG-dd-panel", content_type="image/png")
+        raw, mime, gcs_path, resolved_as_of, cache_control, _rid = render_artifact(
+            self._dd_req(), store=store, prefix=PREFIX,
+        )
+        assert raw == b"\x89PNG-dd-panel"
+        assert mime == "image/png"
+        assert gcs_path == path
+        assert resolved_as_of == "latest"
+        assert "max-age=3600" in cache_control
+
+    def test_explicit_as_of_cache_hit_immutable(self, store):
+        path = _artifact_gcs_path(
+            PREFIX, "dd_peer_dna", "v1", "BW-STOCK-NVDA", "2026-05-07", "png"
+        )
+        store.write(path, b"\x89PNG-vintage", content_type="image/png")
+        raw, _mime, _p, resolved_as_of, cache_control, _rid = render_artifact(
+            self._dd_req(as_of="2026-05-07"), store=store, prefix=PREFIX,
+        )
+        assert raw == b"\x89PNG-vintage"
+        assert resolved_as_of == "2026-05-07"
+        assert "immutable" in cache_control
+
+    def test_cache_miss_returns_tier2_501(self, store):
+        """Tier-2 contract: miss → 501 with the _full pointer and the
+        service@riskmodels.app request path (the demand signal)."""
+        from fastapi import HTTPException
+        with pytest.raises(HTTPException) as exc:
+            render_artifact(
+                self._dd_req(subject_id="BW-STOCK-ZZZC"), store=store, prefix=PREFIX,
+            )
+        assert exc.value.status_code == 501
+        detail = str(exc.value.detail)
+        assert "zzzc_dd_latest.png" in detail
+        assert "service@riskmodels.app" in detail
+
+    def test_json_form_served_from_cache(self, store):
+        path = _artifact_gcs_path(
+            PREFIX, "dd_peer_dna", "v1", "BW-STOCK-NVDA", "latest", "json"
+        )
+        store.write(path, b'{"slug":"dd_peer_dna"}', content_type="application/json")
+        raw, mime, *_rest = render_artifact(
+            self._dd_req(format="json"), store=store, prefix=PREFIX,
+        )
+        assert json.loads(raw)["slug"] == "dd_peer_dna"
+        assert mime == "application/json"


### PR DESCRIPTION
## Summary

Serving side of the DD panel expose project (BWMACRO [`DD_PANEL_REGISTRY_EXPOSE_PROJECT.md`](https://github.com/BlueWaterCorp/BWMACRO/blob/main/docs/ceo/DD_PANEL_REGISTRY_EXPOSE_PROJECT.md); **paired with BWMACRO #72**):

- **`bulk_dd_render --panels` / `--panels-gcs-root`**: emits registry DD panels (`dd_peer_dna@v1`, list in `_DD_PANEL_SLUGS`) per ticker from the *same in-memory DDData* as the letter page (same matplotlib lock → same pixels), uploading PNG+JSON to render-svc's artifact cache keys **plus a `latest.*` alias**. Institutional-renderer-only guard; panel failures never fail the page render. Intended for the Tier-1 hot cohort (~100 tickers, ~seconds/ticker marginal) — not the full universe (cost tiers in the plan doc).
- **render-svc `dd_` branch**: stock `dd_*` slugs resolve as prerendered — `as_of=latest` allowed (reads the batch-written alias; 1h cache), explicit dates immutable. Cache miss returns the **Tier-2 501**: full-page `_full` pointer **+ "email service@riskmodels.app to have this ticker added"** (miss = demand signal).
- Panel route allowlist + OpenAPI (`+ mcp/data/openapi.json` mirror) + SDK `snapshot_panel` docstring: `dd_peer_dna`.
- RUNBOOK: "Stock-panel API key" section — Doppler `erm3/prd` SSOT → GSM `render-svc-riskmodels-api-key` → Cloud Run env; rotation flow. (Deployed today as rev `render-svc-00021-gkn`, fixing the 503 the O.6 route shipped with.)

## Test plan
- `cd services/render-svc && PYTHONPATH=. ./.venv/bin/python -m pytest tests/test_artifacts.py` — **46/46** (4 new `TestDdPanelPrerendered`: latest-alias hit, explicit-date immutable hit, Tier-2 501 message contract, JSON form)
- First live batch run gated on the ext_2t zarr refresh (BWMACRO handoff `docs/ceo/handoffs/2026-07-14-o6-dd-panels-zarr-refresh.md`); render-svc image redeploy needed for the `dd_` branch to go live

🤖 Generated with [Claude Code](https://claude.com/claude-code)