### PR TITLE
fix(data-license): published demo key serves derived data only

### DIFF
--- a/app/api/metrics/[ticker]/route.ts
+++ b/app/api/metrics/[ticker]/route.ts
@@ -95,7 +95,7 @@ async function computeVol252dAnnualised(
 }
 
 export const GET = withBilling(
-  async (request: NextRequest, _context: BillingContext) => {
+  async (request: NextRequest, context: BillingContext) => {
     const rawTicker = request.nextUrl.pathname.split("/").pop();
     const origin = request.headers.get("origin");
 
@@ -250,12 +250,14 @@ export const GET = withBilling(
       },
     );
 
-    // GATE 2 (CRSP derived-only symbol) / GATE 1 license_free mode: the raw
-    // latest-day close and market cap scalars are withheld (nulled); every
-    // derived metric below is unaffected.
+    // GATE 2 (CRSP derived-only symbol) / GATE 1 license_free mode / Exhibit
+    // B(e)(1) (the published shared demo key is not an authenticated
+    // environment): the raw latest-day close and market cap scalars are
+    // withheld (nulled); every derived metric below is unaffected.
     const rawScalarsPermitted =
       !isRestrictedSourceSymbol(symbolRecord.symbol) &&
-      getDataLicenseMode() !== "license_free";
+      getDataLicenseMode() !== "license_free" &&
+      context.rawFieldsPermitted;
 
     const formattedData = {
       symbol: symbolRecord.symbol,

--- a/app/api/ticker-returns/route.ts
+++ b/app/api/ticker-returns/route.ts
@@ -72,9 +72,15 @@ export const GET = withBilling(
     // raw EODHD close for everyone; returns_gross stays (Derived Data under
     // Exhibit B) except for CRSP symbols, where the return path IS the
     // licensed series.
+    // Exhibit B(e)(1) also withholds the close series from the published shared
+    // demo key — a credential lifted from a public text file is not an
+    // authenticated environment. returns_gross is Derived and still serves.
     const restrictedSource = isRestrictedSourceSymbol(symbolRecord.symbol);
     const serveReturns = !restrictedSource;
-    const servePrice = !restrictedSource && getDataLicenseMode() !== "license_free";
+    const servePrice =
+      !restrictedSource &&
+      getDataLicenseMode() !== "license_free" &&
+      context.rawFieldsPermitted;
 
     // ETFs live in ds_etf.zarr and have no L1/L2/L3 decomposition. Only request
     // daily-role keys for them — the hedge/returns zarr stores don't carry ETF

--- a/lib/agent/billing-middleware.ts
+++ b/lib/agent/billing-middleware.ts
@@ -20,6 +20,7 @@ import {
 import { createPaymentRequiredResponse, createMonthlyCapExceededResponse } from "./errors";
 import { generateRequestId, logTelemetry } from "./telemetry";
 import { extractApiKey, validateApiKey } from "./api-keys";
+import { isPublicSampleKey } from "@/lib/data-license";
 import { authenticateRequest } from "@/lib/supabase/auth-helper";
 import { Ratelimit } from "@upstash/ratelimit";
 import { Redis } from "@upstash/redis";
@@ -271,6 +272,14 @@ export interface BillingContext {
   costUsd: number;
   startTime: number;
   apiKey?: string;
+  /**
+   * Exhibit B(e) condition (1). False when the caller presented the SHARED demo
+   * key published in /llms.txt — a credential anyone can copy out of a public
+   * text file is not an authenticated environment, so raw close/market cap are
+   * withheld from it. Required (not optional) so every construction site has to
+   * decide rather than defaulting open.
+   */
+  rawFieldsPermitted: boolean;
   tier?: "free" | "paid" | "enterprise";
   freeTierStatus?: any;
   /** First-party gateway traffic — unlimited internal allowance (no 402/deduct). */
@@ -354,6 +363,9 @@ export function withBilling(
         capabilityId: options.capabilityId,
         costUsd: 0,
         startTime,
+        // Free/unmetered endpoints (search, badge, Plaid link) serve derived
+        // data only; none reads a raw field. Fail closed.
+        rawFieldsPermitted: false,
       };
 
       const response = await handler(req, context);
@@ -713,6 +725,9 @@ export function withBilling(
         costUsd,
         startTime,
         apiKey,
+        // The published /llms.txt demo key authenticates in form only — anyone
+        // can lift it from a public file — so it serves derived data only.
+        rawFieldsPermitted: !isPublicSampleKey(apiKey),
         tier: freeTierCheck?.tier,
         freeTierStatus: freeTierCheck,
         internalUnlimited,
@@ -1062,6 +1077,7 @@ export async function createBillingContext(
       capabilityId,
       costUsd,
       startTime,
+      rawFieldsPermitted: !isPublicSampleKey(extractedKey),
     },
   };
 }

--- a/lib/api/fundamentals-contract.ts
+++ b/lib/api/fundamentals-contract.ts
@@ -1,10 +1,10 @@
 /**
  * Response contract for GET /api/fundamentals/{ticker} — LICENSING IS THE SPEC.
  *
- * The backing store's raw line items are EODHD-primary and are NOT cleared for
- * redistribution (EODHD Exhibit B; H.69 counsel question pending). Only derived
- * analytics plus Exhibit B(e) fields ship. This module is the single place that
- * decides what leaves the server:
+ * The backing store's raw line items are vendor-primary, so they stay internal.
+ * What ships is derived analytics, the Exhibit B(e) fields, and SEC-sourced
+ * facts gated per cell. This module is the single place that decides what
+ * leaves the server:
  *
  * - `FUNDAMENTALS_ROW_ALLOWED_FIELDS` is a strict allowlist enforced by
  *   `sanitizeFundamentalsRow` on every row at the serialization boundary.
@@ -69,7 +69,8 @@ export type FundamentalsRowField = (typeof FUNDAMENTALS_ROW_ALLOWED_FIELDS)[numb
  *    `eps_actual`, `total_debt` (a roll-up), `shares_outstanding_q` (lives in the shares layer).
  *  - `eps_estimate` and forecast/rating fields — no-investment-advice house rule (also in
  *    SEC_FACT_DENY so they cannot enter sec_facts either).
- *  - `earnings_surprise`, `book_value_per_share` — gray pending counsel.
+ *  - `earnings_surprise`, `book_value_per_share` — withheld out of caution; they may only move
+ *    to the allowlist via the SEC-promotion rule above.
  */
 export const FUNDAMENTALS_HELD_BACK_FIELDS = [
   // EODHD-only, no clean SEC raw exposure
@@ -83,7 +84,7 @@ export const FUNDAMENTALS_HELD_BACK_FIELDS = [
   "revenue_forecast",
   "analyst_rating",
   "target_price",
-  // gray pending counsel
+  // withheld out of caution — promote only via the SEC-sourced rule
   "earnings_surprise",
   "book_value_per_share",
   // derived, exposed only as the computed `fcf_margin` ratio, never as a raw flat plane

--- a/lib/data-license.ts
+++ b/lib/data-license.ts
@@ -76,6 +76,26 @@ export function isGatewayAuthenticated(request: NextRequest): boolean {
 }
 
 /**
+ * True when the presented API key is the SHARED demo credential published in
+ * /llms.txt (`LLMS_TXT_PUBLIC_AGENT_KEY`).
+ *
+ * Exhibit B(e) condition (1) requires an *authenticated environment*. A key
+ * printed verbatim in a public text file is authentication in form only —
+ * anyone can lift it — so raw close/mktcap are withheld from it. The derived
+ * surface it does reach is what the agent-discovery demo actually needs.
+ *
+ * Keyed on the same env var that causes the key to be published, and mirroring
+ * buildLlmsTxt()'s own length guard, so the two cannot drift: if it appears in
+ * llms.txt, it is derived-only, by construction.
+ */
+export function isPublicSampleKey(apiKey?: string | null): boolean {
+  const published = process.env.LLMS_TXT_PUBLIC_AGENT_KEY?.trim();
+  if (!published || published.length <= 10) return false;
+  const presented = apiKey?.trim();
+  return Boolean(presented) && presented === published;
+}
+
+/**
  * GATE 1 decision: may raw EODHD fields (close/mktcap) be served on THIS
  * request? Standard mode: yes when gateway-authenticated (Exhibit B(e)
  * condition 1). License-free mode: never, for anyone — use this instead of

--- a/lib/llms-txt.ts
+++ b/lib/llms-txt.ts
@@ -131,6 +131,9 @@ function appendPublicSampleKey(baseUrl: string, plainKey: string): string {
     `When this block appears, the host has enabled a **shared** demo credential (Doppler / Vercel: \`LLMS_TXT_PUBLIC_AGENT_KEY\`). ` +
     `It is intended for documentation and agent smoke tests on the **Magnificent 7** listed above (**${mag7Csv}**). ` +
     `It is rate-limited and may be rotated without notice; for production or the full ~3k universe, use a personal key from https://riskmodels.app/get-key .\n\n` +
+    `Because this key is shared and published, it returns **derived analytics only** — risk decomposition, ` +
+    `hedge ratios, factor exposures, volatility, and returns. Raw last-close and market-cap fields come back ` +
+    `\`null\`; a personal key returns them.\n\n` +
     `Public MAG7 ticker array from the API (no auth; symbols may show GOOGL):\n\n` +
     `curl -sS "${baseUrl}/api/tickers?mag7=true"\n\n` +
     `RISKMODELS_API_KEY=${trimmed}\n\n` +

--- a/tests/data-license.test.ts
+++ b/tests/data-license.test.ts
@@ -7,6 +7,7 @@ import {
   dropRawSeriesKeys,
   getDataLicenseMode,
   isGatewayAuthenticated,
+  isPublicSampleKey,
   isRestrictedSourceSymbol,
   rawEodhdPermitted,
   requestsRawRestricted,
@@ -113,6 +114,38 @@ describe("EODHD data-license policy", () => {
       delete process.env.RISKMODELS_API_SERVICE_KEY;
       expect(isGatewayAuthenticated(reqWithAuth(null))).toBe(true);
     });
+  });
+});
+
+describe("published /llms.txt demo key is not an authenticated environment", () => {
+  const ORIG = process.env.LLMS_TXT_PUBLIC_AGENT_KEY;
+  afterEach(() => {
+    if (ORIG === undefined) delete process.env.LLMS_TXT_PUBLIC_AGENT_KEY;
+    else process.env.LLMS_TXT_PUBLIC_AGENT_KEY = ORIG;
+  });
+
+  it("flags the exact published key", () => {
+    process.env.LLMS_TXT_PUBLIC_AGENT_KEY = "rm_agent_live_publishedkey123";
+    expect(isPublicSampleKey("rm_agent_live_publishedkey123")).toBe(true);
+    expect(isPublicSampleKey(" rm_agent_live_publishedkey123 ")).toBe(true); // tolerates whitespace
+  });
+
+  it("does not flag a personal key", () => {
+    process.env.LLMS_TXT_PUBLIC_AGENT_KEY = "rm_agent_live_publishedkey123";
+    expect(isPublicSampleKey("rm_agent_live_someuserskey456")).toBe(false);
+    expect(isPublicSampleKey(undefined)).toBe(false);
+    expect(isPublicSampleKey(null)).toBe(false);
+    expect(isPublicSampleKey("")).toBe(false);
+  });
+
+  it("flags nothing when no key is published", () => {
+    delete process.env.LLMS_TXT_PUBLIC_AGENT_KEY;
+    expect(isPublicSampleKey("rm_agent_live_anything")).toBe(false);
+  });
+
+  it("mirrors buildLlmsTxt's length guard — a too-short value is never published, so never flagged", () => {
+    process.env.LLMS_TXT_PUBLIC_AGENT_KEY = "short";
+    expect(isPublicSampleKey("short")).toBe(false);
   });
 });
 

--- a/tests/fundamentals-route.test.ts
+++ b/tests/fundamentals-route.test.ts
@@ -51,6 +51,7 @@ const fakeContext: BillingContext = {
   capabilityId: "fundamentals",
   costUsd: 0.005,
   startTime: Date.now(),
+  rawFieldsPermitted: true,
 };
 
 const METADATA = {

--- a/tests/funds-cohort-routes.test.ts
+++ b/tests/funds-cohort-routes.test.ts
@@ -30,6 +30,7 @@ const fakeContext: BillingContext = {
   capabilityId: "style-cohort-metrics",
   costUsd: 0.005,
   startTime: Date.now(),
+  rawFieldsPermitted: true,
 };
 
 function req(path: string): NextRequest {

--- a/tests/funds-cohort-zarr-routes.test.ts
+++ b/tests/funds-cohort-zarr-routes.test.ts
@@ -33,6 +33,7 @@ const fakeContext: BillingContext = {
   capabilityId: "style-cohort-portfolio-history",
   costUsd: 0.005,
   startTime: Date.now(),
+  rawFieldsPermitted: true,
 };
 
 function req(path: string): NextRequest {

--- a/tests/funds-hedge-route.test.ts
+++ b/tests/funds-hedge-route.test.ts
@@ -58,6 +58,7 @@ const fakeContext: BillingContext = {
   capabilityId: "fund-hedge",
   costUsd: 0.005,
   startTime: Date.now(),
+  rawFieldsPermitted: true,
 };
 
 function req(path: string): NextRequest {

--- a/tests/funds-holdings-route.test.ts
+++ b/tests/funds-holdings-route.test.ts
@@ -64,6 +64,7 @@ const fakeContext: BillingContext = {
   capabilityId: "fund-holdings",
   costUsd: 0.005,
   startTime: Date.now(),
+  rawFieldsPermitted: true,
 };
 
 function req(path: string): NextRequest {

--- a/tests/funds-metrics-route.test.ts
+++ b/tests/funds-metrics-route.test.ts
@@ -77,6 +77,7 @@ const fakeContext = {
   capabilityId: "fund-metrics",
   costUsd: 0.005,
   startTime: Date.now(),
+  rawFieldsPermitted: true,
 };
 
 function req(path: string): NextRequest {

--- a/tests/funds-nav-route.test.ts
+++ b/tests/funds-nav-route.test.ts
@@ -57,6 +57,7 @@ const fakeContext: BillingContext = {
   capabilityId: "fund-nav-history",
   costUsd: 0.005,
   startTime: Date.now(),
+  rawFieldsPermitted: true,
 };
 
 function req(path: string): NextRequest {

--- a/tests/funds-portfolio-route.test.ts
+++ b/tests/funds-portfolio-route.test.ts
@@ -66,6 +66,7 @@ const fakeContext: BillingContext = {
   capabilityId: "fund-portfolio-history",
   costUsd: 0.005,
   startTime: Date.now(),
+  rawFieldsPermitted: true,
 };
 
 function req(path: string): NextRequest {

--- a/tests/funds-snapshot-routes.test.ts
+++ b/tests/funds-snapshot-routes.test.ts
@@ -76,6 +76,7 @@ const fakeContext: BillingContext = {
   capabilityId: "fund-snapshot-json",
   costUsd: 0.01,
   startTime: Date.now(),
+  rawFieldsPermitted: true,
 };
 
 function req(path: string): NextRequest {

--- a/tests/lstar-style-axis-removed.test.ts
+++ b/tests/lstar-style-axis-removed.test.ts
@@ -58,6 +58,7 @@ const fakeContext: BillingContext = {
   capabilityId: "lstar",
   costUsd: 0.02,
   startTime: Date.now(),
+  rawFieldsPermitted: true,
 };
 
 describe("GET /api/lstar — axis=style removed (H.92)", () => {


### PR DESCRIPTION
Closes backlog V.8 and V.12. Follow-up to #252 / #253.

## V.8 — the published key

`LLMS_TXT_PUBLIC_AGENT_KEY` is set in prod, so `/llms.txt` publishes a working Bearer token **plus copy-paste curl loops against `/api/metrics/{ticker}` and `/api/ticker-returns`** — the two endpoints that serve raw last-close and market cap. A credential printed in a public text file is authentication in form only: anyone can lift it. That made "authenticated environment" nominal.

The demo doesn't need raw fields — it needs to show the analytics. So the key now serves **derived only** (decomposition, hedge ratios, factor exposures, volatility, returns); `price_close` / `market_cap` return `null`. Personal keys are unaffected.

`isPublicSampleKey()` keys off **the same env var that publishes the key**, and mirrors `buildLlmsTxt()`'s own `length > 10` guard. The two can't drift — if it's in llms.txt, it's derived-only, by construction. Nothing to remember to keep in sync.

`/llms.txt` now says so up front rather than letting an agent discover it via nulls.

### Why `rawFieldsPermitted` is required, not optional

Optional + `!== false` would fail **open** — a new construction site that forgets it serves raw. That's the exact bug class #253 exists to prevent. Making it required means the compiler asks the question. It surfaced a third construction site (`createBillingContext`) I'd otherwise have missed. Free/unmetered endpoints fail closed; none of them read a raw field.

## V.12 — public-repo hygiene

`lib/api/fundamentals-contract.ts` narrated *"H.69 counsel question pending"* on a live, billing endpoint — in a public repo. The field-level governance there is genuinely good; the comment just advertised an unresolved legal question to anyone reading our GitHub. Header now states the rule. Same for two "gray pending counsel" notes on fields we already withhold.

No behavior change from V.12 — comments only.

## Test

- 4 new cases: exact key match (+ whitespace), personal key not flagged, nothing flagged when unpublished, and a too-short value (never published → never flagged, mirroring the publish guard).
- 517 pass, `tsc --noEmit` clean, both license guards pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)