### PR TITLE
fix(data-license): apply raw-field gate to remaining surfaces

### DIFF
--- a/app/api/batch/analyze/route.ts
+++ b/app/api/batch/analyze/route.ts
@@ -416,8 +416,6 @@ async function analyzeTicker(
         [
           // Core
           "vol_23d",
-          "price_close",
-          "market_cap",
           "stock_var",
           // L1
           "l1_mkt_hr",
@@ -527,8 +525,6 @@ async function analyzeTicker(
           l1_mkt_beta: m?.l1_mkt_beta ?? null,
           l2_sec_beta: m?.l2_sec_beta ?? null,
           l3_sub_beta: m?.l3_sub_beta ?? null,
-          market_cap: m?.market_cap ?? null,
-          close_price: m?.price_close ?? null,
         };
       }
 

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -177,6 +177,8 @@ const chatHandler = async (request: NextRequest, context: BillingContext) => {
         allowParallelOpenAI: backend.allowParallel && bodyParallelToolCalls !== false,
         omitParallelToolCalls: backend.omitParallelToolCalls,
         execParallel: !bodyExecSequential,
+        // withBilling-gated: an authenticated environment per Exhibit B(e).
+        rawFieldsPermitted: true,
       });
     } catch (e) {
       if (e instanceof AgentUpstreamError) {
@@ -327,6 +329,8 @@ const chatStreamHandler = async (
               backend.allowParallel && bodyParallelToolCalls !== false,
             omitParallelToolCalls: backend.omitParallelToolCalls,
             execParallel: !bodyExecSequential,
+            // withBilling-gated: an authenticated environment per Exhibit B(e).
+            rawFieldsPermitted: true,
           },
           (event) => {
             if (event.type === "final") return; // re-emitted enriched below

--- a/app/api/data/symbols/search/route.ts
+++ b/app/api/data/symbols/search/route.ts
@@ -2,6 +2,7 @@ import { NextResponse, type NextRequest } from "next/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { verifyGatewayAuth } from "@/lib/gateway-auth";
 import { TICKER_ALIASES } from "@/lib/ticker-aliases";
+import { filterSafeMetadata } from "@/lib/dal/symbol-metadata";
 
 export const dynamic = "force-dynamic";
 
@@ -64,5 +65,24 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: "Internal error" }, { status: 500 });
   }
 
-  return NextResponse.json({ results: data ?? [] });
+  // Same normalization as /symbols/{ticker} and /symbols/batch: the raw
+  // metadata JSONB carries licensed identifiers, so it never ships whole.
+  const results = (data ?? []).map((row) => {
+    const metadata = (row.metadata as Record<string, unknown>) ?? {};
+    return {
+      symbol: row.symbol,
+      ticker: row.ticker,
+      name: row.name ?? (metadata.company_name as string | null) ?? null,
+      asset_type: row.asset_type,
+      sector_etf: row.sector_etf ?? (metadata.sector_etf as string | null) ?? null,
+      subsector_etf: row.subsector_etf,
+      is_adr: row.is_adr,
+      metadata: filterSafeMetadata(row.metadata),
+      latest_metrics: row.latest_metrics,
+      latest_vol: row.latest_vol,
+      latest_teo: row.latest_teo,
+    };
+  });
+
+  return NextResponse.json({ results });
 }

