### PR TITLE
fix(f1): realized_strips metrics carry total_vol_ann from the gross strip

### DIFF
--- a/sdk/riskmodels/snapshots/_fund_data.py
+++ b/sdk/riskmodels/snapshots/_fund_data.py
@@ -11,6 +11,7 @@ shares backed by RiskModels Supabase reads; pip consumers work without keys.
 
 from __future__ import annotations
 
+import datetime as _dt
 import logging
 from dataclasses import dataclass, field, replace
 from pathlib import Path
@@ -80,7 +81,27 @@ def _realized_variance_shares(
     total = sum(clamped.values())
     if not (total > 1e-12):
         return None
-    return {k: v / total for k, v in clamped.items()}
+    shares = {k: v / total for k, v in clamped.items()}
+
+    # Annualized total vol from the SAME gross strip the shares come from —
+    # internally consistent with the decomposition (unlike the published-NAV
+    # fit vol, which is also absent entirely for synthetic composites, leaving
+    # the F1 Active Risk Composition panel blank). Cadence inferred from the
+    # median teo spacing so quarterly-filing series annualize correctly.
+    periods_per_year = 12.0
+    try:
+        teos = [_dt.date.fromisoformat(str(t[0])[:10]) for t in layer_series]
+        gaps = sorted(
+            (teos[i + 1] - teos[i]).days for i in range(len(teos) - 1)
+        )
+        if gaps:
+            med_gap = float(gaps[len(gaps) // 2])
+            if med_gap > 0:
+                periods_per_year = min(365.25 / med_gap, 252.0)
+    except (ValueError, TypeError):
+        pass
+    shares["total_vol_ann"] = float((g_var ** 0.5) * (periods_per_year ** 0.5))
+    return shares
 
 
 # ---------------------------------------------------------------------------
@@ -1454,6 +1475,7 @@ def get_data_for_f1(
             "l2_sector_er":    realized["sector"],
             "l3_subsector_er": realized["subsector"],
             "l3_residual_er":  realized["residual"],
+            "total_vol_ann":   realized.get("total_vol_ann", 0.0),
             "_basis":          "realized_strips",
         }
         # "Recent" window = trailing slice of the same realized series, when
@@ -1468,6 +1490,7 @@ def get_data_for_f1(
                     "l2_sector_er":    realized_recent["sector"],
                     "l3_subsector_er": realized_recent["subsector"],
                     "l3_residual_er":  realized_recent["residual"],
+                    "total_vol_ann":   realized_recent.get("total_vol_ann", 0.0),
                     "_basis":          "realized_strips_recent",
                 }
 

--- a/sdk/tests/test_realized_fund_variance_shares.py
+++ b/sdk/tests/test_realized_fund_variance_shares.py
@@ -44,9 +44,12 @@ def test_shares_sum_to_one_and_largest_amplitude_dominates():
         rows.append((m, s, u, r))
     out = _realized_variance_shares(_series(rows))
     assert out is not None
-    assert sum(out.values()) == pytest.approx(1.0, abs=1e-9)
-    for v in out.values():
-        assert 0.0 <= v <= 1.0
+    LAYERS = ("market", "sector", "subsector", "residual")
+    assert sum(out[k] for k in LAYERS) == pytest.approx(1.0, abs=1e-9)
+    for k in LAYERS:
+        assert 0.0 <= out[k] <= 1.0
+    # Annualized total vol rides along, from the same gross strip.
+    assert out["total_vol_ann"] > 0.0
     assert out["market"] > out["sector"]
     assert out["market"] > out["subsector"]
     assert out["market"] > out["residual"]
@@ -79,4 +82,4 @@ def test_negative_hedging_layer_clamped_and_renormalized():
     out = _realized_variance_shares(_series(rows))
     assert out is not None
     assert out["residual"] == 0.0
-    assert sum(out.values()) == pytest.approx(1.0, abs=1e-9)
+    assert sum(out[k] for k in ("market", "sector", "subsector", "residual")) == pytest.approx(1.0, abs=1e-9)


### PR DESCRIPTION
The F1 Active Risk Composition panel scales layer ER shares by total vol. That vol previously came only from `fund_fit.parquet` (`fit_nav_vol_5y`) — absent for synthetic composite entities, so their panel rendered blank.

`_realized_variance_shares` now also returns `total_vol_ann`, computed from the same gross strip the shares derive from (annualization inferred from median teo spacing, capped at daily). `portfolio_metrics` / `portfolio_metrics_recent` carry it through; the renderer already prefers `pm.total_vol_ann` and falls back to the NAV-fit vol.

SDK pytest 479 passed; vitest 517 passed; existing share invariants unchanged (tests updated for the new key + a total_vol_ann assertion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)