### PR TITLE
fix(docs): G.25 methodology and status URL alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ RiskModels provides clean dividend-adjusted total returns, factor risk decomposi
 
 This repository is the **authoritative public API reference** for the [RiskModels](https://riskmodels.net) equity risk model API, featuring:
 
-- 📖 **Model methodology (wiki)** — [ERM3 L3 overview](https://riskmodels.net/docs/methodology/erm3-l3) (same URI as API `wiki_uri` in response metadata)
+- 📖 **Model methodology** — [ERM3 overview](https://riskmodels.app/docs/methodology) (canonical; also mirrored on [riskmodels.net](https://riskmodels.net/docs/methodology/erm3-l3))
 - 📚 **Comprehensive API Documentation** — OpenAPI 3.0.3 specification, guides, and examples
 - 🌐 **Developer Portal** — Beautiful Next.js site (this repo) deployed at **riskmodels.app**
 - 🐍 **Python & TypeScript Examples** — Production-ready code in `examples/`
@@ -25,7 +25,7 @@ This repository is the **authoritative public API reference** for the [RiskModel
 - **Python SDK — AOM quickstart (Google Colab):** [Open notebook](https://colab.research.google.com/github/BlueWaterCorp/RiskModels_API/blob/main/sdk/notebooks/riskmodels_aom_colab.ipynb) · source: [`sdk/notebooks/riskmodels_aom_colab.ipynb`](sdk/notebooks/riskmodels_aom_colab.ipynb)
 - **Developer Portal:** [riskmodels.app](https://riskmodels.app)
 - **Live API Docs:** [riskmodels.net/docs/api/erm3](https://riskmodels.net/docs/api/erm3)
-- **ERM3 methodology (wiki):** [riskmodels.net/docs/methodology/erm3-l3](https://riskmodels.net/docs/methodology/erm3-l3)
+- **ERM3 methodology:** [riskmodels.app/docs/methodology](https://riskmodels.app/docs/methodology)
 - **Get API Key:** [riskmodels.app/get-key](https://riskmodels.app/get-key)
 - **API Terms:** [riskmodels.net/terms/api](https://riskmodels.net/terms/api)
 - **Issues:** [github.com/BlueWaterCorp/RiskModels_API/issues](https://github.com/BlueWaterCorp/RiskModels_API/issues)
@@ -372,7 +372,7 @@ We welcome pull requests, especially to improve the **OpenAPI spec** — clearer
 
 - **API Support:** [service@riskmodels.app](mailto:service@riskmodels.app)
 - **Issues:** [github.com/BlueWaterCorp/RiskModels_API/issues](https://github.com/BlueWaterCorp/RiskModels_API/issues)
-- **Status:** [riskmodels.net/status](https://riskmodels.net/status)
+- **Status:** [riskmodels.net/status](https://riskmodels.net/status) · API metrics [riskmodels.app/api/status](https://riskmodels.app/api/status)
 
 ---
 

--- a/README_API.md
+++ b/README_API.md
@@ -192,4 +192,4 @@ Get your key at [riskmodels.net/settings](https://riskmodels.net/settings) → A
 - **Issues & feature requests:** [github.com/BlueWaterCorp/RiskModels_API/issues](https://github.com/BlueWaterCorp/RiskModels_API/issues)
 - **API support email:** [service@riskmodels.app](mailto:service@riskmodels.app)
 - **Interactive docs:** [riskmodels.net/docs/api/erm3](https://riskmodels.net/docs/api/erm3)
-- **Status:** [riskmodels.net/status](https://riskmodels.net/status)
+- **Status:** [riskmodels.net/status](https://riskmodels.net/status) · API metrics [riskmodels.app/api/status](https://riskmodels.app/api/status)

--- a/lib/agent/capabilities.ts
+++ b/lib/agent/capabilities.ts
@@ -109,7 +109,7 @@ export const CAPABILITIES: Capability[] = [
       data_quality_score: 0.98,
       update_frequency: "daily",
       sources: ["market_data", "proprietary_models", "erm3_regression"],
-      methodology_url: "https://riskmodels.net/docs/methodology",
+      methodology_url: "https://riskmodels.app/docs/methodology",
     },
     tags: ["returns", "hedging", "risk-analysis"],
     examples: [
@@ -246,7 +246,7 @@ export const CAPABILITIES: Capability[] = [
       data_quality_score: 0.99,
       update_frequency: "daily",
       sources: ["erm3_models", "factor_regression"],
-      methodology_url: "https://riskmodels.net/docs/l3-methodology",
+      methodology_url: "https://riskmodels.app/docs/methodology",
     },
     tags: ["risk-analysis", "decomposition", "factors"],
   },

--- a/lib/agent/response-utils.ts
+++ b/lib/agent/response-utils.ts
@@ -99,7 +99,7 @@ export function createAgentResponse(
           historical_coverage: 1.0
         },
         warnings: warnings,
-        methodology: 'https://riskmodels.net/docs/methodology'
+        methodology: 'https://riskmodels.app/docs/methodology'
       },
       alternatives: alternatives
     };
@@ -290,7 +290,7 @@ export function createAgentErrorResponse(
         capability_id: capabilityId,
         timestamp: new Date().toISOString(),
         support: 'service@riskmodels.app',
-        documentation: 'https://riskmodels.net/docs/api',
+        documentation: 'https://riskmodels.app/api-reference',
         ...additionalContext
       }
     },

--- a/mcp/data/capabilities.json
+++ b/mcp/data/capabilities.json
@@ -47,7 +47,7 @@
         "proprietary_models",
         "erm3_regression"
       ],
-      "methodology_url": "https://riskmodels.net/docs/methodology"
+      "methodology_url": "https://riskmodels.app/docs/methodology"
     },
     "tags": [
       "returns",
@@ -209,7 +209,7 @@
         "erm3_models",
         "factor_regression"
       ],
-      "methodology_url": "https://riskmodels.net/docs/l3-methodology"
+      "methodology_url": "https://riskmodels.app/docs/methodology"
     },
     "tags": [
       "risk-analysis",
@@ -691,7 +691,7 @@
   {
     "id": "fundamentals",
     "name": "Quarterly Fundamentals",
-    "description": "Point-in-time quarterly fundamentals for a single ticker: TTM profitability ratios (ROE, ROA, FCF margin), capital-return ratios (payout, retention, buyback, total payout, sustainable growth), leverage, ERM3 cascade betas with provenance, the cost-of-capital layer (cost of equity, cost of debt, book-weight WACC, economic profit), and an equity-bridge decomposition. sec_facts carries raw line items per cell where the serving value is SEC XBRL (revenue, net income, equity, cash flows, dividends, buybacks, etc.); vendor-sourced cells are not exposed as raw. Rows are visible iff filed_date <= as_of (never 'latest'). Realized historical data only — no forecasts, no analyst fields. Coverage starts ~2009 for most filers. Per-symbol per-call only; no batch variant.",
+    "description": "Point-in-time quarterly fundamentals for a single ticker: TTM profitability ratios (ROE, ROA, FCF margin), capital-return ratios (payout, retention, buyback, total payout, sustainable growth), leverage, ERM3 cascade betas with provenance, the cost-of-capital layer (cost of equity, cost of debt, book-weight WACC, economic profit), and an equity-bridge decomposition. sec_facts carries raw line items per cell where the serving value is SEC XBRL (revenue, net income, equity, cash flows, dividends, buybacks, etc.); vendor-sourced cells are not exposed as raw. Rows are visible iff filed_date <= as_of (never 'latest'). Realized historical data only \u2014 no forecasts, no analyst fields. Coverage starts ~2009 for most filers. Per-symbol per-call only; no batch variant.",
     "endpoint": "/api/fundamentals",
     "method": "GET",
     "parameters": {
@@ -756,7 +756,7 @@
   {
     "id": "hedge-basket",
     "name": "Hedge Basket",
-    "description": "Structured 4-leg hedge basket (stock + SPY + sector ETF + subsector ETF) with per-leg β-to-SPY contribution, net market β subtotal, marginal ERs, recommended_hedge_level, and a human-readable decision_trace narration. Replaces the easy-to-misread single 'Market HR (L3)' row in chat/SDK surfaces.",
+    "description": "Structured 4-leg hedge basket (stock + SPY + sector ETF + subsector ETF) with per-leg \u03b2-to-SPY contribution, net market \u03b2 subtotal, marginal ERs, recommended_hedge_level, and a human-readable decision_trace narration. Replaces the easy-to-misread single 'Market HR (L3)' row in chat/SDK surfaces.",
     "endpoint": "/api/hedge-basket",
     "method": "GET",
     "parameters": {
@@ -768,7 +768,7 @@
       "user_segment": {
         "type": "string",
         "required": false,
-        "description": "Drives leverage cap: retail (1.5×) | family_office (2.0× default) | ls_equity (3.0×) | stat_arb (5.0×)"
+        "description": "Drives leverage cap: retail (1.5\u00d7) | family_office (2.0\u00d7 default) | ls_equity (3.0\u00d7) | stat_arb (5.0\u00d7)"
       }
     },
     "pricing": {
@@ -914,7 +914,7 @@
   {
     "id": "industry-panel",
     "name": "Industry Panel",
-    "description": "Cross-section of Vasicek industry peer β statistics from ds_erm3_industry: beta_mean, beta_variance, n_companies, and total_log_mcap_weight by EODHD industry code and cascade level (market/sector/subsector).",
+    "description": "Cross-section of Vasicek industry peer \u03b2 statistics from ds_erm3_industry: beta_mean, beta_variance, n_companies, and total_log_mcap_weight by EODHD industry code and cascade level (market/sector/subsector).",
     "endpoint": "/api/industry-panel",
     "method": "GET",
     "parameters": {
@@ -1017,7 +1017,7 @@
       "limit": {
         "type": "integer",
         "required": false,
-        "description": "Max rows after filter (1–500, default 100)",
+        "description": "Max rows after filter (1\u2013500, default 100)",
         "default": 100
       }
     },
@@ -1186,7 +1186,7 @@
   {
     "id": "residual-signal",
     "name": "Residual Mean-Reversion Signal",
-    "description": "L3 orthogonal-residual 5-day mean-reversion factor. A combo-input building block for multi-signal alpha stacks — NOT a standalone strategy. Returns residual_z_5d, decile_rank, signal_quality_quintile (subsector-tracking conditioning), industry_percentile and a residual autocorrelation diagnostic. Every response carries an explicit gross-Sharpe + market-impact capacity disclosure.",
+    "description": "L3 orthogonal-residual 5-day mean-reversion factor. A combo-input building block for multi-signal alpha stacks \u2014 NOT a standalone strategy. Returns residual_z_5d, decile_rank, signal_quality_quintile (subsector-tracking conditioning), industry_percentile and a residual autocorrelation diagnostic. Every response carries an explicit gross-Sharpe + market-impact capacity disclosure.",
     "endpoint": "/api/residual-signal",
     "method": "GET",
     "parameters": {
@@ -1233,14 +1233,14 @@
   {
     "id": "residual-signal-basket",
     "name": "Residual Mean-Reversion Basket",
-    "description": "Aggregate the L3 residual mean-reversion signal across a user-defined basket of tickers (max 500). Returns the weighted aggregate of residual_z_5d / signal_strength / l3_subsector_er + decile and quality-quintile histograms + per-member rows. Equal-weight default; optional `weights[]` aligned to tickers; optional `signal_quality_min_quintile` gate (Phase B: gross Sharpe lifts from ~0.79 to ~1.28 at quintile 5). Tickers absent from ds_erm3_residual_signal are silently dropped — see `coverage.missing_tickers`. Combo-input building block, NOT a standalone strategy.",
+    "description": "Aggregate the L3 residual mean-reversion signal across a user-defined basket of tickers (max 500). Returns the weighted aggregate of residual_z_5d / signal_strength / l3_subsector_er + decile and quality-quintile histograms + per-member rows. Equal-weight default; optional `weights[]` aligned to tickers; optional `signal_quality_min_quintile` gate (Phase B: gross Sharpe lifts from ~0.79 to ~1.28 at quintile 5). Tickers absent from ds_erm3_residual_signal are silently dropped \u2014 see `coverage.missing_tickers`. Combo-input building block, NOT a standalone strategy.",
     "endpoint": "/api/signals/residual-reversion/basket",
     "method": "POST",
     "parameters": {
       "tickers": {
         "type": "array",
         "required": true,
-        "description": "1–500 tickers to aggregate.",
+        "description": "1\u2013500 tickers to aggregate.",
         "items": {
           "type": "string"
         }
@@ -1256,7 +1256,7 @@
       "signal_quality_min_quintile": {
         "type": "integer",
         "required": false,
-        "description": "Optional 1–5 gate on signal_quality_quintile. Members below this still appear in the response but don't contribute to the aggregate."
+        "description": "Optional 1\u20135 gate on signal_quality_quintile. Members below this still appear in the response but don't contribute to the aggregate."
       }
     },
     "pricing": {
@@ -1336,7 +1336,7 @@
   {
     "id": "etf-factor-returns",
     "name": "ETF Factor Returns (Public Scope)",
-    "description": "One-teo snapshot of close + trailing-window total returns (1d / 21d / 63d / 252d) for SPY + the 11 GICS sector SPDR ETFs (XLE/XLB/XLI/XLY/XLP/XLV/XLF/XLK/XLC/XLU/XLRE). Public scope only — the broader BWMACRO factor roster (subsectors, style, macro, broad-market) is NOT exposed here by design. Use this to pair with /industry-panel for the daily 'what's happening at the market and sector index level' read. Tickers outside the public scope return 400.",
+    "description": "One-teo snapshot of close + trailing-window total returns (1d / 21d / 63d / 252d) for SPY + the 11 GICS sector SPDR ETFs (XLE/XLB/XLI/XLY/XLP/XLV/XLF/XLK/XLC/XLU/XLRE). Public scope only \u2014 the broader BWMACRO factor roster (subsectors, style, macro, broad-market) is NOT exposed here by design. Use this to pair with /industry-panel for the daily 'what's happening at the market and sector index level' read. Tickers outside the public scope return 400.",
     "endpoint": "/api/etf/factor-returns",
     "method": "GET",
     "parameters": {
@@ -1495,7 +1495,7 @@
   },
   {
     "id": "portfolio-risk-snapshot",
-    "name": "Snapshot — portfolio or ticker",
+    "name": "Snapshot \u2014 portfolio or ticker",
     "description": "Canonical JSON snapshot via `POST /api/snapshot` for either a weighted portfolio (`type: \"portfolio\"`) or a single name (`type: \"ticker\"`, a shim over `/metrics` + `/decompose`): L3 explained-risk decomposition, hedge ratios, frozen-weight return attribution, cumulative return / drawdown, risk summary. Ticker mode also returns `snapshot.ticker_meta` with sector/subsector ETFs and the active L3 factor list. Also serves the bundled PDF/JSON via `POST /api/portfolio/risk-snapshot`. Single bundled charge per request; uses internal data access only (no double-billing).",
     "endpoint": "/api/portfolio/risk-snapshot",
     "method": "POST",
@@ -1589,7 +1589,7 @@
       "subject_id": {
         "type": "string",
         "required": true,
-        "description": "BW-STOCK-…, BW-FUND-…, BW-FILER-…, BW-PORTFOLIO-…, or BW-STOCK-WATCHLIST"
+        "description": "BW-STOCK-\u2026, BW-FUND-\u2026, BW-FILER-\u2026, BW-PORTFOLIO-\u2026, or BW-STOCK-WATCHLIST"
       },
       "as_of": {
         "type": "string",
@@ -1654,7 +1654,7 @@
       "factors": {
         "type": "array",
         "required": false,
-        "description": "Macro factor keys (inflation, term_spread, short_rates, credit, oil, gold, usd, volatility, bitcoin, vix_spot); default all ten. volatility=VXX futures, vix_spot=FRED VIXCLS — different series. Legacy aliases accepted (dxy→usd, vix→vix_spot, ust10y2y→term_spread)."
+        "description": "Macro factor keys (inflation, term_spread, short_rates, credit, oil, gold, usd, volatility, bitcoin, vix_spot); default all ten. volatility=VXX futures, vix_spot=FRED VIXCLS \u2014 different series. Legacy aliases accepted (dxy\u2192usd, vix\u2192vix_spot, ust10y2y\u2192term_spread)."
       },
       "return_type": {
         "type": "string",
@@ -1836,7 +1836,7 @@
   {
     "id": "fund-search",
     "name": "Fund Search & Discovery",
-    "description": "Search the funds universe by ticker, fund name, or equity style 9-box cohort. Returns a list of FundRow records (bw_fund_id, ticker, fund_name, equity_style_9box, asset_class, total_assets, etc.) for downstream calls to /api/funds/{bw_fund_id}/*. Free for users (no per-request cost) — discovery is intentionally unbilled so quants and agents can resolve a bw_fund_id without paying. Per-fund follow-up calls are metered.",
+    "description": "Search the funds universe by ticker, fund name, or equity style 9-box cohort. Returns a list of FundRow records (bw_fund_id, ticker, fund_name, equity_style_9box, asset_class, total_assets, etc.) for downstream calls to /api/funds/{bw_fund_id}/*. Free for users (no per-request cost) \u2014 discovery is intentionally unbilled so quants and agents can resolve a bw_fund_id without paying. Per-fund follow-up calls are metered.",
     "endpoint": "/api/funds/search",
     "method": "GET",
     "parameters": {
@@ -1892,7 +1892,7 @@
   {
     "id": "fund-metrics",
     "name": "Latest Fund Metrics",
-    "description": "Latest knowledge-mode portfolio return decomposition + diagnostics for a single mutual fund. Returns the gross / market / sector / subsector / idiosyncratic return components, the identity_residual, ERM3 universe coverage (weight_sum), n_holdings_active, effective_n (HHI-derived diversification), and top10_weight_sum. Resolves bw_fund_id against public.funds + public.funds_latest. Bitemporal lineage surfaces as X-Data-As-Of (report_date) and X-Data-Filing-Date headers; v1 returns the latest knowledge-mode answer only (no ?as_of= / ?mode= — deferred to v2).",
+    "description": "Latest knowledge-mode portfolio return decomposition + diagnostics for a single mutual fund. Returns the gross / market / sector / subsector / idiosyncratic return components, the identity_residual, ERM3 universe coverage (weight_sum), n_holdings_active, effective_n (HHI-derived diversification), and top10_weight_sum. Resolves bw_fund_id against public.funds + public.funds_latest. Bitemporal lineage surfaces as X-Data-As-Of (report_date) and X-Data-Filing-Date headers; v1 returns the latest knowledge-mode answer only (no ?as_of= / ?mode= \u2014 deferred to v2).",
     "endpoint": "/api/funds/{bw_fund_id}",
     "method": "GET",
     "parameters": {
@@ -2121,7 +2121,7 @@
   {
     "id": "style-cohort-metrics",
     "name": "Style Cohort Latest Metrics",
-    "description": "Latest portfolio return decomposition + diagnostics for one of the 9-box style cells, aggregated across all funds in the cell. Returns both equal-weight (EW) and market-value-weighted (MV) cohort portfolios side-by-side. Sourced from Slice 6's per-cell ds_portfolio.zarr (latest snapshot in style_portfolios_latest). The differentiated wedge — Morningstar reports per-fund metrics but doesn't expose cohort aggregates with this attribution depth.",
+    "description": "Latest portfolio return decomposition + diagnostics for one of the 9-box style cells, aggregated across all funds in the cell. Returns both equal-weight (EW) and market-value-weighted (MV) cohort portfolios side-by-side. Sourced from Slice 6's per-cell ds_portfolio.zarr (latest snapshot in style_portfolios_latest). The differentiated wedge \u2014 Morningstar reports per-fund metrics but doesn't expose cohort aggregates with this attribution depth.",
     "endpoint": "/api/funds/style/{slug}",
     "method": "GET",
     "parameters": {
@@ -2161,7 +2161,7 @@
   {
     "id": "style-cohort-rankings",
     "name": "Style Cohort Top-N Rankings",
-    "description": "Top-N rankings within a 9-box style cell × cohort_type × metric × period_window × weighting. cohort_type ∈ {symbol, sector, fund}. period_window ∈ {1m, 3m, 12m, 36m}. weighting ∈ {ew, mv} — ignored for cohort_type=fund (writer stores 'ew' placeholder). Top-N capped at 50 (Slice 9 storage ceiling).",
+    "description": "Top-N rankings within a 9-box style cell \u00d7 cohort_type \u00d7 metric \u00d7 period_window \u00d7 weighting. cohort_type \u2208 {symbol, sector, fund}. period_window \u2208 {1m, 3m, 12m, 36m}. weighting \u2208 {ew, mv} \u2014 ignored for cohort_type=fund (writer stores 'ew' placeholder). Top-N capped at 50 (Slice 9 storage ceiling).",
     "endpoint": "/api/funds/style/{slug}/rankings/{cohort_type}",
     "method": "GET",
     "parameters": {
@@ -2448,7 +2448,7 @@
   {
     "id": "style-cohort-snapshot-json",
     "name": "Style Cohort Snapshot (JSON)",
-    "description": "Composed JSON snapshot for a 9-box style cell — the differentiated wedge vs Morningstar. Bundles cohort metrics (EW + MV) + top-25 cohort holdings (MV) + 12-month cohort portfolio history (both weightings) + top-10 funds in cell + top-15 symbols in cell. Matching server-rendered PDF is /funds/style/{slug}/snapshot.pdf (Stage D.2).",
+    "description": "Composed JSON snapshot for a 9-box style cell \u2014 the differentiated wedge vs Morningstar. Bundles cohort metrics (EW + MV) + top-25 cohort holdings (MV) + 12-month cohort portfolio history (both weightings) + top-10 funds in cell + top-15 symbols in cell. Matching server-rendered PDF is /funds/style/{slug}/snapshot.pdf (Stage D.2).",
     "endpoint": "/api/funds/style/{slug}/snapshot",
     "method": "GET",
     "parameters": {
@@ -2535,7 +2535,7 @@
   {
     "id": "filer-search",
     "name": "13F Filer Search & Discovery",
-    "description": "Search the 13F filer universe by name, CIK, LEI, or filer_type/aum_tier cohort. Returns a list of FilerRow records (bw_filer_id, cik, name, filer_type, aum_tier, latest_aum_usd, etc.) for downstream calls to /api/13f/filers/{bw_filer_id}/*. Optional modelable_only filter restricts results to filers whose in-ERM3 sub-portfolio carries signal value (passes the modelability gate). Free for users — discovery is unbilled; per-filer follow-up calls are metered.",
+    "description": "Search the 13F filer universe by name, CIK, LEI, or filer_type/aum_tier cohort. Returns a list of FilerRow records (bw_filer_id, cik, name, filer_type, aum_tier, latest_aum_usd, etc.) for downstream calls to /api/13f/filers/{bw_filer_id}/*. Optional modelable_only filter restricts results to filers whose in-ERM3 sub-portfolio carries signal value (passes the modelability gate). Free for users \u2014 discovery is unbilled; per-filer follow-up calls are metered.",
     "endpoint": "/api/13f/filers/search",
     "method": "GET",
     "parameters": {
@@ -2597,7 +2597,7 @@
   {
     "id": "filer-metrics",
     "name": "Latest 13F Filer Metrics",
-    "description": "Latest knowledge-mode portfolio metrics for a single 13F filer. Returns diagnostics (weight_sum, n_holdings_active, effective_n, top10_weight_sum), AUM (total_aum_usd + aum_in_erm3 — the latter is the absolute scale of holdings inside the ERM3 universe), ERM3-coverage modelability inputs, and the portfolio-derived 9-box style attribution (portfolio_style_hhi, dominant_9box, effective_n_styles). Return components are NULL until D.8 Phase 2 (the security-master ↔ ERM3 attribution bridge). NAV is permanently absent — filers have no NAV time series. Resolves bw_filer_id against public.filers + public.filer_portfolios_latest.",
+    "description": "Latest knowledge-mode portfolio metrics for a single 13F filer. Returns diagnostics (weight_sum, n_holdings_active, effective_n, top10_weight_sum), AUM (total_aum_usd + aum_in_erm3 \u2014 the latter is the absolute scale of holdings inside the ERM3 universe), ERM3-coverage modelability inputs, and the portfolio-derived 9-box style attribution (portfolio_style_hhi, dominant_9box, effective_n_styles). Return components are NULL until D.8 Phase 2 (the security-master \u2194 ERM3 attribution bridge). NAV is permanently absent \u2014 filers have no NAV time series. Resolves bw_filer_id against public.filers + public.filer_portfolios_latest.",
     "endpoint": "/api/13f/filers/{bw_filer_id}",
     "method": "GET",
     "parameters": {
@@ -2683,7 +2683,7 @@
   {
     "id": "filer-portfolio-history",
     "name": "13F Filer Portfolio History",
-    "description": "Per-filer portfolio time series of diagnostics + AUM + style attribution from per-filer ds_portfolio.zarr on GCS. One row per teo (quarter-end). Optional ?start_date and ?end_date trim the panel. Return components (portfolio_*_return, identity_residual) are NULL until D.8 Phase 2 (the security-master ↔ ERM3 attribution bridge).",
+    "description": "Per-filer portfolio time series of diagnostics + AUM + style attribution from per-filer ds_portfolio.zarr on GCS. One row per teo (quarter-end). Optional ?start_date and ?end_date trim the panel. Return components (portfolio_*_return, identity_residual) are NULL until D.8 Phase 2 (the security-master \u2194 ERM3 attribution bridge).",
     "endpoint": "/api/13f/filers/{bw_filer_id}/portfolio",
     "method": "GET",
     "parameters": {
@@ -2784,7 +2784,7 @@
   {
     "id": "filer-snapshot-json",
     "name": "13F Filer Snapshot (JSON)",
-    "description": "Single-call composed snapshot for a 13F filer: registry + latest metrics + top 25 holdings + 12mo portfolio history + cohort ranks (filer_type and aum_tier partitions) + portfolio-derived 9-box style attribution + ERM3 coverage diagnostics + modelability flag. Permanently no NAV (surfaced as _metadata.nav_applicable: false) — filers have no NAV time series. Hedge ratios are Phase 3 (D.8.10) and absent today.",
+    "description": "Single-call composed snapshot for a 13F filer: registry + latest metrics + top 25 holdings + 12mo portfolio history + cohort ranks (filer_type and aum_tier partitions) + portfolio-derived 9-box style attribution + ERM3 coverage diagnostics + modelability flag. Permanently no NAV (surfaced as _metadata.nav_applicable: false) \u2014 filers have no NAV time series. Hedge ratios are Phase 3 (D.8.10) and absent today.",
     "endpoint": "/api/13f/filers/{bw_filer_id}/snapshot",
     "method": "GET",
     "parameters": {

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -20,6 +20,12 @@ const nextConfig = {
       { source: '/documentation', destination: '/docs', permanent: true },
       // Only one comparison page today; bare /compare points at it so a trimmed URL doesn't 404.
       { source: '/compare', destination: '/compare/barra-axioma', permanent: false },
+      // Stale README / SDK wiki_uri path — canonical methodology is /docs/methodology.
+      {
+        source: '/docs/methodology/erm3-l3',
+        destination: '/docs/methodology',
+        permanent: true,
+      },
     ];
   },
   async rewrites() {

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -3,7 +3,7 @@
 [![PyPI version](https://img.shields.io/pypi/v/riskmodels-py.svg)](https://pypi.org/project/riskmodels-py/)
 [![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/BlueWaterCorp/RiskModels_API/blob/main/sdk/notebooks/riskmodels_aom_colab.ipynb)
 
-Published on PyPI as [`riskmodels-py`](https://pypi.org/project/riskmodels-py/) (import package `riskmodels`). **Methodology / wiki:** [ERM3 L3](https://riskmodels.net/docs/methodology/erm3-l3) (aligned with API `wiki_uri`).
+Published on PyPI as [`riskmodels-py`](https://pypi.org/project/riskmodels-py/) (import package `riskmodels`). **Methodology:** [ERM3](https://riskmodels.app/docs/methodology) (aligned with API `wiki_uri` / `METHODOLOGY_URL`).
 
 **Try the Analysis Object Model without cloning:** open the **[AOM quickstart (Colab)](https://colab.research.google.com/github/BlueWaterCorp/RiskModels_API/blob/main/sdk/notebooks/riskmodels_aom_colab.ipynb)** — install cell, API key (Secrets or paste), then `rm` / `run` examples. Same flows live in-repo as [`notebooks/quickstart.ipynb`](./notebooks/quickstart.ipynb).
 


### PR DESCRIPTION
## Summary
- Point methodology URLs in README/capabilities/MCP at `riskmodels.app/docs/methodology`
- Redirect retired `/docs/methodology/erm3-l3` → `/docs/methodology`
- Cite live `riskmodels.net/status` plus `.app` API metrics

Companion: Risk_Models G.25 portal polish (implements `/status`).

## Test plan
- [ ] `curl -sI https://riskmodels.app/docs/methodology/erm3-l3` → redirect to `/docs/methodology` after deploy
- [ ] Capabilities methodology_url values are `.app/docs/methodology`
- [ ] README status links resolve (200)


Made with [Cursor](https://cursor.com)