--- a/app/api/landing/chat/route.ts
+++ b/app/api/landing/chat/route.ts
@@ -195,6 +195,9 @@ export async function POST(request: NextRequest) {
       maxCompletionTokens: LANDING_MAX_TOKENS,
       allowedToolNames: ALLOWED_TOOLS,
       skipBilling: true,
+      // Unauthenticated demo: Exhibit B(e) permits raw close/market cap only in
+      // authenticated environments, so tool results are stripped to derived.
+      rawFieldsPermitted: false,
       preFlightGuard: mag7Guard,
       execParallel: true,
       allowParallelOpenAI: backend.allowParallel,

--- a/app/api/landing/concentration/route.ts
+++ b/app/api/landing/concentration/route.ts
@@ -69,7 +69,6 @@ type PortfolioBlock = {
 type ConcentrationTicker = {
   ticker: string;
   name: string | null;
-  market_cap: number | null;
   l3_mkt_er: number;
   l3_sec_er: number;
   l3_sub_er: number;
@@ -180,7 +179,6 @@ export async function GET(request: NextRequest) {
         perTicker[ticker] = {
           ticker,
           name: sym.name ?? WALKTHROUGH_MAG7_NAMES[ticker] ?? null,
-          market_cap: cap,
           l3_mkt_er: mkt,
           l3_sec_er: sec,
           l3_sub_er: sub,

--- a/app/api/og/[ticker]/route.tsx
+++ b/app/api/og/[ticker]/route.tsx
@@ -19,7 +19,7 @@ import {
 export const runtime = "nodejs";
 
 const OG_METRIC_KEYS: V3MetricKey[] = [
-  "vol_23d", "price_close", "market_cap",
+  "vol_23d",
   "l3_mkt_hr", "l3_sec_hr", "l3_sub_hr",
   "l3_mkt_er", "l3_sec_er", "l3_sub_er", "l3_res_er",
 ];
@@ -54,14 +54,6 @@ function fmtHR(v: number | null | undefined): string {
   return v.toFixed(2);
 }
 
-function fmtCap(v: number | null | undefined): string {
-  if (v == null) return "—";
-  if (v >= 1e12) return `$${(v / 1e12).toFixed(1)}T`;
-  if (v >= 1e9) return `$${(v / 1e9).toFixed(1)}B`;
-  if (v >= 1e6) return `$${(v / 1e6).toFixed(1)}M`;
-  return `$${v.toLocaleString()}`;
-}
-
 // ── Route Handler ───────────────────────────────────────────────────────
 export async function GET(
   request: Request,
@@ -70,7 +62,8 @@ export async function GET(
   const { ticker: rawTicker } = await params;
   const ticker = rawTicker.toUpperCase();
 
-  // Fetch metrics directly from DAL (no auth needed)
+  // Fetch metrics directly from DAL. This card is public and unauthenticated,
+  // so it carries derived metrics only — no raw close/market cap.
   const symbolRecord = await resolveSymbolByTicker(ticker);
   const latest = symbolRecord
     ? await fetchLatestMetricsWithFallback(symbolRecord.symbol, OG_METRIC_KEYS, "daily")
@@ -79,8 +72,6 @@ export async function GET(
   const m = (latest?.metrics ?? {}) as Record<string, number | null>;
 
   const vol = m.vol_23d;
-  const price = m.price_close;
-  const marketCap = m.market_cap;
   const teo = latest?.teo ?? "—";
   const subsectorEtf = symbolRecord?.subsector_etf ?? symbolRecord?.sector_etf ?? "—";
 
@@ -187,8 +178,6 @@ export async function GET(
               marginBottom: "32px",
             }}
           >
-            <MetricRow label="Price" value={price != null ? `$${price.toFixed(2)}` : "—"} />
-            <MetricRow label="Market Cap" value={fmtCap(marketCap)} />
             <MetricRow label="Vol (23d)" value={fmtPct(vol)} />
             <MetricRow
               label="Residual α"

--- a/app/legal/page.tsx
+++ b/app/legal/page.tsx
@@ -21,6 +21,12 @@ const sections = [
       'Risk estimates, decompositions, hedge ratios, and other analytics are model-driven outputs based on historical and third-party data. These outputs may be incomplete, delayed, inaccurate, or unsuitable for a particular use case. Past performance and historical relationships do not guarantee future results.',
   },
   {
+    title: 'Data Sources and Attribution',
+    summary: 'Analytics are derived works; underlying market data is licensed from third parties.',
+    body:
+      'RiskModels analytics are derived outputs computed by Blue Water Macro Corp. from a combination of public filings (U.S. Securities and Exchange Commission EDGAR) and licensed third-party market data. End-of-day pricing, market capitalization, corporate fundamentals, and reference classification data are sourced in part from EOD Historical Data (Unicorn Data Services SAS). Third-party data is provided under license, remains the property of its respective provider, and may not be extracted, redistributed, or used to reconstruct the underlying data feed.',
+  },
+  {
     title: 'No Warranty; Use at Your Own Risk',
     summary: 'We do not promise the API or its outputs are error-free or fit for your purpose.',
     body:

--- a/app/ticker/[symbol]/page.tsx
+++ b/app/ticker/[symbol]/page.tsx
@@ -32,8 +32,6 @@ interface TickerMetrics {
   teo: string;
   sector_etf: string | null;
   subsector_etf: string | null;
-  market_cap: number | null;
-  price_close: number | null;
   vol_23d: number | null;
   l3_mkt_hr: number | null;
   l3_sec_hr: number | null;
@@ -56,7 +54,7 @@ const BASE_URL = process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000";
 
 const METRIC_KEYS: V3MetricKey[] = [
   "returns_gross",
-  "vol_23d", "price_close", "market_cap",
+  "vol_23d",
   "l3_mkt_hr", "l3_sec_hr", "l3_sub_hr",
   "l3_mkt_er", "l3_sec_er", "l3_sub_er", "l3_res_er",
   "l1_fr", "l2_fr", "l3_fr", "l3_rr",
@@ -95,8 +93,6 @@ async function getTickerMetrics(ticker: string): Promise<TickerMetrics | null> {
       teo: latest.teo,
       sector_etf: symbolRecord.sector_etf,
       subsector_etf: symbolRecord.subsector_etf || symbolRecord.sector_etf,
-      market_cap: m.market_cap ?? null,
-      price_close: m.price_close ?? null,
       vol_23d: m.vol_23d ?? null,
       l3_mkt_hr: m.l3_mkt_hr ?? null,
       l3_sec_hr: m.l3_sec_hr ?? null,
@@ -151,22 +147,6 @@ function fmtPct(v: unknown, decimals = 1): string {
   if (v == null) return "—";
   const n = Number(v);
   return isNaN(n) ? "—" : `${(n * 100).toFixed(decimals)}%`;
-}
-
-function fmtNum(v: unknown, decimals = 2): string {
-  if (v == null) return "—";
-  const n = Number(v);
-  return isNaN(n) ? "—" : n.toFixed(decimals);
-}
-
-function fmtCap(v: unknown): string {
-  if (v == null) return "—";
-  const n = Number(v);
-  if (isNaN(n)) return "—";
-  if (n >= 1e12) return `$${(n / 1e12).toFixed(1)}T`;
-  if (n >= 1e9) return `$${(n / 1e9).toFixed(1)}B`;
-  if (n >= 1e6) return `$${(n / 1e6).toFixed(1)}M`;
-  return `$${n.toLocaleString()}`;
 }
 
 /** Daily simple return as ±bps for small moves */
@@ -273,8 +253,6 @@ export default async function TickerDashboard({
       {/* ── Metric Cards ────────────────────────────────────────── */}
       <section className="max-w-6xl mx-auto px-8 py-8">
         <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 gap-4">
-          <MetricCard label="Last Price" value={`$${fmtNum(metrics.price_close)}`} />
-          <MetricCard label="Market Cap" value={fmtCap(metrics.market_cap)} />
           <MetricCard label="Vol (23d)" value={fmtPct(vol)} />
           <MetricCard label="L3 Res ER (α)" value={fmtPct(resER)} accent />
           <MetricCard label="Subsector" value={subEtf} />

--- a/components/landing/PortfolioConcentration.tsx
+++ b/components/landing/PortfolioConcentration.tsx
@@ -47,7 +47,6 @@ const DEFAULT_HEDGED: LayerKey[] = ["market", "sector"];
 interface ConcentrationTicker {
   ticker: string;
   name: string | null;
-  market_cap: number | null;
   l3_mkt_er: number;
   l3_sec_er: number;
   l3_sub_er: number;
@@ -181,27 +180,25 @@ function ChartBody({ data }: { data: ConcentrationPayload }) {
   const { tickers, per_ticker, portfolios, cap_etf_hedges, notional_usd } = data;
   const cap = portfolios.cap_weighted;
 
+  // Cap weights come from the API already normalized — the raw market caps
+  // they derive from are licensed and are not sent to the browser.
   const capRows = useMemo<CapRow[]>(() => {
-    const totalCap = tickers.reduce(
-      (sum, t) => sum + (per_ticker[t]?.market_cap ?? 0),
-      0,
-    );
-    if (totalCap <= 0) return [];
+    const capWeights = cap?.weights;
+    if (!capWeights) return [];
     return tickers
       .map((t) => {
         const row = per_ticker[t];
-        const c = row?.market_cap ?? 0;
         return {
           ticker: t,
           name: row?.name ?? null,
-          capWeight: c / totalCap,
+          capWeight: capWeights[t] ?? 0,
           sigma: row?.sigma ?? 0,
           shares: normalizeShares(row),
         };
       })
       .filter((r) => r.capWeight > 0)
       .sort((a, b) => b.capWeight - a.capWeight);
-  }, [tickers, per_ticker]);
+  }, [tickers, per_ticker, cap]);
 
   const sigmaMaxTicker = capRows.reduce((m, r) => Math.max(m, r.sigma), 0);
   const sharedSigmaMax = niceCeil5(Math.max(sigmaMaxTicker, cap?.sigma_naive ?? 0) * 1.06);

--- a/lib/chat/agent-runner.ts
+++ b/lib/chat/agent-runner.ts
@@ -35,6 +35,8 @@ export interface RunChatAgentOptions {
   openai?: OpenAI;
   /** Skip per-tool deductBalance (keyless demo). */
   skipBilling?: boolean;
+  /** Serve raw close/market cap (Exhibit B(e): authenticated callers only). */
+  rawFieldsPermitted?: boolean;
   /** Reject tool calls whose args fail this gate (e.g. non-MAG7 ticker). */
   preFlightGuard?: (toolName: string, parsedArgs: unknown) => string | null;
   /** Optional cancellation; checked between rounds and passed to provider round-trips. */
@@ -262,6 +264,7 @@ async function runOpenAIChatAgent(
     allowParallelOpenAI = true,
     omitParallelToolCalls = false,
     skipBilling = false,
+    rawFieldsPermitted = false,
     preFlightGuard,
     signal,
   } = opts;
@@ -392,6 +395,7 @@ async function runOpenAIChatAgent(
       userId,
       requestId,
       skipBilling,
+      rawFieldsPermitted,
       preFlightGuard,
     });
 

--- a/lib/chat/anthropic-agent.ts
+++ b/lib/chat/anthropic-agent.ts
@@ -87,6 +87,7 @@ export async function runAnthropicChatAgent(
     allowedToolNames,
     execParallel = true,
     skipBilling = false,
+    rawFieldsPermitted = false,
     preFlightGuard,
     signal,
   } = opts;
@@ -218,6 +219,7 @@ export async function runAnthropicChatAgent(
       userId,
       requestId,
       skipBilling,
+      rawFieldsPermitted,
       preFlightGuard,
     });
     for (const r of results) {

--- a/lib/chat/tool-executor.ts
+++ b/lib/chat/tool-executor.ts
@@ -2,6 +2,7 @@ import type { ChatCompletionMessageToolCall } from "openai/resources/chat/comple
 import { deductBalance } from "@/lib/agent/billing";
 import { calculateRequestCost } from "@/lib/agent/capabilities";
 import { TOOL_MAP, type ChatToolDef } from "@/lib/chat/tools";
+import { getDataLicenseMode, stripRawRestrictedDeep } from "@/lib/data-license";
 
 export interface ToolCallResult {
   tool_call_id: string;
@@ -20,6 +21,12 @@ export interface ExecuteToolCallsOptions {
   requestId: string;
   /** When true, skip deductBalance (keyless demo / landing proxy). */
   skipBilling?: boolean;
+  /**
+   * Exhibit B(e) condition (1): raw close/market cap may only be served in an
+   * authenticated environment. Defaults to false so any new caller fails
+   * closed; authenticated, billed chat routes opt in explicitly.
+   */
+  rawFieldsPermitted?: boolean;
   /**
    * Optional per-call arg gate. Return a string to reject with that error
    * message; return null to allow. Runs after Zod parse, before executor.
@@ -48,6 +55,7 @@ async function runOneTool(
     userId: string;
     requestId: string;
     skipBilling?: boolean;
+    rawFieldsPermitted?: boolean;
     preFlightGuard?: (toolName: string, parsedArgs: unknown) => string | null;
   },
 ): Promise<ToolCallResult> {
@@ -149,6 +157,12 @@ async function runOneTool(
     }
   }
 
+  // Gate 1 (EODHD Exhibit B(e)) for the chat surface. license_free mode
+  // withholds raw fields from every caller, authenticated or not.
+  if (!ctx.rawFieldsPermitted || getDataLicenseMode() === "license_free") {
+    result = stripRawRestrictedDeep(result);
+  }
+
   let costUsd = 0;
   if (def.capabilityId && !ctx.skipBilling) {
     costUsd = calculateRequestCost(def.capabilityId);
@@ -198,8 +212,9 @@ export async function executeToolCalls(
   toolCalls: ChatCompletionMessageToolCall[],
   options: ExecuteToolCallsOptions,
 ): Promise<ToolCallResult[]> {
-  const { parallel = true, userId, requestId, skipBilling, preFlightGuard } = options;
-  const ctx = { userId, requestId, skipBilling, preFlightGuard };
+  const { parallel = true, userId, requestId, skipBilling, rawFieldsPermitted, preFlightGuard } =
+    options;
+  const ctx = { userId, requestId, skipBilling, rawFieldsPermitted, preFlightGuard };
 
   if (!parallel) {
     const out: ToolCallResult[] = [];

--- a/lib/data-license.ts
+++ b/lib/data-license.ts
@@ -98,6 +98,27 @@ export function stripRawRestricted<T extends Record<string, unknown>>(row: T): T
   return out;
 }
 
+/**
+ * Recursively drop raw, license-restricted fields from an arbitrary value.
+ *
+ * The chat surface returns nested tool results — raw fields sit under
+ * `metrics.price_close` on one tool and across a `data[].price_close` series on
+ * another — so a shallow strip is not enough. Used to serve the unauthenticated
+ * landing demo, where Exhibit B(e) condition (1) is not met for any raw field.
+ */
+export function stripRawRestrictedDeep<T>(value: T): T {
+  if (Array.isArray(value)) {
+    return value.map((v) => stripRawRestrictedDeep(v)) as unknown as T;
+  }
+  if (value === null || typeof value !== "object") return value;
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+    if (RAW_RESTRICTED_KEYS.has(k)) continue;
+    out[k] = stripRawRestrictedDeep(v);
+  }
+  return out as T;
+}
+
 /* ------------------------------------------------------------------------- *
  * GATE 2 — CRSP-sourced symbols (symbol-level, unconditional in BOTH modes).
  *

--- a/tests/data-license.test.ts
+++ b/tests/data-license.test.ts
@@ -11,6 +11,7 @@ import {
   rawEodhdPermitted,
   requestsRawRestricted,
   stripRawRestricted,
+  stripRawRestrictedDeep,
   stripRawSeries,
 } from "@/lib/data-license";
 
@@ -45,6 +46,48 @@ describe("EODHD data-license policy", () => {
   it("strips raw fields but keeps derived columns", () => {
     const row = { symbol: "AAPL", price_close: 200, market_cap: 3e12, l1_mkt_hr: 0.9 };
     expect(stripRawRestricted(row)).toEqual({ symbol: "AAPL", l1_mkt_hr: 0.9 });
+  });
+
+  describe("stripRawRestrictedDeep (chat tool results)", () => {
+    it("strips raw fields nested under an object", () => {
+      const result = {
+        ticker: "AAPL",
+        teo: "2026-07-15",
+        metrics: { vol_23d: 0.28, price_close: 200, market_cap: 3e12, l3_res_er: 0.4 },
+      };
+      expect(stripRawRestrictedDeep(result)).toEqual({
+        ticker: "AAPL",
+        teo: "2026-07-15",
+        metrics: { vol_23d: 0.28, l3_res_er: 0.4 },
+      });
+    });
+
+    it("strips raw fields across every row of a history series", () => {
+      const result = {
+        ticker: "AAPL",
+        data: [
+          { date: "2026-07-14", returns_gross: 0.01, price_close: 198 },
+          { date: "2026-07-15", returns_gross: -0.02, price_close: 200 },
+        ],
+      };
+      expect(stripRawRestrictedDeep(result)).toEqual({
+        ticker: "AAPL",
+        data: [
+          { date: "2026-07-14", returns_gross: 0.01 },
+          { date: "2026-07-15", returns_gross: -0.02 },
+        ],
+      });
+    });
+
+    it("keeps returns_gross — Derived Data under the EODHD terms", () => {
+      expect(stripRawRestrictedDeep({ returns_gross: 0.01 })).toEqual({ returns_gross: 0.01 });
+    });
+
+    it("passes through primitives, null, and arrays of scalars", () => {
+      expect(stripRawRestrictedDeep(null)).toBeNull();
+      expect(stripRawRestrictedDeep("AAPL")).toBe("AAPL");
+      expect(stripRawRestrictedDeep([1, 2, 3])).toEqual([1, 2, 3]);
+    });
   });
 
   describe("isGatewayAuthenticated", () => {


### PR DESCRIPTION
## What

`lib/data-license.ts` already encodes the raw-vs-derived field policy correctly. It was only imported by 6 of ~130 route files. This extends it to the surfaces that bypassed it.

Raw close / market cap serve only in **authenticated, per-symbol** contexts. Everything else is derived and unrestricted.

| Surface | Before | After |
|---|---|---|
| `/ticker/{symbol}` | public page rendered Last Price + Market Cap | derived metrics only (page + SEO value unchanged) |
| `/api/og/{ticker}` | public PNG rendered price + market cap | derived metrics only |
| `POST /api/batch/analyze` | raw close + market cap across up to 100 symbols, CSV/Parquet | no raw fields in multi-symbol responses |
| chat tools | raw fields returned to the anonymous landing demo | new `rawFieldsPermitted` flag, **fails closed**; authenticated `/api/chat` opts in |
| `/api/data/symbols/search` | returned raw `metadata` JSONB (licensed identifiers) | `filterSafeMetadata()`, matching its two sibling routes |
| `/api/landing/concentration` | emitted raw market cap | emits normalized cap weights (raw caps stay server-side as a derived input) |
| `/legal` | no upstream attribution | names upstream data sources |

## Notes

- `stripRawRestrictedDeep()` is new: chat tool results nest raw fields under `metrics.*` and across `data[].*` series, so a shallow strip wasn't enough.
- `DATA_LICENSE_MODE=license_free` now covers the chat surface too.
- The concentration chart is unchanged visually — the browser previously recomputed cap weights from raw caps; the API already computed the same normalized weights, so it now sends those.

## Test

- `tests/data-license.test.ts` extended for the deep strip (nested object, series rows, `returns_gross` retained as derived, primitives).
- 513 tests pass, `tsc --noEmit` clean, lint clean.
- Not verified against live data locally: `.env.local` carries legacy Supabase keys disabled 2026-07-06, so the DAL can't resolve tickers on this machine. Worth a preview-deploy click on `/ticker/NVDA` + `/api/og/NVDA` before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)